### PR TITLE
CanvasFrame: fixup Alt state checking under Windows 7

### DIFF
--- a/widgets/canvas_frame.py
+++ b/widgets/canvas_frame.py
@@ -8,6 +8,9 @@ from .gui_frame import (
 from six.moves.tkinter import (
     NW
 )
+from os import (
+    name as os_name
+)
 
 RESIZE_GAP = 4
 DOUBLE_GAP = RESIZE_GAP << 1
@@ -45,12 +48,20 @@ def translate(e, container):
 
 # "Alt" keyboard button state checker
 # https://stackoverflow.com/questions/19861689/check-if-modifier-key-is-pressed-in-tkinter
-def alt(e):
-    try:
-        return e.state & 0x0088
-    except TypeError:
-        # sometimes e.state is `str`
-        return False
+if os_name == "nt":
+    def alt(e):
+        # There is no a confirmation found in a document, but it's observed
+        # that under Windows 7 bit 0x20000 is set when `Alt` key (left or
+        # right) is being held and bit 0x08 is always set (even when `Alt` is
+        # released).
+        return e.state & 0x20000
+else:
+    def alt(e):
+        try:
+            return e.state & 0x0088
+        except TypeError:
+            # sometimes e.state is `str`
+            return False
 
 
 # CanvasFrame states, use them with `is` operator only!


### PR DESCRIPTION
Under Win7 Tkinter uses different bit for `Alt` key in event `state` while bit `0x80` is always set.
It can be a bug of my Tkinter version but I'm [not alone](https://stackoverflow.com/a/34482048/7623015).

Signed-off-by: Efimov Vasily <laer.18@gmail.com>