### PR TITLE
Version fixes

### DIFF
--- a/qemu/version.py
+++ b/qemu/version.py
@@ -545,9 +545,7 @@ def define_only_qemu_2_6_0_types():
             args = [ Pointer(Type["NetClientState"])("nc") ]
         ),
         Structure("NetClientInfo",
-            # "type" field type is enum NetClientDriver, but enum is not
-            # supported by model
-            Type["int"]("type"),
+            Type["NetClientDriver"]("type"),
             Type["size_t"]("size"),
             Type["NetReceive"]("receive"),
             Type["NetCanReceive"]("can_receive"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -284,12 +284,11 @@ def define_only_qemu_2_6_0_types():
         Function(name = "gdb_get_reg64")
     ]).add_reference(osdep_fake_type)
 
+    ioport_header = Header["exec/ioport.h"].add_reference(osdep_fake_type)
     if get_vp("pio_addr_t exists"):
-        Header["exec/ioport.h"].add_types([
+        ioport_header.add_types([
             Type("pio_addr_t", incomplete = False)
-        ]).add_reference(osdep_fake_type)
-    else:
-        Header["exec/ioport.h"].add_reference(osdep_fake_type)
+        ])
 
     Header["hw/boards.h"].add_types([
         Structure("MachineClass"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -13,6 +13,7 @@ from source import (
     Type,
     Function,
     Macro,
+    Enumeration,
     Structure
 )
 
@@ -503,6 +504,15 @@ def define_only_qemu_2_6_0_types():
             Type["MemoryRegion"]
         ])
 
+    Header["qapi/qapi-types-net.h"].add_types([
+        # The value is taken from a auto generated file and may change in the
+        # future.
+        Enumeration([("NET_CLIENT_DRIVER_NIC", 1)],
+            enum_name = "NetClientDriver",
+            typedef_name = "NetClientDriver"
+        )
+    ])
+
     Header["net/net.h"].add_types([
         Type("qemu_macaddr_default_if_unset"),
         Type("qemu_format_nic_info_str"),
@@ -545,9 +555,6 @@ def define_only_qemu_2_6_0_types():
             Type["LinkStatusChanged"]("link_status_changed")
             # There are other fields but they are not needed.
         ),
-        Macro("NET_CLIENT_DRIVER_NIC") # This is an enum item actually. It
-        # is defined in auto generated "qapi-types.h" which is not presented in
-        # registry but is included by "net.h" indirectly.
     ]).add_references([
         osdep_fake_type
     ])

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -545,13 +545,13 @@ def define_only_qemu_2_6_0_types():
             args = [ Pointer(Type["NetClientState"])("nc") ]
         ),
         Structure("NetClientInfo",
+            # These are required fields only
             Type["NetClientDriver"]("type"),
             Type["size_t"]("size"),
             Type["NetReceive"]("receive"),
             Type["NetCanReceive"]("can_receive"),
             Type["NetCleanup"]("cleanup"),
             Type["LinkStatusChanged"]("link_status_changed")
-            # There are other fields but they are not needed.
         ),
     ]).add_references([
         osdep_fake_type

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -566,7 +566,7 @@ def define_only_qemu_2_6_0_types():
         Function(
             name = name,
             ret_type = Type["bfd_vma"],
-            args = [ Pointer(Pointer(Type["const bfd_byte"]))("addr") ]
+            args = [ Pointer(Type["const bfd_byte"])("addr") ]
         ) for name in ["bfd_getl64", "bfd_getl32", "bfd_getb32", "bfd_getl16",
             "bfd_getb16"
         ]

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -295,6 +295,7 @@ def define_only_qemu_2_6_0_types():
         Structure("MachineState")
     ]).add_reference(osdep_fake_type)
 
+    pio_t = Type["pio_addr_t" if get_vp("pio_addr_t exists") else "uint32_t"]
     Header["hw/sysbus.h"].add_types([
         Type("SysBusDevice", False),
         Type("qemu_irq", False),
@@ -328,12 +329,8 @@ def define_only_qemu_2_6_0_types():
             ret_type = Type["void"],
             args = [
                 Pointer(Type["SysBusDevice"])("dev"),
-                Type[
-                    "pio_addr_t" if get_vp("pio_addr_t exists") else "uint32_t"
-                ]("ioport"),
-                Type[
-                    "pio_addr_t" if get_vp("pio_addr_t exists") else "uint32_t"
-                ]("size")
+                pio_t("ioport"),
+                pio_t("size")
             ]
         ),
         Function(name = "sysbus_mmio_map"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -438,7 +438,10 @@ def define_only_qemu_2_6_0_types():
         Function(name = "timer_new_ns"),
         Function(name = "timer_del"),
         Function(name = "timer_free"),
-        Type("QEMU_CLOCK_VIRTUAL") # It is enumeration entry...
+        # These are required elements only
+        Enumeration([("QEMU_CLOCK_VIRTUAL", 1)],
+            typedef_name = "QEMUClockType"
+        )
     ]).add_references([
         osdep_fake_type
     ])

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -514,7 +514,7 @@ class QemuVersionDescription(object):
     current = None
     # Current version of the QVD. Please use notation `u"_v{number}"` for next
     # versions. Increase number manually if current changes affect the QVD.
-    version = u""
+    version = u"_v2"
 
     def __init__(self, build_path, version = None):
         config_host_path = join(build_path, "config-host.mak")

--- a/source/model.py
+++ b/source/model.py
@@ -326,7 +326,6 @@ class Source(object):
 
         TypeFixerVisitor(self, var).visit()
 
-        # Auto add definers for types used by variable initializer
         if type(self) is Source: # exactly a module, not a header
             if var.definer is not None:
                 raise RuntimeError(

--- a/source/model.py
+++ b/source/model.py
@@ -4,7 +4,8 @@ __all__ = [
   , "AddTypeRefToDefinerException"
   , "TypeNotRegistered"
   , "Type"
-      , "TypeReference"
+      # must not be used externally
+      # "TypeReference"
       , "Structure"
       , "Function"
       , "Pointer"

--- a/source/model.py
+++ b/source/model.py
@@ -2743,6 +2743,21 @@ digraph Chunks {
 """
         )
 
+        if self.origin.references:
+            def ref_node_name(ref, mapping = {}, counter = count(0)):
+                try:
+                    name = mapping[ref]
+                except KeyError:
+                    name = "ref_%u" % next(counter)
+                    mapping[ref] = name
+                return name
+
+            w.write("    /* Source references */\n")
+            for ref in self.origin.references:
+                w.write('    %s [style=dashed label="%s"]\n\n' % (
+                    ref_node_name(ref), ref
+                ))
+
         w.write("    /* Chunks */\n")
 
         def chunk_node_name(chunk, mapping = {}, counter = count(0)):

--- a/source/model.py
+++ b/source/model.py
@@ -1297,11 +1297,21 @@ class Structure(Type):
 
 class Enumeration(Type):
 
-    def __init__(self, type_name, elems_list, enum_name = ""):
-        super(Enumeration, self).__init__(name = type_name, incomplete = False)
+    def __init__(self, elems_list, enum_name = None, typedef_name = None):
+        super(Enumeration, self).__init__(
+            name = typedef_name or enum_name,
+            incomplete = False
+        )
+
+        self.enum_name = enum_name
+        self.typedef_name = typedef_name
+        self.typedef = typedef_name is not None
+
+        if self.is_named and not self.typedef:
+            # overwrite `c_name` to generate a correct variable type name
+            self.c_name = "enum@b" + self.c_name
 
         self.elems = OrderedDict()
-        self.enum_name = enum_name
         t = [ Type["int"] ]
         for key, val in elems_list:
             self.elems[key] = EnumerationElement(self, key,
@@ -1361,6 +1371,12 @@ class Enumeration(Type):
             definers.extend(f.get_definers())
 
         return definers
+
+    def __str__(self):
+        if self.is_named:
+            return super(Enumeration, self).__str__()
+        else:
+            return "anonymous enumeration"
 
     __type_references__ = ["elems"]
 
@@ -2529,10 +2545,11 @@ class EnumerationDeclarationBegin(SourceChunk):
         super(EnumerationDeclarationBegin, self).__init__(enum,
             "Beginning of enumeration %s declaration" % enum,
             """\
-{indent}enum@b{enum_name}{{
+{indent}{typedef}enum@b{enum_name}{{
 """.format(
     indent = indent,
-    enum_name = enum.enum_name + "@b" if enum.enum_name else ""
+    typedef = "typedef@b" if enum.typedef else "",
+    enum_name = (enum.enum_name + "@b") if enum.enum_name is not None else ""
             )
         )
 
@@ -2544,8 +2561,11 @@ class EnumerationDeclarationEnd(SourceChunk):
         super(EnumerationDeclarationEnd, self).__init__(enum,
             "Ending of enumeration %s declaration" % enum,
             """\
-{indent}}};\n
-""".format(indent = indent)
+{indent}}}{typedef_name};\n
+""".format(
+    indent = indent,
+    typedef_name = ("@b" + enum.typedef_name) if enum.typedef else ""
+            )
         )
 
 

--- a/source/model.py
+++ b/source/model.py
@@ -736,6 +736,7 @@ class Header(Source):
                         p.add_path(path)
 
                     p.on_include = Header._on_include
+                    p.all_inclusions = True
                     p.on_define.append(Header._on_define)
 
                     if sys.version_info[0] == 3:

--- a/source/model.py
+++ b/source/model.py
@@ -1289,7 +1289,7 @@ class Structure(Type):
 class Enumeration(Type):
 
     def __init__(self, type_name, elems_list, enum_name = ""):
-        super(Enumeration, self).__init__(name = type_name)
+        super(Enumeration, self).__init__(name = type_name, incomplete = False)
 
         self.elems = OrderedDict()
         self.enum_name = enum_name

--- a/source/model.py
+++ b/source/model.py
@@ -430,7 +430,12 @@ class Source(object):
             )
 
         _type.definer = self
-        self.types[_type.name] = _type
+        if _type.is_named:
+            self.types[_type.name] = _type
+        else:
+            # Register the type with any name in order to be able to generate
+            # its chunks.
+            self.types[".anonymous" + str(id(_type))] = _type
 
         # Some types (like `Enumeration`) contains types without definer or
         # may reference to other just created types.

--- a/source/model.py
+++ b/source/model.py
@@ -1957,15 +1957,16 @@ class Variable(object):
         indent = "",
         extern = False
     ):
-        if (    isinstance(self.type, Pointer)
-            and not self.type.is_named
-            and isinstance(self.type.type, Function)
+        type_ = self.type
+        if (    isinstance(type_, Pointer)
+            and not type_.is_named
+            and isinstance(type_.type, Function)
         ):
             ch = FunctionPointerDeclaration(self, indent, extern)
-            refs = gen_function_decl_ref_chunks(self.type.type, generator)
+            refs = gen_function_decl_ref_chunks(type_.type, generator)
         else:
             ch = VariableDeclaration(self, indent, extern)
-            refs = generator.provide_chunks(self.type)
+            refs = generator.provide_chunks(type_)
         ch.add_references(refs)
 
         return [ch]

--- a/source/model.py
+++ b/source/model.py
@@ -325,10 +325,8 @@ class Source(object):
                 % (var, self.name)
             )
 
-        fixer = TypeFixerVisitor(self, var).visit()
+        TypeFixerVisitor(self, var).visit()
 
-        # Auto add references to types this variable does depend on
-        self.add_references(tr.type for tr in fixer.new_type_references)
         # Auto add definers for types used by variable initializer
         if type(self) is Source: # exactly a module, not a header
             if var.definer is not None:
@@ -444,10 +442,7 @@ class Source(object):
         # Note, replacement of foreign types with `TypeReference` is actually
         # not required right now (see `gen_chunks`).
 
-        fixer = TypeFixerVisitor(self, _type).visit()
-
-        # Auto add references to types this one does depend on
-        self.add_references(tr.type for tr in fixer.new_type_references)
+        TypeFixerVisitor(self, _type).visit()
 
         # Addition of a required type does satisfy the dependence.
         if _type in self.references:
@@ -477,9 +472,7 @@ switching to that mode.
 
         # Finally, we must fix types just before generation because user can
         # change already added types.
-        fixer = TypeFixerVisitor(self, self).visit()
-
-        self.add_references(tr.type for tr in fixer.new_type_references)
+        TypeFixerVisitor(self, self).visit()
 
         # fix up types for headers with references
         # list of types must be copied because it is changed during each
@@ -2107,6 +2100,14 @@ class TypeFixerVisitor(TypeReferencesVisitor):
                 self.new_type_references.append(tr)
 
             self.replace(tr)
+
+    def visit(self):
+        ret = super(TypeFixerVisitor, self).visit()
+
+        # Auto add references to types this type_object does depend on
+        self.source.add_references(tr.type for tr in self.new_type_references)
+
+        return ret
 
     """
     CopyVisitor is now used for true copying function body arguments

--- a/source/model.py
+++ b/source/model.py
@@ -2520,7 +2520,7 @@ class EnumerationDeclarationBegin(SourceChunk):
 
     def __init__(self, enum, indent = ""):
         super(EnumerationDeclarationBegin, self).__init__(enum,
-            "Beginning of enumeration %s declaration" % enum.enum_name,
+            "Beginning of enumeration %s declaration" % enum,
             """\
 {indent}enum@b{enum_name}{{
 """.format(
@@ -2535,7 +2535,7 @@ class EnumerationDeclarationEnd(SourceChunk):
 
     def __init__(self, enum, indent = ""):
         super(EnumerationDeclarationEnd, self).__init__(enum,
-            "Ending of enumeration %s declaration" % enum.enum_name,
+            "Ending of enumeration %s declaration" % enum,
             """\
 {indent}}};\n
 """.format(indent = indent)

--- a/source/model.py
+++ b/source/model.py
@@ -2774,13 +2774,16 @@ digraph Chunks {
             label = ch.name
 
             if isinstance(ch, HeaderInclusion):
+                style = "style=filled "
                 label += "\\n*\\n"
                 for r in ch.reasons:
                     label += "%s %s\\l" % r
+            else:
+                style = ''
 
             label = label.replace('"', '\\"')
 
-            w.write('\n    %s [label="%s"]\n' % (cnn, label))
+            w.write('\n    %s [%slabel="%s"]\n' % (cnn, style, label))
 
             # invisible edges provides vertical order like in the output file
             if upper_cnn is not None:

--- a/source/model.py
+++ b/source/model.py
@@ -376,6 +376,8 @@ class Source(object):
 
             for t in header.types.values():
                 try:
+                    if not t.is_named:
+                        continue
                     if isinstance(t, TypeReference):
                         self._add_type_recursive(TypeReference(t.type))
                     else:
@@ -835,8 +837,9 @@ class Header(Source):
         super(Header, self).add_type(_type)
 
         # Auto add type references to self includers
-        for s in self.includers:
-            s._add_type_recursive(TypeReference(_type))
+        if _type.is_named:
+            for s in self.includers:
+                s._add_type_recursive(TypeReference(_type))
 
         return self
 
@@ -1041,8 +1044,7 @@ class TypeReference(Type):
             base = _type.base
         )
 
-        if _type.is_named:
-            self.name = _type.name
+        self.name = _type.name
         self.c_name = _type.c_name
         self.type = _type
         self.definer_references = None

--- a/source/model.py
+++ b/source/model.py
@@ -150,6 +150,7 @@ class ChunkGenerator(object):
     def __init__(self, definer):
         self.chunk_cache = { definer: [], CPP: [] }
         self.for_header = isinstance(definer, Header)
+        self.references = definer.references
         """ Tracking of recursive calls of `provide_chunks`. Currently used
         only to generate "extern" keyword for global variables in header and to
         distinguish structure fields and normal variables. """
@@ -233,10 +234,8 @@ class ChunkGenerator(object):
                             chunks = origin.gen_declaration_chunks(self, **kw)
                         else:
                             chunks = origin.get_definition_chunks(self, **kw)
-            elif (    SKIP_GLOBAL_HEADERS
-                  and isinstance(origin, TypeReference)
-                  and self.for_header
-                  and origin.type.definer.is_global
+            elif (    isinstance(origin, TypeReference)
+                  and origin.type in self.references
             ):
                 chunks = []
             else:
@@ -2105,7 +2104,18 @@ class TypeFixerVisitor(TypeReferencesVisitor):
         ret = super(TypeFixerVisitor, self).visit()
 
         # Auto add references to types this type_object does depend on
-        self.source.add_references(tr.type for tr in self.new_type_references)
+        s = self.source
+        # The current approach does not generate header inclusion chunks for
+        # foreign types which are contained in the `references` list.
+        if SKIP_GLOBAL_HEADERS and isinstance(s, Header):
+            for tr in self.new_type_references:
+                t = tr.type
+                definer = t.definer
+                # A type declared in a global header is added to the
+                # `references` list to prevent the inclusion of the global
+                # header.
+                if isinstance(definer, Header) and definer.is_global:
+                    s.references.add(t)
 
         return ret
 

--- a/source/model.py
+++ b/source/model.py
@@ -32,6 +32,8 @@ __all__ = [
       , "StructureTypedefDeclarationEnd"
       , "FunctionDeclaration"
       , "FunctionDefinition"
+      , "EnumerationDeclarationBegin"
+      , "EnumerationDeclarationEnd"
       , "EnumerationElementDeclaration"
       , "OpaqueChunk"
   , "SourceFile"

--- a/source/model.py
+++ b/source/model.py
@@ -511,8 +511,17 @@ switching to that mode.
                             # defined in the current file.
                             t.definer_references.add(ref)
                         else:
-                            for self_ref in self.references:
-                                if self_ref is ref:
+                            # Definer of a foreign type (t) may depend on a
+                            # foreign type (ref) from another file, which will
+                            # be included in the resulting file (since we use
+                            # some type from it). In this case, inclusion of
+                            # that definer must be placed below the inclusion
+                            # of another file in the resulting file.
+                            for tt in l:
+                                if not isinstance(tt, TypeReference):
+                                    continue
+                                if ref.definer is tt.type.definer:
+                                    t.definer_references.add(ref)
                                     break
                             else:
                                 self.references.add(ref)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -503,14 +503,14 @@ class TestEnumerations(SourceModelTestHelper, TestCase):
             h = Header["enums.h"]
         except:
             h = Header("enums.h")
-        h.add_type(Enumeration("A", [("one", 1), ("two", 2)]))
+        h.add_type(Enumeration([("one", 1), ("two", 2)], enum_name = "A"))
 
         a = Type["int"]("a")
         b = Type["int"]("b")
         c = Type["int"]("c")
 
         src = Source(name.lower() + ".c").add_types([
-            Enumeration("B", [("three", 3), ("four", 4)], "B"),
+            Enumeration([("three", 3), ("four", 4)], enum_name = "B"),
             Function(name = "main", body = BodyTree()(
                 Declare(a, b, c),
                 OpAssign(a, Type["A"].one),

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -684,6 +684,49 @@ extern M_TYPE var;
         ]
 
 
+class TestReferencingToTypeInAnotherHeader(SourceModelTestHelper, TestCase):
+    inherit_references = True
+
+    def setUp(self):
+        super(TestReferencingToTypeInAnotherHeader, self).setUp()
+        name = type(self).__name__
+
+        hdr = Header(name.lower() + ".h")
+
+        h1 = Header("some_types.h")
+        h2 = Header("another_some_types.h")
+
+        h1.add_type(Type("f1", incomplete = False))
+        h2.add_type(Type("f2", incomplete = False))
+
+        # Without reference headers `another_some_types` and `some_types` would
+        # be in alphabetical order.
+        h2.add_reference(Type["f1"])
+
+        s = Structure("S", Type["f1"]("field1"), Type["f2"]("field2"))
+        hdr.add_type(s)
+
+        hdr_content = """\
+/* {path} */
+#ifndef INCLUDE_{fname_upper}_H
+#define INCLUDE_{fname_upper}_H
+
+#include "some_types.h"
+#include "another_some_types.h"
+
+typedef struct S {{
+    f1 field1;
+    f2 field2;
+}} S;
+
+#endif /* INCLUDE_{fname_upper}_H */
+""".format(path = hdr.path, fname_upper = name.upper())
+
+        self.files = [
+            (hdr, hdr_content)
+        ]
+
+
 class TestOpaqueCode(SourceModelTestHelper, TestCase):
 
     def setUp(self):

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -503,19 +503,32 @@ class TestEnumerations(SourceModelTestHelper, TestCase):
             h = Header["enums.h"]
         except:
             h = Header("enums.h")
-        h.add_type(Enumeration([("one", 1), ("two", 2)], enum_name = "A"))
+        h.add_type(Enumeration([("EXT", 1)]))
+
+        src = Source(name.lower() + ".c").add_types([
+            Enumeration([("ONE", 1)]),
+            Enumeration([("TWO", 2)], enum_name = "A"),
+            Enumeration([("THREE", 3)], typedef_name = "B"),
+            Enumeration([("FOUR", 4)], enum_name = "C", typedef_name ="D")
+        ])
 
         a = Type["int"]("a")
         b = Type["int"]("b")
-        c = Type["int"]("c")
+        c = Type["A"]("c")
+        d = Type["B"]("d")
+        e = Type["D"]("e")
 
-        src = Source(name.lower() + ".c").add_types([
-            Enumeration([("three", 3), ("four", 4)], enum_name = "B"),
+        src.add_types([
             Function(name = "main", body = BodyTree()(
-                Declare(a, b, c),
-                OpAssign(a, Type["A"].one),
-                OpAssign(b, Type["B"].three),
-                OpAssign(c, Type["four"])
+                Declare(a, b),
+                OpAssign(a, Type["EXT"]),
+                OpAssign(b, Type["ONE"]),
+                Declare(c),
+                OpAssign(c, Type["TWO"]),
+                Declare(d),
+                OpAssign(d, Type["THREE"]),
+                Declare(e),
+                OpAssign(e, Type["FOUR"])
             ))
         ])
 
@@ -524,17 +537,33 @@ class TestEnumerations(SourceModelTestHelper, TestCase):
 
 #include "enums.h"
 
-enum B {{
-    three = 3,
-    four = 4
+enum A {{
+    TWO = 2
+}};
+
+typedef enum {{
+    THREE = 3
+}} B;
+
+typedef enum C {{
+    FOUR = 4
+}} D;
+
+enum {{
+    ONE = 1
 }};
 
 void main(void)
 {{
-    int a, b, c;
-    a = one;
-    b = three;
-    c = four;
+    int a, b;
+    a = EXT;
+    b = ONE;
+    enum A c;
+    c = TWO;
+    B d;
+    d = THREE;
+    D e;
+    e = FOUR;
 }}
 
 """.format(src.path)


### PR DESCRIPTION
- add `NetClientDriver` and `QEMUClockType` enumerations
- shorten code

### v5
- fixup articles in comments
- transfer `OpaqueCode` changes to future MR

### v4
- add explanatory comments
- add brackets in `Enumeration` chunks initialization code to clearly explain the priority of operations
- OpaqueCode: store separately `used_types` and `used_variables` to prevent `TypeError: unorderable types: Variable() < Function()` in `TypeFixerVisitor` on Py3
- revert `const bfd_byte` type
- rename few commits
- rebase onto new `master`

### v3
- Enumeration: support all kinds of declaration
- TestEnumerations: add more examples
- delete `EnumerationTypedefDeclarationBegin`, `EnumerationTypedefDeclarationEnd` chunks
- add lost references to types defined in the another file and add a test for this 
- rework global headers skipping mechanism
- expand support for nameless types
- add lost list of fields to visit `OpaqueCode`
- highlight header inclusion chunks and display references on graph
- rebase onto new `master`

### v2
- use enumeration fields directly by name
- support nameless `Enumeration`