### PR TITLE
Get QOM tree from build directory

### DIFF
--- a/common/co_dispatcher.py
+++ b/common/co_dispatcher.py
@@ -10,6 +10,9 @@ __all__ = [
   , "callco"
 ]
 
+from time import (
+    sleep
+)
 from types import (
     GeneratorType
 )
@@ -406,6 +409,17 @@ after last statement in the corresponding callable object.
     def has_work(self):
         return self.tasks or self.active_tasks
 
+    def dispatch_all(self, delay = 0.01):
+        has_work, iteration = self.has_work, self.iteration
+
+        if delay is None:
+            # No delay mode
+            while has_work():
+                iteration()
+        else:
+            while has_work():
+                if not iteration():
+                    sleep(delay)
 
 class CoStackFailure(RuntimeError):
 

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -18,11 +18,8 @@ from common import (
 from os.path import (
     join
 )
-from multiprocessing import (
-    Process
-)
-from os import (
-    system
+from subprocess import (
+    Popen
 )
 # use ours pyrsp
 with pypath("..pyrsp"):
@@ -135,11 +132,7 @@ def co_update_device_tree(qemu_exec, src_path, arch_name, root):
 
     port = find_free_port(4321)
     qemu_debug_addr = "localhost:%u" % port
-    qemu_proc = Process(
-        target = system,
-        args = (" ".join(["gdbserver", qemu_debug_addr, qemu_exec]),)
-    )
-    qemu_proc.start()
+    Popen(["gdbserver", qemu_debug_addr, qemu_exec])
 
     if not wait_for_tcp_port(port):
         raise RuntimeError("gdbserver does not listen %u" % port)

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -122,9 +122,7 @@ def co_fill_children(qomtr_node, qtype_node, arch):
         yield co_fill_children(c, qt, arch)
 
 
-def co_update_device_tree(bindir, src_path, arch_name, root):
-    qemu_exec = join(bindir, "qemu-system-" + arch_name)
-
+def co_update_device_tree(qemu_exec, src_path, arch_name, root):
     dic = create_dwarf_cache(qemu_exec)
 
     gvl_adptr = GitLineVersionAdapter(src_path)

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -509,7 +509,7 @@ class QemuVersionDescription(object):
         config_host_path = join(build_path, "config-host.mak")
         if not isfile(config_host_path):
             raise BadBuildPath("%s does not exists." % config_host_path)
-        config_host = ConfigHost(config_host_path)
+        self.config_host = config_host = ConfigHost(config_host_path)
 
         self.build_path = build_path
         self.src_path = fixpath(config_host.SRC_PATH)


### PR DESCRIPTION
Add a fallback way to get QOM tree (actually "device" subtree) using Qemu
binary from build directory.
Currently, "device" subtree is obtained using binary in install prefix.

Related changes summary:
- implement `callco` using `CoDispatcher`
- use `Popen` to run `gdbserver` instead of `Process`