### PR TITLE
QVD versioning

### DIFF
--- a/common/compat.py
+++ b/common/compat.py
@@ -4,6 +4,7 @@ __all__ = [
   , "charcodes"
   , "characters"
   , "HelpFormatter"
+  , "uname"
 ]
 
 from .pypath import (
@@ -12,6 +13,9 @@ from .pypath import (
 )
 from os.path import (
     dirname
+)
+from platform import (
+    uname as platform_uname
 )
 
 from six import (
@@ -93,3 +97,7 @@ for flags.
         if isinstance(action, (_CountAction, _StoreConstAction)):
             return action.help
         return super(HelpFormatter, self)._get_help_string(action)
+
+
+def uname():
+    return tuple(platform_uname())

--- a/common/git_measurer.py
+++ b/common/git_measurer.py
@@ -6,7 +6,7 @@ __all__ = [
 ]
 
 
-from platform import (
+from .compat import (
     uname
 )
 from contextlib import (

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -156,10 +156,16 @@ class Plot(object):
             _avg = 0
             _err = 0
         else:
-            _avg = sum(self.mes) / _len
+            # median filtering with a window size 3 and looped edges
+            mes = [self.mes[-1]] + self.mes + [self.mes[0]]
+            smes = [None] * _len
+            for i in range(0, _len):
+                smes[i] = sorted(mes[i:i + 3])[1]
+
+            _avg = sum(smes) / _len
 
             _err = 0
-            for t in self.mes:
+            for t in smes:
                 _err += (t - _avg) ** 2
             _err = sqrt(_err / _len)
 

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -27,6 +27,7 @@ from matplotlib import (
     pyplot as plt
 )
 from common import (
+    uname,
     Measurer,
     fast_repo_clone,
     ee,
@@ -39,9 +40,6 @@ from argparse import (
     ArgumentTypeError,
     ArgumentParser,
     ArgumentDefaultsHelpFormatter
-)
-from platform import (
-    uname
 )
 import qdt
 from traceback import (

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -175,12 +175,12 @@ class Plot(object):
         t_fmt = "%%.%uf" % accuracy(_err)
 
         self.commits.append((
-                "%s\n%s--\nlaunches = %u, avg. t = " + t_fmt + " sec, err = "
-                +t_fmt + " sec"
-            ) % (
-                sha1, message, _len, _avg, _err
-            )
-        )
+            "%s\n%s--\nlaunches = %u, " +
+            "avg. t = " + t_fmt + " sec, " +
+            "err = " + t_fmt + " sec"
+        ) % (
+            sha1, message, _len, _avg, _err
+        ))
 
         self.xcoords.append(x)
         self.ycoords.append(_avg)

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -64,6 +64,9 @@ from collections import (
 from contextlib import (
     contextmanager
 )
+from math import (
+    sqrt
+)
 
 
 TC_PRINT_COMMANDS = ee("TC_PRINT_COMMANDS")
@@ -167,7 +170,7 @@ class Plot(object):
         if _len == 0:
             _err = 0
         else:
-            _err /= _len
+            _err = sqrt(_err / _len)
 
         t_fmt = "%%.%uf" % accuracy(_err)
 

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -201,8 +201,6 @@ def plot_measurements(repo, ctx, commit_seq):
                 continue
             if res: # failed, do not show
                 continue
-            if not cache_ready: # cache building, too long
-                continue
 
             plots[env].mes.append(t)
 

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -150,26 +150,17 @@ class Plot(object):
             self.yerr.append(0)
             self.commits.append("-")
 
-        _sum = 0.0
-        _len = 0
-
-        for t in self.mes:
-            _len += 1
-            _sum += t
+        _len = len(self.mes)
 
         if _len == 0:
             _avg = 0
-        else:
-            _avg = _sum / _len
-
-        _err = 0
-
-        for t in self.mes:
-            _err += (t - _avg) ** 2
-
-        if _len == 0:
             _err = 0
         else:
+            _avg = sum(self.mes) / _len
+
+            _err = 0
+            for t in self.mes:
+                _err += (t - _avg) ** 2
             _err = sqrt(_err / _len)
 
         t_fmt = "%%.%uf" % accuracy(_err)

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -9,6 +9,7 @@ from subprocess import (
     Popen
 )
 from os.path import (
+    getmtime,
     join,
     isfile,
     isdir,
@@ -16,9 +17,12 @@ from os.path import (
     dirname
 )
 from shutil import (
-    copyfile,
+    copy,
     copytree,
     rmtree
+)
+from glob import (
+    glob
 )
 from time import (
     time
@@ -331,7 +335,9 @@ class QDTMeasurer(Measurer):
 
         self.diffs = diffs
 
-        self.qvc = "qvc_%s.py" % qemugit.commit(project.target_version).hexsha
+        self.qvc_pattern = (
+            "qvc*_%s.py" % qemugit.commit(project.target_version).hexsha
+        )
 
     def __enter__(self):
         print("Checking Qemu out...")
@@ -369,6 +375,10 @@ class QDTMeasurer(Measurer):
                 )
             )
 
+        if self.caches is not None:
+            for cache in glob(join(self.caches, self.qvc_pattern)):
+                copy(cache, tmp_build)
+
         print("Backing Qemu configuration...")
         self.q_back = q_back = mkdtemp(
             prefix = "qemu-%s-back-" % self.qproject.target_version
@@ -405,12 +415,6 @@ class QDTMeasurer(Measurer):
 
         Popen(cmds, cwd = qdt_cwd, env = dict(TEST_STARTUP_ENV)).wait()
 
-        if ctx.caches is not None and join(ctx.caches, ctx.qvc):
-            # use existing cache
-            ctx.qv_cache = join(ctx.caches, ctx.qvc)
-        else:
-            ctx.qv_cache = None
-
         try:
             yield self
         finally:
@@ -432,20 +436,6 @@ class QDTMeasurer(Measurer):
         yield "machine", ctx.machine
         yield "env", ctx.env_name
         yield "i", ctx.launch_number
-
-        print("Preparing CWD...")
-
-        qv_cache = ctx.qv_cache
-
-        if qv_cache:
-            # restore cache
-            copyfile(
-                qv_cache,
-                join(ctx.tmp_build, ctx.qvc)
-            )
-            yield "cache_ready", True
-        else:
-            yield "cache_ready", False
 
         print("Measuring...")
         cmds = [
@@ -480,11 +470,21 @@ class QDTMeasurer(Measurer):
                 print("Command was:")
                 print(" ".join(cmds))
 
-        if qv_cache is None:
-            # preserve cache
-            qv_cache = join(ctx.clone.working_tree_dir, ctx.qvc)
-            copyfile(join(ctx.tmp_build, ctx.qvc), qv_cache)
-            ctx.qv_cache = qv_cache
+        cache_changed = False
+
+        if ctx.errors:
+            # preserve cache from bad version to allow the user to analyze it
+            cache_preserve_path = ctx.clone.working_tree_dir
+        else:
+            # preserve cache for next runs
+            cache_preserve_path = join(ctx.q_back, "build")
+
+        for cache in glob(join(ctx.tmp_build, ctx.qvc_pattern)):
+            if getmtime(cache) > t0:
+                cache_changed = True
+                copy(cache, cache_preserve_path)
+
+        yield "cache_ready", not cache_changed
 
         print("Running test...")
 

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -21,6 +21,7 @@ from source import (
     Macro
 )
 from common import (
+    lazy,
     CancelledCallee,
     FailedCallee,
     fast_repo_clone,
@@ -504,6 +505,9 @@ QVD_QH_HASH = "qh_hash"
 
 class QemuVersionDescription(object):
     current = None
+    # Current version of the QVD. Please use notation `u"_v{number}"` for next
+    # versions. Increase number manually if current changes affect the QVD.
+    version = u""
 
     def __init__(self, build_path, version = None):
         config_host_path = join(build_path, "config-host.mak")
@@ -579,13 +583,18 @@ class QemuVersionDescription(object):
             self.qvc_is_ready = False
             remove_file(self.qvc_path)
 
+    @lazy
+    def qvc_file_name(self):
+        return (u"qvc" + QemuVersionDescription.version + u"_" +
+            self.commit_sha + u".py"
+        )
+
     def co_init_cache(self):
         if self.qvc is not None:
             print("Multiple QVC initialization " + self.src_path)
             self.qvc = None
 
-        qvc_file_name = u"qvc_" + self.commit_sha + u".py"
-        qvc_path = self.qvc_path = join(self.build_path, qvc_file_name)
+        qvc_path = self.qvc_path = join(self.build_path, self.qvc_file_name)
 
         qemu_heuristic_hash = calculate_qh_hash()
 


### PR DESCRIPTION
Cache versioning support for qdt and test_commits tool.

### v5
- fix comment
- fix import of `uname`

### v4
- add and use `uname` wrapper
- shorten code
- add median filtering for time
- rename `qvc` field to `qvc_pattern`

### v3
- delete `gen_qvc_file_name` function
- delete `get_qvc_file_name.py` script
- add `QemuVersionDescription.qvc_file_name` attribute
- add `uname_result` import so that the commits test results are loaded
- shorten code
- correct the error in the standard deviation formula
- add median time and build a graph on it
- ignore `cache_ready` flag
- a new way to work with caches

### v2
- change cache version in a separate commit