### PR TITLE
Hide coroutine timings

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,3 +793,15 @@ For example:
 
 PYTHONPATH=".." python canvas_frame_test.py
 ```
+
+## Development tips
+
+### Environment variables
+
+Environment variables affect operation of QDT modules and tools.
+Commonly, a value is an `eval`uated Python expression which must return
+a boolean.
+
+* `QDT_PROFILE_COTASK`: turns on messages about coroutine-like tasks
+    that consumed too many time between `yield`s.
+* `grep` for `ee(` for other.

--- a/common/co_dispatcher.py
+++ b/common/co_dispatcher.py
@@ -28,6 +28,12 @@ from traceback import (
 from six import (
     StringIO
 )
+from .os_wrappers import (
+    ee
+)
+
+
+PROFILE_COTASK = ee("QDT_PROFILE_COTASK")
 
 
 class FailedCallee(RuntimeError):
@@ -215,7 +221,7 @@ after last statement in the corresponding callable object.
                     ready = True
 
             ti = t1 - t0
-            if ti > 0.05:
+            if PROFILE_COTASK and ti > 0.05:
                 sys.stderr.write("Task %s consumed %f sec during iteration "
                     # file:line is the line reference format supported by
                     # Eclipse IDE Console.

--- a/widgets/tk_co_dispatcher.py
+++ b/widgets/tk_co_dispatcher.py
@@ -3,12 +3,17 @@ __all__ = [
 ]
 
 from common import (
+    ee,
     CoDispatcher
 )
 from time import (
     time
 )
 import sys
+
+
+PROFILE_COTASK = ee("QDT_PROFILE_COTASK")
+
 
 class TkCoDispatcher(CoDispatcher):
     """
@@ -31,7 +36,7 @@ peaces among Tkinter event driven GUI model.
         t0 = time()
         ready = CoDispatcher.iteration(self)
         ti = time() - t0
-        if ti > 0.1:
+        if PROFILE_COTASK and ti > 0.1:
 
             sys.stderr.write(("Iteration consumed %f sec\n" % ti)
                 + "Active tasks:\n  "


### PR DESCRIPTION
This patch series hides debug messages about _time greedy_ tasks. See #24.