### PR TITLE
Clone Qemu in parallel

### DIFF
--- a/common/co_dispatcher.py
+++ b/common/co_dispatcher.py
@@ -2,6 +2,8 @@ __all__ = [
 # RuntimeError
     "FailedCallee"
   , "CancelledCallee"
+# BaseException
+  , "CoReturn"
 # object
   , "CoTask"
   , "CoDispatcher"
@@ -76,6 +78,8 @@ class CoTask(object):
         self.gi_frame = None
         # Exception to be injected into that task at current `yield`.
         self._to_raise = None
+        # Value returned by callee. It's returned by `yield`
+        self._co_ret = None
 
     @property
     def traceback_lines(self):
@@ -167,16 +171,25 @@ after last statement in the corresponding callable object.
 
             try:
                 if to_raise is None:
-                    t0 = time()
+                    co_ret = task._co_ret
 
-                    ret = next(generator)
+                    if co_ret is None:
+                        t0 = time()
+
+                        ret = next(generator)
+                    else:
+                        task._co_ret = None
+
+                        t0 = time()
+
+                        ret = generator.send(co_ret)
                 else:
                     task._to_raise = None
 
                     t0 = time()
 
                     ret = generator.throw(type(to_raise), to_raise)
-            except StopIteration:
+            except (StopIteration, CoReturn) as e:
                 t1 = time()
 
                 traceback = sys.exc_info()[2].tb_next
@@ -194,7 +207,12 @@ after last statement in the corresponding callable object.
                 else:
                     lineno = traceback.tb_frame.f_lineno
 
-                finished.append(task)
+                if isinstance(e, CoReturn):
+                    co_ret = e.value
+                else:
+                    co_ret = None
+
+                finished.append((task, co_ret))
             except Exception as e:
                 t1 = time()
 
@@ -231,7 +249,7 @@ after last statement in the corresponding callable object.
 
             task.lineno = lineno
 
-        for task in finished:
+        for task, co_ret in finished:
             self.__finish__(task)
 
             try:
@@ -244,6 +262,7 @@ after last statement in the corresponding callable object.
             for caller in callers:
                 del self.callers[caller]
                 self.tasks.insert(0, caller)
+                caller._co_ret = co_ret
 
         for caller, callee in calls:
             # Cast callee to CoTask
@@ -438,3 +457,20 @@ def callco(co, delay = default):
         disp.dispatch_all()
     else:
         disp.dispatch_all(delay = delay)
+
+
+# TODO: There is no _known_ both Py3 & Py2 compatible way to `return` a
+# value from a coroutine without specific exception class.
+# See: misc/co_return.py
+
+# Note, `CoReturn` is not an _exception_ by meaning. It's a technique to
+# return a value from a generator.
+# So, it is derived from `BaseException`.
+class CoReturn(BaseException):
+    """ Use `CoReturn(value)` to return the value from callee. The caller's
+`yield` will return the value.
+    """
+
+    @property
+    def value(self):
+        return self.args[0]

--- a/common/co_process.py
+++ b/common/co_process.py
@@ -1,0 +1,55 @@
+__all__ = [
+    "co_process"
+  , "FunctionFailure"
+]
+
+from multiprocessing import (
+    Pipe,
+    Process
+)
+from sys import (
+    exc_info
+)
+from .co_dispatcher import (
+    CoReturn
+)
+
+
+class FunctionFailure(RuntimeError): pass
+
+
+def co_process(function, *a, **kw):
+    """ Call the `function` in a dedicated process, `a` & `kw` are for
+the call.
+    """
+
+    in_, out = Pipe(False)
+    proc = Process(
+        target = caller,
+        args = (out, function, a, kw)
+    )
+    proc.start()
+    while proc.is_alive():
+        yield False
+
+    if proc.exitcode:
+        raise RuntimeError(
+            "process with function %s has ended with return code %s" % (
+                function, proc.exitcode
+            )
+        )
+
+    kind, payload = in_.recv()
+    if kind == 0: # normal return
+        raise CoReturn(payload)
+    else: # 1 the function failed
+        raise FunctionFailure(*payload)
+
+
+def caller(feedback, function, a, kw):
+    try:
+        ret = function(*a, **kw)
+    except:
+        feedback.send((1, exc_info()))
+    else:
+        feedback.send((0, ret))

--- a/misc/co_return.py
+++ b/misc/co_return.py
@@ -1,0 +1,56 @@
+""" How to return a value from coroutine in a Python portable way?
+"""
+
+from six import (
+    PY2
+)
+
+
+def co_with_return():
+    yield 1
+    if PY2:
+        raise StopIteration(2)
+    else:
+        # Py3 only
+        # under Py2: SyntaxError: 'return' with argument inside generator
+        # return 2
+
+        # SyntaxError: 'return' outside function
+        # exec("return 2")
+
+        # XXX: will be error in future Py3 versions
+        raise StopIteration(2)
+
+
+
+def co_simple():
+    yield 3
+    yield 4
+
+
+def do_probes(co_func):
+    print(co_func.__name__)
+    print("for:")
+    for i in co_func():
+        print(i)
+
+    print("while:")
+    co = co_func()
+
+    try:
+        while True:
+            ret = next(co)
+            print(ret)
+    except StopIteration as e:
+        # value = e.value # Py3 only
+        try:
+            value = e.args[0]
+        except IndexError:
+            value = None
+
+        print(value)
+
+
+if __name__ == '__main__':
+    do_probes(co_with_return)
+    do_probes(co_simple)

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -21,6 +21,7 @@ from source import (
     Macro
 )
 from common import (
+    co_process,
     get_cleaner,
     lazy,
     CancelledCallee,
@@ -620,7 +621,13 @@ class QemuVersionDescription(object):
             # GIT_WORK_TREE environment variables. But, this approach resets
             # staged files in src_path repository which can be inconvenient
             # for a user.
-            tmp_repo = fast_repo_clone(self.repo, self.commit_sha, "qdt-qemu")
+            # `fast_repo_clone` relies on external library functions which
+            # grab control for a long time. Hence, we should call it in a
+            # dedicated process.
+            tmp_repo = yield co_process(
+                fast_repo_clone,
+                self.repo, self.commit_sha, "qdt-qemu"
+            )
             tmp_work_dir = tmp_repo.working_tree_dir
 
             # Qemu source tree analysis is too long process and temporary


### PR DESCRIPTION
To clone Qemu in parallel (by `fast_repo_clone`) some changes to common API were made:

* return protocol for coroutines
* coroutine calling a function in a dedicated process