### PR TITLE
Fixes for commit testing script

### DIFF
--- a/common/cleaner.py
+++ b/common/cleaner.py
@@ -11,6 +11,9 @@ from multiprocessing import (
 from os import (
     getpid
 )
+from os.path import (
+    exists
+)
 from psutil import (
     pid_exists
 )
@@ -135,8 +138,16 @@ Returns internal id that can be used to `cancel` the call.
 
     # Some helpers
 
-    def rmtree(self, path):
-        return self.schedule(rmtree, path)
+    def rmtree(self, path, absent_ok = False):
+        if absent_ok:
+            return self.schedule(rmtree_existing, path)
+        else:
+            return self.schedule(rmtree, path)
+
+
+def rmtree_existing(path):
+    if exists(path):
+        rmtree(path)
 
 
 def get_cleaner(*defult_args, **default_kw):

--- a/common/git_measurer.py
+++ b/common/git_measurer.py
@@ -27,6 +27,9 @@ from .lazy import (
 from traceback import (
     print_exc
 )
+from .cleaner import (
+    get_cleaner
+)
 
 
 @contextmanager
@@ -66,6 +69,7 @@ Roles of those methods are described in base method implementations below.
 
         self.base_sha = repo.commit(base).hexsha
         self.current_sha = repo.commit(current).hexsha
+        self.cleaner = get_cleaner()
 
     def __enter__(self):
         """ Called before any measuring. It MUST initialize and return a global
@@ -194,6 +198,7 @@ measurement is natively stopped.
                 )
 
                 clone = fast_repo_clone(self.repo, sha1, self.clone_prefix)
+                clean_task = self.cleaner.rmtree(clone.working_tree_dir)
                 gctx.clone = clone
 
                 try:
@@ -203,9 +208,10 @@ measurement is natively stopped.
                     errors = True
                     raise
                 finally:
+                    # allow user to work with bad version
                     if not errors or self._internal_error:
-                        # allow user to work with bad version
                         rmtree(clone.working_tree_dir)
+                    self.cleaner.cancel(clean_task)
 
                 if self._internal_error:
                     break

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -356,6 +356,10 @@ class QDTMeasurer(Measurer):
             prefix = "qemu"
         )
 
+        # 1: Instead of canceling cleaning just ignore directory absence.
+        # It's easy to forget cancel the cleaning in future.
+        self.cleaner.rmtree(qemuwc.working_tree_dir, absent_ok = True)
+
         # `fast_repo_clone` changes `.gitmodules` file. This change is not
         # required for consequent operation. So, revert it to avoid junk in
         # diff files.
@@ -364,6 +368,8 @@ class QDTMeasurer(Measurer):
         self.tmp_build = tmp_build = mkdtemp(
             prefix = "qemu-%s-build-" % self.qproject.target_version
         )
+
+        self.cleaner.rmtree(tmp_build, absent_ok = True) # search for # 1:
 
         print("Configuring Qemu...")
         configure = Popen(
@@ -394,6 +400,8 @@ class QDTMeasurer(Measurer):
             prefix = "qemu-%s-back-" % self.qproject.target_version
         )
 
+        self.cleaner.rmtree(q_back, absent_ok = True) # search for # 1:
+
         copytree_ignore_error(qemuwc.working_tree_dir, join(q_back, "src"))
         copytree_ignore_error(tmp_build, join(q_back, "build"))
 
@@ -412,6 +420,8 @@ class QDTMeasurer(Measurer):
 
         # Prepare working directory for launches
         self.qdt_cwd = qdt_cwd = mkdtemp(prefix = "qdt-cwd-")
+
+        self.cleaner.rmtree(qdt_cwd, absent_ok = True) # search for # 1:
 
         # Launch QDC for generating LALR tables of PLY.
         cmds = [


### PR DESCRIPTION
Auxiliary changes:

* `fast_repo_clone` recursively handles all submodules
* `Cleaner` can suppress path absent errors

### v2
* "directoris"
* re-format errors printing by `copytree_ignore_error`
* `rmtree` scheduling by `Measurer.measure`