### PR TITLE
MacroType & MacroUsage

### DIFF
--- a/qemu/pcie.py
+++ b/qemu/pcie.py
@@ -520,7 +520,7 @@ corresponding vendor is given" % attr
             code = { "function": self.register_types }
         )
         self.source.add_type(
-            Type["type_init"].gen_usage(type_init_usage_init)
+            Type["type_init"].gen_type(type_init_usage_init)
         )
 
         # order life cycle functions

--- a/qemu/pcie.py
+++ b/qemu/pcie.py
@@ -520,7 +520,7 @@ corresponding vendor is given" % attr
             code = { "function": self.register_types }
         )
         self.source.add_type(
-            Type["type_init"].gen_type(type_init_usage_init)
+            Type["type_init"].gen_type(initializer = type_init_usage_init)
         )
 
         # order life cycle functions

--- a/qemu/sysbusdevice.py
+++ b/qemu/sysbusdevice.py
@@ -626,7 +626,7 @@ class SysBusDeviceType(QOMDevice):
             code = { "function": self.register_types }
         )
         self.source.add_type(
-            Type["type_init"].gen_usage(type_init_usage_init)
+            Type["type_init"].gen_type(type_init_usage_init)
         )
 
         # order life cycle functions

--- a/qemu/sysbusdevice.py
+++ b/qemu/sysbusdevice.py
@@ -626,7 +626,7 @@ class SysBusDeviceType(QOMDevice):
             code = { "function": self.register_types }
         )
         self.source.add_type(
-            Type["type_init"].gen_type(type_init_usage_init)
+            Type["type_init"].gen_type(initializer = type_init_usage_init)
         )
 
         # order life cycle functions

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -715,9 +715,7 @@ def machine_register_2_5(mach):
         code = { "function": mach.type_reg_func }
     )
     mach.source.add_type(
-        Type[def_type].gen_usage(
-            initializer = machine_init_def_args
-        )
+        Type[def_type].gen_type(initializer = machine_init_def_args)
     )
 
 def machine_register_2_6(mach):
@@ -775,9 +773,7 @@ def machine_register_2_6(mach):
     # Main machine registration macro
     machine_init_def_args = Initializer({ "function": mach.type_reg_func })
     mach.source.add_type(
-        Type["type_init"].gen_usage(
-            initializer = machine_init_def_args
-        )
+        Type["type_init"].gen_type(initializer = machine_init_def_args)
     )
 
 qemu_heuristic_db = {

--- a/source/model.py
+++ b/source/model.py
@@ -1718,26 +1718,26 @@ class Macro(Type):
 
 
 class MacroType(Type):
-    def __init__(self, _macro,
+    def __init__(self, macro,
         initializer = None,
         name = None,
         is_usage = False
     ):
-        if not isinstance(_macro, Macro):
+        if not isinstance(macro, Macro):
             raise ValueError("Attempt to create macrotype from "
-                " %s which is not macro." % _macro
+                " %s which is not macro." % macro
             )
 
         if is_usage and name is None:
-            name = _macro.name + ".usage" + str(id(self))
+            name = macro.name + ".usage" + str(id(self))
 
         super(MacroType, self).__init__(name = name, incomplete = False)
 
         # define c_name for nameless macrotypes
         if not self.is_named:
-            self.c_name = _macro.gen_usage_string(initializer)
+            self.c_name = macro.gen_usage_string(initializer)
 
-        self.macro = _macro
+        self.macro = macro
         self.initializer = initializer
 
     def get_definers(self):

--- a/source/model.py
+++ b/source/model.py
@@ -1764,8 +1764,8 @@ class MacroUsage(Type):
 
         if initializer is not None:
             for v in initializer.used_variables:
-                """ Note that 0-th chunk is variable and rest are its
-                dependencies """
+                # Note that 0-th chunk is variable and rest are its
+                # dependencies.
                 refs.append(generator.provide_chunks(v)[0])
 
             for t in initializer.used_types:
@@ -2018,8 +2018,8 @@ class Variable(object):
 
         if self.initializer is not None:
             for v in self.initializer.used_variables:
-                """ Note that 0-th chunk is variable and rest are its
-                dependencies """
+                # Note that 0-th chunk is variable and rest are its
+                # dependencies.
                 refs.append(generator.provide_chunks(v)[0])
 
             for t in self.initializer.used_types:

--- a/source/model.py
+++ b/source/model.py
@@ -1705,7 +1705,7 @@ class Macro(Type):
             used = used
         )
 
-    def gen_usage(self, initializer = None, name = None, counter = count(0)):
+    def gen_type(self, initializer = None, name = None, counter = count(0)):
         "A helper that automatically generates a name for `MacroUsage`."
         if name is None:
             name = self.name + ".auto" + str(next(counter))

--- a/source/model.py
+++ b/source/model.py
@@ -1180,6 +1180,15 @@ class Structure(Type):
                 " the structure %s" % (v_name, self)
             )
 
+        if isinstance(variable, Type):
+            if variable.definer is not None:
+                raise RuntimeError(
+                    "Type '%s' is already defined in '%s'" % (
+                        variable, variable.definer.path
+                    )
+                )
+            variable.definer = self
+
         self.fields[v_name] = variable
 
         ForwardDeclarator(variable).visit()

--- a/source/model.py
+++ b/source/model.py
@@ -1764,7 +1764,7 @@ class MacroUsage(Type):
                 refs.extend(generator.provide_chunks(t))
 
         if self.is_named:
-            ch = MacroTypeChunk(macro, initializer, indent)
+            ch = MacroTypeChunk(self, indent)
             ch.add_references(refs)
             return [ch]
         else:
@@ -2411,13 +2411,10 @@ class FunctionPointerTypeDeclaration(SourceChunk):
 
 class MacroTypeChunk(SourceChunk):
 
-    def __init__(self, macro, initializer, indent):
-        self.macro = macro
-        self.initializer = initializer
-
-        super(MacroTypeChunk, self).__init__(macro,
-            "Usage of macro type %s" % macro,
-            code = indent + macro.gen_usage_string(initializer)
+    def __init__(self, _type, indent):
+        super(MacroTypeChunk, self).__init__(_type,
+            "Usage of type %s" % _type,
+            code = indent + _type.macro.gen_usage_string(_type.initializer)
         )
 
 

--- a/source/model.py
+++ b/source/model.py
@@ -2091,6 +2091,19 @@ class TypeFixerVisitor(TypeReferencesVisitor):
                 if type(t) is TypeReference:
                     t = t.type
 
+            # A type defined inside another type is not subject of this fixer.
+            # Because internal type is always defined within its container and,
+            # hence, never defined by a header inclusion or directly by a
+            # source.
+            # Note that `definer` is not visited by this type fixer. Hence,
+            # the field is never a `TypeReference`.
+            # Note that if we are here then topmost container of the `t`ype is
+            # within `self.source`.
+            # Else, the topmost container is replaced with a `TypeReference`
+            # and a `BreakVisiting` is raised (see above).
+            if isinstance(t.definer, Type):
+                return
+
             # replace foreign type with reference to it
             try:
                 tr = self.source.types[t.name]

--- a/source/model.py
+++ b/source/model.py
@@ -1705,12 +1705,11 @@ class Macro(Type):
             used = used
         )
 
-    def gen_usage(self, initializer = None, name = None):
-        return MacroUsage(self,
-            initializer = initializer,
-            name = name,
-            is_usage = True
-        )
+    def gen_usage(self, initializer = None, name = None, counter = count(0)):
+        "A helper that automatically generates a name for `MacroUsage`."
+        if name is None:
+            name = self.name + ".auto" + str(next(counter))
+        return MacroUsage(self, initializer = initializer, name = name)
 
     def gen_dict(self):
         res = {HDB_MACRO_NAME : self.name}
@@ -1736,18 +1735,11 @@ class Macro(Type):
 class MacroUsage(Type):
     "Something defined using a macro expansion."
 
-    def __init__(self, macro,
-        initializer = None,
-        name = None,
-        is_usage = False
-    ):
+    def __init__(self, macro, initializer = None, name = None):
         if not isinstance(macro, Macro):
             raise ValueError("Attempt to create %s from "
                 " %s which is not macro." % (type(self).__name__, macro)
             )
-
-        if is_usage and name is None:
-            name = macro.name + ".usage" + str(id(self))
 
         super(MacroUsage, self).__init__(name = name, incomplete = False)
 

--- a/source/model.py
+++ b/source/model.py
@@ -21,7 +21,7 @@ __all__ = [
       , "MacroDefinition"
       , "PointerTypeDeclaration"
       , "FunctionPointerTypeDeclaration"
-      , "MacroTypeUsage"
+      , "MacroTypeChunk"
       , "FunctionPointerDeclaration"
       , "VariableDeclaration"
       , "VariableDefinition"
@@ -1762,7 +1762,7 @@ class MacroType(Type):
                 refs.extend(generator.provide_chunks(t))
 
         if self.is_named:
-            ch = MacroTypeUsage(macro, initializer, indent)
+            ch = MacroTypeChunk(macro, initializer, indent)
             ch.add_references(refs)
             return [ch]
         else:
@@ -2407,13 +2407,13 @@ class FunctionPointerTypeDeclaration(SourceChunk):
         )
 
 
-class MacroTypeUsage(SourceChunk):
+class MacroTypeChunk(SourceChunk):
 
     def __init__(self, macro, initializer, indent):
         self.macro = macro
         self.initializer = initializer
 
-        super(MacroTypeUsage, self).__init__(macro,
+        super(MacroTypeChunk, self).__init__(macro,
             "Usage of macro type %s" % macro,
             code = indent + macro.gen_usage_string(initializer)
         )

--- a/source/model.py
+++ b/source/model.py
@@ -338,6 +338,13 @@ class Source(object):
                     for s in t.get_definers():
                         if s == self:
                             continue
+
+                        # A `t`ype can be locally defined within something
+                        # (e.g. `Type`). There we looks for source-level
+                        # container of the `t`ype.
+                        while not isinstance(s, Source):
+                            s = s.definer
+
                         if not isinstance(s, Header):
                             raise RuntimeError("Attempt to define variable"
                                 " {var} whose initializer code uses type {t}"

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -286,32 +286,43 @@ class TestMacroType(SourceModelTestHelper, TestCase):
         super(TestMacroType, self).setUp()
         name = type(self).__name__
 
-        hdr = Header(name.lower() + ".h")
-        hdr.add_type(Macro("QTAIL_ENTRY", args = [ "type" ]))
+        Header("entry_macro.h").add_type(
+            Macro("QTAIL_ENTRY", args = [ "type" ])
+        )
+        Header("struct_end.h").add_type(Macro("END_STRUCT"))
+        Header("header_init.h").add_type(Macro("INIT_HEADER"))
 
+        hdr = Header(name.lower() + ".h")
         struct = Structure("StructA")
         struct.append_fields([
             Type["QTAIL_ENTRY"]("entry",
                 macro_initializer = Initializer({ "type":  struct })
             ),
-            Pointer(struct)("next")
+            Pointer(struct)("next"),
+            Type["END_STRUCT"].gen_type()
         ])
         hdr.add_type(struct)
+
+        hdr.add_type(Type["INIT_HEADER"].gen_type())
 
         hdr_content = """\
 /* {path} */
 #ifndef INCLUDE_{fname_upper}_H
 #define INCLUDE_{fname_upper}_H
 
-#define QTAIL_ENTRY(type)
+#include "entry_macro.h"
+#include "header_init.h"
+#include "struct_end.h"
 
 typedef struct StructA StructA;
 
 struct StructA {{
     QTAIL_ENTRY(StructA) entry;
     StructA *next;
+    END_STRUCT
 }};
 
+INIT_HEADER
 #endif /* INCLUDE_{fname_upper}_H */
 """.format(path = hdr.path, fname_upper = name.upper())
 


### PR DESCRIPTION
- add `MacroUsage` class and inherit `MacroType` from it
- support `Type` definers

### v2
- all changes are re-splitting into commits
- delete `MacroType` type

### v1.1
- `MacroType` is only a helper, much functionality is defined by `MacroUsage`
- use `count` to generate more deterministic `".auto"` names for `MacroType`s
- work on comments
