### PR TITLE
Support for git version specification using a remote branch name

### DIFF
--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -197,7 +197,7 @@ as fast as possible. A clone is neither honest nor independent, so be careful.
     if version is None:
         version = repo.head.commit.hexsha
     else:
-        version = repo.commit(version).hexsha
+        version = git_find_commit(repo, version).hexsha
 
     tmp_wc = mkdtemp(prefix = "%s-%s-" % (prefix, version))
 

--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -4,6 +4,7 @@ __all__ = [
   , "iter_chunks"
   , "git_diff2delta_intervals"
   , "fast_repo_clone"
+  , "git_find_commit"
 ]
 
 from collections import (
@@ -23,6 +24,7 @@ from os.path import (
     join
 )
 from git import (
+    BadName,
     Repo
 )
 
@@ -269,3 +271,19 @@ def init_submodules_from_cache(repo, cache_dir):
 
         sub_repo = Repo(join(repo.working_tree_dir, sm_path))
         init_submodules_from_cache(sub_repo, join(sub_cache, "modules"))
+
+
+def git_find_commit(repo, version):
+    """ A wrapper for Repo.commit. It also searches the version as
+a remote head.
+    """
+    try:
+        return repo.commit(version)
+    except BadName:
+        # Try to look the version (it's a branch) in remotes.
+        for rem in repo.remotes:
+            for ref in rem.refs:
+                if ref.remote_head == version:
+                    return ref.commit
+
+        raise

--- a/misc/test_commits.py
+++ b/misc/test_commits.py
@@ -32,6 +32,7 @@ from matplotlib import (
     pyplot as plt
 )
 from common import (
+    git_find_commit,
     uname,
     Measurer,
     fast_repo_clone,
@@ -345,8 +346,9 @@ class QDTMeasurer(Measurer):
 
         self.diffs = diffs
 
+        target_commit = git_find_commit(qemugit, project.target_version)
         self.qvc_pattern = (
-            "qvc*_%s.py" % qemugit.commit(project.target_version).hexsha
+            "qvc*_%s.py" % target_commit.hexsha
         )
 
     def __enter__(self):

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -21,6 +21,7 @@ from source import (
     Macro
 )
 from common import (
+    git_find_commit,
     co_process,
     get_cleaner,
     lazy,
@@ -539,7 +540,7 @@ class QemuVersionDescription(object):
         if version is None:
             c = self.repo.head.commit
         else:
-            c = self.repo.commit(version)
+            c = git_find_commit(self.repo, version)
 
         self.commit_sha = c.hexsha
 


### PR DESCRIPTION
Targets the case when remote branch (used a git version id) is not checked
out or checked out with different name.