### PR TITLE
Fixes pack #7

### DIFF
--- a/debug/runtime.py
+++ b/debug/runtime.py
@@ -150,6 +150,7 @@ not actual now.
                 print_exc()
 
         t = Thread(target = run)
+        t.name = "RSP client"
         t.start()
 
         while t.isAlive():

--- a/debug/type.py
+++ b/debug/type.py
@@ -103,7 +103,7 @@ of this field at runtime.
 # TODO: assign values according to GDB Python API
 c = count(1)
 
-TYPE_CODE_PTR = next(c)
+TYPE_CODE_PTR = next(c) # 1
 TYPE_CODE_ARRAY = next(c)
 TYPE_CODE_STRUCT = next(c)
 TYPE_CODE_UNION = next(c)
@@ -112,7 +112,7 @@ TYPE_CODE_FLAGS = next(c)
 TYPE_CODE_FUNC = next(c)
 TYPE_CODE_INT = next(c)
 TYPE_CODE_FLT = next(c)
-TYPE_CODE_VOID = next(c)
+TYPE_CODE_VOID = next(c) # 10
 TYPE_CODE_SET = next(c)
 TYPE_CODE_RANGE = next(c)
 TYPE_CODE_STRING = next(c)
@@ -122,7 +122,7 @@ TYPE_CODE_METHOD = next(c)
 TYPE_CODE_METHODPTR = next(c)
 TYPE_CODE_MEMBERPTR = next(c)
 TYPE_CODE_REF = next(c)
-TYPE_CODE_RVALUE_REF = next(c)
+TYPE_CODE_RVALUE_REF = next(c) # 20
 TYPE_CODE_CHAR = next(c)
 TYPE_CODE_BOOL = next(c)
 TYPE_CODE_COMPLEX = next(c)

--- a/qlv.py
+++ b/qlv.py
@@ -453,6 +453,12 @@ if __name__ == "__main__":
     ap = ArgumentParser(
         prog = "QEMU Log Viewer"
     )
+    DEFAULT_LIMIT = "1000"
+    ap.add_argument("-l",
+        metavar = "N",
+        default = DEFAULT_LIMIT,
+        help = "limit number of log lines (default %s)" % DEFAULT_LIMIT
+    )
     ap.add_argument("qlog")
 
     args = ap.parse_args()
@@ -462,7 +468,9 @@ if __name__ == "__main__":
     print("Reading " + qlogFN)
 
     qlog = QEMULog()
-    qlog.feed_file_by_name(qlogFN)
+    with open(qlogFN, "r") as log_stream:
+        qlog.feed_lines(log_stream, int(args.l))
+    qlog.feeder.send(EOL)
 
     print("Building full trace")
     trace = qlog.full_trace()

--- a/qlv.py
+++ b/qlv.py
@@ -58,6 +58,9 @@ class InInstr(object):
         self.disas = ":".join(parts[1:])
         self.size = 1
 
+    def __str__(self):
+        return self.l
+
 
 class TBCache(object):
     def __init__(self, back):

--- a/qlv.py
+++ b/qlv.py
@@ -107,22 +107,37 @@ class QTrace(object):
     def __init__(self, lines):
         l0 = iter(lines[0])
 
-        addr = []
+        # Search for "CPU_LOG_EXEC" for trace message format.
+        addrs = []
         for c in l0:
             if c == "[":
                 break
-        for c in l0:
-            if c == " ":
-                break
-        for c in l0:
-            if c in hexDigits:
-                addr.append(c)
+        while True:
+            addr = []
+            for c in l0:
+                if c in hexDigits:
+                    addr.append(c)
+                    break
             else:
                 break
+            for c in l0:
+                if c in hexDigits:
+                    addr.append(c)
+                else:
+                    break
+            else:
+                break
+            try:
+                addr_val = int("".join(addr), base = 16)
+            except ValueError:
+                continue
+            addrs.append(addr_val)
 
+        # `addrs[1]` is `pc`. Other values can represent different things
+        # depending on Qemu version. They are not interesting here.
         try:
-            self.firstAddr = int("".join(addr), base = 16)
-        except ValueError:
+            self.firstAddr = addrs[1]
+        except IndexError:
             self.bad = True
 
         if len(lines) > 1:

--- a/qlv.py
+++ b/qlv.py
@@ -47,7 +47,7 @@ def is_in_asm_instr(l):
 class InInstr(object):
 
     def __init__(self, l):
-        l = l.rstrip()
+        self.l = l = l.rstrip()
         parts = l.split(":")
 
         if len(parts) < 2:

--- a/qlv.py
+++ b/qlv.py
@@ -23,6 +23,10 @@ from six.moves.tkinter_ttk import (
 from common import (
     mlget as _
 )
+from six.moves import (
+    zip as izip,
+    range as xrange,
+)
 
 # less value = more info
 DEBUG = 3
@@ -148,6 +152,12 @@ class QTrace(object):
         self.bad = False
         self.next = None
 
+
+class EOL:
+    "End Of Log"
+    pass
+
+
 class QEMULog(object):
     def __init__(self):
         self.trace = []
@@ -160,6 +170,9 @@ class QEMULog(object):
         self.tbIdMap = {}
 
         self.prevTrace = None
+
+        self.feeder = self.feed()
+        next(self.feeder)
 
     def lookInstr(self, addr, fromCache = None):
         if fromCache is None:
@@ -363,47 +376,64 @@ class QEMULog(object):
             print("--- new_unrecognized line")
             print(l)
 
-    def feed(self, reader):
-        for l0 in reader:
-            while l0 is not None:
-                if is_in_asm(l0):
-                    in_asm = []
-                    for l1 in reader:
-                        if is_in_asm_instr(l1):
-                            in_asm.append(l1)
-                        else:
-                            l0 = l1
-                            break
+    def feed(self):
+        l0 = yield
+        while l0 is not EOL:
+            if is_in_asm(l0):
+                in_asm = []
+                l1 = yield
+                while l1 is not EOL:
+                    if is_in_asm_instr(l1):
+                        in_asm.append(l1)
                     else:
-                        l0 = None
+                        l0 = l1 # try that line in other `if`s
+                        break
+                    l1 = yield
+                else:
+                    l0 = l1
 
-                    self.new_in_asm(in_asm)
-                    continue
+                self.new_in_asm(in_asm)
+                continue
 
-                if is_trace(l0):
-                    trace = [l0]
+            if is_trace(l0):
+                trace = [l0]
 
-                    for l1 in reader:
-                        if is_trace(l1) or is_linking(l1) or is_in_asm(l1):
-                            l0 = l1
-                            break
-                        trace.append(l1)
-                    else:
-                        l0 = None
+                l1 = yield
+                while l1 is not EOL:
+                    # Traces are following one by one.
+                    # - User did not passed other flags to -d.
+                    # - Qemu can cancel TB execution because of `exit_request`
+                    # or `tcg_exit_req` after trace message has been printed.
+                    if is_trace(l1) or is_linking(l1) or is_in_asm(l1):
+                        l0 = l1
+                        break
+                    trace.append(l1)
+                    l1 = yield
+                else:
+                    l0 = l1
 
-                    self.new_trace(trace)
-                    continue
+                self.new_trace(trace)
+                continue
 
-                if is_linking(l0):
-                    self.new_linking(l0)
-                    break
+            if is_linking(l0):
+                self.new_linking(l0)
+                l0 = yield
+                continue
 
-                self.new_unrecognized(l0)
-                break
+            self.new_unrecognized(l0)
+            l0 = yield
+
+        # `StopIteration` should not be raised because `send` method is used
+        # to input lines. Just ignore consequent input.
+        while True:
+            yield
 
     def feed_file(self, f):
         # iterate file line by line
-        self.feed(iter(f))
+        feeder = self.feeder
+        for l in f:
+            feeder.send(l)
+        feeder.send(EOL)
 
     def feed_file_by_name(self, file_name):
         f = open(file_name, "r")

--- a/qlv.py
+++ b/qlv.py
@@ -17,6 +17,9 @@ from widgets import (
 from six.moves.tkinter import (
     Scrollbar
 )
+from six.moves.tkinter_ttk import (
+    Style
+)
 from common import (
     mlget as _
 )
@@ -412,11 +415,14 @@ if __name__ == "__main__":
 
     tk = GUITk()
     tk.title(_("QEmu Log Viewer"))
-    tk.geometry("600x600")
+    tk.geometry("1000x600")
     tk.grid()
     tk.rowconfigure(0, weight = 1)
     tk.columnconfigure(0, weight = 1)
     tk.columnconfigure(1, weight = 0)
+
+    tkstyle = Style()
+    tkstyle.configure("Treeview", font = ("Courier", 10))
 
     columns = [
         "addr",
@@ -431,7 +437,7 @@ if __name__ == "__main__":
     tv.column("#0", width = 10)
     tv.column("addr", minwidth = 120, width = 120)
     tv.column("size", minwidth = 30, width = 30)
-    tv.column("disas", minwidth = 200)
+    tv.column("disas", width = 600)
     tv.grid(row = 0, column = 0, sticky = "NESW")
 
     vscroll = Scrollbar(tk)

--- a/qlv.py
+++ b/qlv.py
@@ -435,6 +435,13 @@ class QEMULog(object):
             feeder.send(l)
         feeder.send(EOL)
 
+    def feed_lines(self, f, limit = 1000):
+        feeder = self.feeder
+        for last, l in izip(xrange(limit), f):
+            feeder.send(l)
+        if last < limit - 1:
+            feeder.send(EOL)
+
     def feed_file_by_name(self, file_name):
         f = open(file_name, "r")
         self.feed_file(f)

--- a/qlv.py
+++ b/qlv.py
@@ -160,6 +160,9 @@ class QTrace(object):
         self.bad = False
         self.next = None
 
+    def __str__(self):
+        return self.header
+
 
 class EOL:
     "End Of Log"

--- a/qlv.py
+++ b/qlv.py
@@ -115,7 +115,9 @@ hexDigits = set("0123456789abcdefABCDEF")
 class QTrace(object):
 
     def __init__(self, lines):
-        l0 = iter(lines[0])
+        self.header = header = lines[0].rstrip()
+
+        l0 = iter(header)
 
         # Search for "CPU_LOG_EXEC" for trace message format.
         addrs = []

--- a/qlv.py
+++ b/qlv.py
@@ -46,6 +46,8 @@ def is_in_asm_instr(l):
 
 class InInstr(object):
 
+    first = False # (in TB), set externally
+
     def __init__(self, l):
         self.l = l = l.rstrip()
         parts = l.split(":")
@@ -321,6 +323,7 @@ class QEMULog(object):
             if prev_instr is None:
                 self.current_cache.tbMap[instr.addr] = tb
                 self.tbIdMap[tb] = (instr.addr, len(self.in_asm))
+                instr.first = True
 
             if prev_instr:
                 prev_instr.size = instr.addr - prev_instr.addr
@@ -516,6 +519,12 @@ if __name__ == "__main__":
     tv.column("addr", minwidth = 120, width = 120)
     tv.column("size", minwidth = 30, width = 30)
     tv.column("disas", width = 600)
+
+    tv.tag_configure("first", background = "#EEEEEE")
+
+    STYLE_FIRST = ("first",)
+    STYLE_DEFAULT = tuple()
+
     tv.grid(row = 0, column = 0, sticky = "NESW")
 
     vscroll = Scrollbar(tk)
@@ -529,6 +538,7 @@ if __name__ == "__main__":
             print("0x%08X: %s" % (i.addr, i.disas))
         tv.insert("", "end",
             text = str(idx),
+            tags = STYLE_FIRST if i.first else STYLE_DEFAULT,
             values = ("0x%08X" % i.addr, "-", str(i.disas))
         )
 

--- a/qlv.py
+++ b/qlv.py
@@ -43,7 +43,9 @@ def is_in_asm(l):
 def is_in_asm_instr(l):
     return l[:2] == "0x"
 
+
 class InInstr(object):
+
     def __init__(self, l):
         l = l.rstrip()
         parts = l.split(":")
@@ -55,6 +57,7 @@ class InInstr(object):
 
         self.disas = ":".join(parts[1:])
         self.size = 1
+
 
 class TBCache(object):
     def __init__(self, back):
@@ -105,9 +108,12 @@ class TBCache(object):
 
         return False
 
+
 hexDigits = set("0123456789abcdefABCDEF")
 
+
 class QTrace(object):
+
     def __init__(self, lines):
         l0 = iter(lines[0])
 
@@ -159,6 +165,7 @@ class EOL:
 
 
 class QEMULog(object):
+
     def __init__(self):
         self.trace = []
         self.in_asm = []
@@ -448,6 +455,7 @@ class QEMULog(object):
         f = open(file_name, "r")
         self.feed_file(f)
         f.close()
+
 
 if __name__ == "__main__":
     ap = ArgumentParser(

--- a/qlv.py
+++ b/qlv.py
@@ -419,15 +419,17 @@ if __name__ == "__main__":
     tk.columnconfigure(1, weight = 0)
 
     columns = [
+        "addr",
         "size",
         "disas"
     ]
 
     tv = VarTreeview(tk, columns = columns)
-    tv.heading("#0", text = _("Address"))
+    tv.heading("addr", text = _("Address"))
     tv.heading("size", text = _("Size"))
     tv.heading("disas", text = _("Disassembly"))
-    tv.column("#0", minwidth = 120, width = 120)
+    tv.column("#0", width = 10)
+    tv.column("addr", minwidth = 120, width = 120)
     tv.column("size", minwidth = 30, width = 30)
     tv.column("disas", minwidth = 200)
     tv.grid(row = 0, column = 0, sticky = "NESW")
@@ -438,12 +440,12 @@ if __name__ == "__main__":
     tv.config(yscrollcommand = vscroll.set)
     vscroll.config(command = tv.yview)
 
-    for i in trace:
+    for idx, i in enumerate(trace):
         if DEBUG < 3:
             print("0x%08X: %s" % (i.addr, i.disas))
         tv.insert("", "end",
-            text = "0x%08X" % i.addr,
-            values = ("-", str(i.disas))
+            text = str(idx),
+            values = ("0x%08X" % i.addr, "-", str(i.disas))
         )
 
     tk.mainloop()

--- a/source/model.py
+++ b/source/model.py
@@ -1235,12 +1235,12 @@ class Structure(Type):
 
         if self.declaration is None:
             struct_begin = StructureTypedefDeclarationBegin(self, indent)
-            struct_end = StructureTypedefDeclarationEnd(self, fields_indent,
+            struct_end = StructureTypedefDeclarationEnd(self,
                 indent, True
             )
         else:
             struct_begin = StructureDeclarationBegin(self, indent)
-            struct_end = StructureDeclarationEnd(self, fields_indent,
+            struct_end = StructureDeclarationEnd(self,
                 indent, True
             )
 
@@ -2561,7 +2561,6 @@ class StructureTypedefDeclarationEnd(SourceChunk):
     weight = 2
 
     def __init__(self, struct,
-        fields_indent = "    ",
         indent = "",
         append_nl = True
     ):
@@ -2595,7 +2594,6 @@ class StructureDeclarationEnd(SourceChunk):
     weight = 2
 
     def __init__(self, struct,
-        fields_indent = "    ",
         indent = "",
         append_nl = True
     ):

--- a/widgets/cross_dialogs.py
+++ b/widgets/cross_dialogs.py
@@ -100,15 +100,17 @@ def askopen(*args, **kw):
     return CrossOpenDialog(*args, **kw).ask()
 
 class CrossDirectoryDialog(CrossDialog):
-    def __init__(self, master, title = None):
+    def __init__(self, master, title = None, **extra):
         super(CrossDirectoryDialog, self).__init__(master)
 
         self.title = _("Select directory") if title is None else title
+        self.extra = extra
 
     def __ask__(self):
-        kw = {
-            "title" : self.title.get()
-        }
+        kw = dict(
+            title = self.title.get(),
+            **self.extra
+        )
 
         return tk_askdirector(**kw)
 

--- a/widgets/var_widgets.py
+++ b/widgets/var_widgets.py
@@ -87,7 +87,7 @@ class VarLabel(Label):
             self.text_var = kw.pop("text")
             kw["text"] = self.text_var.get()
         else:
-            self.text_var = StringVar("")
+            self.text_var = StringVar()
         Label.__init__(self, *args, **kw)
         self.text_var.trace_variable("w", self.on_var_changed)
 

--- a/widgets/var_widgets.py
+++ b/widgets/var_widgets.py
@@ -272,13 +272,10 @@ class VarTreeview(Treeview):
         to_track = []
 
         try:
-            values = kw["values"]
+            kw["values"] = values = list(kw.pop("values"))
         except KeyError:
             pass
         else:
-            if not isinstance(values, (tuple, list)):
-                values = (values,)
-
             for col, v in enumerate(values):
                 if isinstance(v, variables):
                     to_track.append((col, v))

--- a/widgets/var_widgets.py
+++ b/widgets/var_widgets.py
@@ -84,8 +84,12 @@ class VarLabel(Label):
             kw["text"] = var
 
         if "text" in kw:
-            self.text_var = kw.pop("text")
-            kw["text"] = self.text_var.get()
+            text = kw.pop("text")
+            if isinstance(text, variables):
+                kw["text"] = text.get()
+                self.text_var = text
+            else:
+                self.text_var = StringVar(value = text)
         else:
             self.text_var = StringVar()
         Label.__init__(self, *args, **kw)


### PR DESCRIPTION
Fixes for:
- widgets,
- Qemu log visualizer,
- source code model,
- debug module.

### v3
- fixup tab in `VarTreeview`
- QLV:
    - work on coding style
    - `__str__` for `InInstr` and `QTrace`
    - extend/fixup comments
    - highlight first instruction in TB
    - fixup typo `is_trace(l0)`

### v2
- use `Thread.name`
- In `VarTreeview.__init__` copy values list and replace items instead of
list building by `insert`.
- QLV:
    - close `log_stream`
    - `feed_lines` is added in its own patch
    - fixup comment about Trace record format
    - `EOL`: end of log marker
    - fixup errors in `QEMULog.feed`
- `__main__` indicates `EOL` after desired lines amount are fed.