### PR TITLE
Fixup qlog tail loss

### DIFF
--- a/common/co_pipeline.py
+++ b/common/co_pipeline.py
@@ -11,6 +11,11 @@ It's output is `yield` argument. If next output requires extra input
 it can just `yield` (`None`). Output of last stage is pipeline output.
     First stage is never `send`-ed input: any standard iterator can
 be used. Rest stages are never `send`-ed `None`.
+    When a stage `return`s, the whole pipeline is stopped.
+    Tip: a stage must `yield` all ready data because the `yield` statement
+potentially can never return control (pipeline stop).
+    Tip: a stage can use collections to `yield` data when it produces more
+items than consumes.
     """
 
     if not stages:

--- a/qemu/qlog.py
+++ b/qemu/qlog.py
@@ -231,6 +231,10 @@ class QEMULog(object):
 
         self.pipeline = pipeline(*stages)
 
+    def iter_instructions(self):
+        for i in self.pipeline:
+            yield i
+
     def lookInstr(self, addr, fromCache = None):
         if fromCache is None:
             return self.current_cache.lookInstrDown(addr)

--- a/qlv.py
+++ b/qlv.py
@@ -149,7 +149,7 @@ class QLVWindow(GUITk):
         # This is list of those lists.
         self.all_instructions = all_instructions = list(list() for _ in qlogs)
 
-        trace_iters = list(qlog.pipeline for qlog in qlogs)
+        trace_iters = list(qlog.iter_instructions() for qlog in qlogs)
         idx = 0
 
         while True:


### PR DESCRIPTION
This patch series fixes loss of tail instructions caused by pipeline logic pitfall (see patches).