### PR TITLE
Cpu gen

### DIFF
--- a/cpu_imports/__init__.py
+++ b/cpu_imports/__init__.py
@@ -1,0 +1,38 @@
+from source import (
+    CINT
+  , CSTR
+
+# CPU instructions semantics definition
+  , Type
+  , Comment
+  , Call
+  , MCall
+  , Macro
+  , Function
+  , Declare
+  , Variable
+  , BranchSwitch
+  , SwitchCase
+  , OpAssign
+  , OpIndex
+  , OpAdd
+  , BranchIf
+  , BranchElse
+  , OpLess
+  , OpOr
+  , OpAnd
+  , OpNot
+  , OpEq
+)
+from qemu import (
+# CPU template generation settings
+    CPUInfo
+  , CPURegister
+  , gen_reg_names_range
+  , Instruction
+  , Opcode
+  , Operand
+  , Reserved
+# helpers
+  , underscored_name_shortener
+)

--- a/qdc-gui.py
+++ b/qdc-gui.py
@@ -83,6 +83,8 @@ import sys
 from os.path import (
     join,
     isfile,
+    abspath,
+    dirname,
     expanduser
 )
 
@@ -793,6 +795,7 @@ later.").get()
                 else:
                     raise Exception("No project object was loaded")
 
+            v.replace_relpaths_to_abspaths(abspath(dirname(file_name)))
             self.set_project(v)
             self.set_current_file_name(file_name)
             self.saved_operation = self.pht.pos
@@ -812,7 +815,12 @@ later.").get()
             if isinstance(d, MachineNode):
                 d.link(handle_system_bus = False)
 
+        file_path = abspath(dirname(file_name))
+        project.replace_abspaths_to_relpaths(file_path)
+
         pythonize(project, file_name)
+
+        project.replace_relpaths_to_abspaths(file_path)
 
         self.set_current_file_name(file_name)
         self.saved_operation = self.pht.pos

--- a/qdt/__init__.py
+++ b/qdt/__init__.py
@@ -16,6 +16,9 @@ from qemu import (
 # Access to PCI identifiers database
   , PCIId
 
+# CPU template generation settings
+  , CPUDescription
+
 # Machine draft generation settings
   , MachineDescription
   , MachineNode # Alias of MachineDescription. Legacy. Do not use it.

--- a/qemu/cpu/__init__.py
+++ b/qemu/cpu/__init__.py
@@ -1,0 +1,6 @@
+from common import (
+    iter_submodules
+)
+
+for mod in iter_submodules():
+    exec("from ." + mod + " import *")

--- a/qemu/cpu/code_generation.py
+++ b/qemu/cpu/code_generation.py
@@ -1,0 +1,1334 @@
+# functions filling CPU & TCG front-end implementation
+
+__all__ = [
+    "fill_bfd_getb64_body"
+  , "fill_class_by_name_body"
+  , "fill_class_init_body"
+  , "fill_cpu_get_tb_cpu_state_body"
+  , "fill_cpu_init_body"
+  , "fill_cpu_mmu_index_body"
+  , "fill_cpuclass_tlb_fill_body"
+  , "fill_decode_opc_body"
+  , "fill_disas_set_info_body"
+  , "fill_disas_write_helper_body"
+  , "fill_dump_state_body"
+  , "fill_env_get_cpu_body"
+  , "fill_gdb_rw_register_body"
+  , "fill_gen_intermediate_code_body"
+  , "fill_get_phys_page_debug_body"
+  , "fill_handle_mmu_fault_body"
+  , "fill_has_work_body"
+  , "fill_helper_debug_body"
+  , "fill_helper_illegal_body"
+  , "fill_initfn_body"
+  , "fill_print_insn_body"
+  , "fill_raise_exception_body"
+  , "fill_realizefn_body"
+  , "fill_reset_body"
+  , "fill_restore_state_to_opc_body"
+  , "fill_set_pc_body"
+  , "fill_set_pc_inc_body"
+  , "fill_tcg_init_body"
+  , "fill_tlb_fill_body"
+]
+
+from ..version import (
+    get_vp,
+)
+from .constants import (
+    BYTE_BITSIZE,
+    SUPPORTED_READ_BITSIZES,
+)
+from .instruction import (
+    re_disas_format,
+)
+from .parse_tree_code_builder import (
+    ParseTreeCodeBuilder,
+)
+from common import (
+    ee,
+)
+from copy import (
+    copy,
+)
+from source import (
+    BodyTree,
+    BranchElse,
+    BranchIf,
+    BranchSwitch,
+    Break,
+    CINT,
+    Call,
+    Comment,
+    Declare,
+    Function,
+    Goto,
+    Header,
+    Ifdef,
+    Label,
+    LoopDoWhile,
+    LoopFor,
+    MCall,
+    MacroBranch,
+    NewLine,
+    Node,
+    OpAdd,
+    OpAddr,
+    OpAnd,
+    OpAssign,
+    OpCast,
+    OpCombAssign,
+    OpDeclareAssign,
+    OpDeref,
+    OpEq,
+    OpGE,
+    OpGreater,
+    OpIndex,
+    OpLShift,
+    OpLess,
+    OpLogAnd,
+    OpLogNot,
+    OpLogOr,
+    OpNEq,
+    OpOr,
+    OpPreInc,
+    OpRShift,
+    OpRem,
+    OpSDeref,
+    OpSizeOf,
+    OpSub,
+    Pointer,
+    Return,
+    SwitchCase,
+    Type,
+    Variable,
+)
+
+
+DEBUG_DECODER = ee("QDT_DEBUG_DECODER")
+
+def fill_bfd_getb64_body(function):
+    ull = "unsigned long long"
+    v = Type[ull].gen_var("v")
+    addr = function.args[0]
+    function.body = BodyTree()(
+        Declare(v),
+        NewLine(),
+        OpAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 0), 56))),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 1), 48)), "|"),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 2), 40)), "|"),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 3), 32)), "|"),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 4), 24)), "|"),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 5), 16)), "|"),
+        OpCombAssign(v, OpCast(ull, OpLShift(OpIndex(addr, 6), 8)), "|"),
+        OpCombAssign(v, OpCast(ull, OpIndex(addr, 7)), "|"),
+        Return(OpCast("bfd_vma", v))
+    )
+
+def fill_class_by_name_body(cputype, function):
+    function.body = body = BodyTree()
+
+    oc = Pointer(Type["ObjectClass"])("oc")
+    cpu_model = function.args[0]
+    null = MCall("NULL")
+
+    if get_vp("cpu_model null check"):
+        body(
+            Declare(oc),
+            NewLine(),
+            BranchIf(OpEq(cpu_model, null))(Return(null)),
+            OpAssign(oc, Call("object_class_by_name", cpu_model))
+        )
+    else:
+        body(
+            Declare(
+                OpDeclareAssign(
+                    oc,
+                    Call("object_class_by_name", cpu_model)
+                )
+            )
+        )
+
+    body(
+        BranchIf(
+            OpLogAnd(
+                OpNEq(oc, null),
+                OpLogOr(
+                    OpEq(
+                        Call(
+                            "object_class_dynamic_cast",
+                            oc,
+                            MCall(cputype.qtn.type_macro)
+                        ),
+                        null
+                    ),
+                    Call("object_class_is_abstract", oc)
+                )
+            )
+        )(Return(null)),
+        Return(oc)
+    )
+
+def fill_class_init_body(cputype, function, num_core_regs, vmstate):
+    function.body = body = BodyTree()
+
+    oc = function.args[0]
+    dc = Pointer(Type["DeviceClass"])("dc")
+    cc = Pointer(Type["CPUClass"])("cc")
+    mcc = Pointer(Type[cputype.struct_class_name])("mcc")
+
+    fn_name = cputype.gen_func_name
+
+    body(
+        Declare(
+            OpDeclareAssign(
+                dc,
+                MCall("DEVICE_CLASS", oc)
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                cc,
+                MCall("CPU_CLASS", oc)
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                mcc,
+                MCall(cputype.class_macro, oc)
+            )
+        ),
+        NewLine()
+    )
+
+    if get_vp("device_class_set_parent_realize exists"):
+        body(
+            Call(
+                "device_class_set_parent_realize",
+                dc,
+                Type[fn_name("realizefn")],
+                OpAddr(OpSDeref(mcc, "parent_realize")),
+            )
+        )
+    else:
+        body(
+            OpAssign(
+                OpSDeref(mcc, "parent_realize"),
+                OpSDeref(dc, "realize")
+            ),
+            OpAssign(
+                OpSDeref(dc, "realize"),
+                Type[fn_name("realizefn")]
+            )
+        )
+
+    body(
+        OpAssign(
+            OpSDeref(mcc, "parent_reset"),
+            OpSDeref(cc, "reset")
+        )
+    )
+    body(*[
+        OpAssign(
+            OpSDeref(cc, name),
+            Type[fn_name(name)]
+        ) for name in ["reset", "has_work", "do_interrupt", "set_pc",
+            "dump_state", "disas_set_info", "class_by_name"
+        ]
+    ])
+    body(
+        OpAssign(
+            OpSDeref(cc, "vmsd"),
+            OpAddr(vmstate)
+        ),
+        OpAssign(
+            OpSDeref(cc, "gdb_num_core_regs"),
+            num_core_regs
+        )
+    )
+    body(*[
+        OpAssign(
+            OpSDeref(cc, name),
+            Type[fn_name(name)]
+        ) for name in ["gdb_read_register", "gdb_write_register",
+            "get_phys_page_debug"
+        ]
+    ])
+
+    if get_vp("Generic call to tcg_initialize"):
+        body(
+            OpAssign(
+                OpSDeref(cc, "tcg_initialize"),
+                Type[cputype.tcg_init_name]
+            )
+        )
+
+    if get_vp("CPUClass has tlb_fill field"):
+        body(
+            OpAssign(
+                OpSDeref(cc, "tlb_fill"),
+                Type[cputype.gen_func_name("tlb_fill")]
+            )
+        )
+
+def fill_cpu_get_tb_cpu_state_body(function, pc_register):
+    function.body = BodyTree()(
+        OpAssign(
+            OpDeref(function.args[1]),
+            OpSDeref(function.args[0], pc_register)
+        ),
+        OpAssign(OpDeref(function.args[2]), 0),
+        OpAssign(OpDeref(function.args[3]), 0)
+    )
+
+def fill_cpu_init_body(cputype, function):
+    function.body = BodyTree()(
+        Return(
+            MCall(
+                cputype.qtn.for_macros,
+                Call("cpu_generic_init", MCall(cputype.qtn.type_macro),
+                    function.args[0]
+                )
+            )
+        )
+    )
+
+def fill_cpu_mmu_index_body(function):
+    function.body = BodyTree()(Return(0))
+
+def fill_cpuclass_tlb_fill_body(function):
+    prot = Type["int"]("prot")
+
+    function.body = BodyTree()(
+        Declare(
+            OpDeclareAssign(
+                prot,
+                OpOr(
+                    MCall("PAGE_READ"),
+                    OpOr(
+                        MCall("PAGE_WRITE"),
+                        MCall("PAGE_EXEC")
+                    )
+                )
+            )
+        ),
+        OpCombAssign(function.args[1], MCall("TARGET_PAGE_MASK"), "&"),
+        Call(
+            "tlb_set_page",
+            function.args[0],
+            function.args[1],
+            function.args[1],
+            prot,
+            function.args[-3],
+            MCall("TARGET_PAGE_SIZE")
+        ),
+        Return(Type["true"])
+    )
+
+def fill_decode_opc_body(cputype, function, cpu_env):
+    function.body = body = BodyTree()
+
+    result = Type["int"]("result")
+    body(Declare(OpDeclareAssign(result, 0)))
+
+    ctx = function.args[1]
+    ctx_pc = OpSDeref(ctx, "pc")
+    set_pc_ref = {Type["set_pc"]}
+
+    h = cputype.gen_files["translate.inc.c"]
+
+    def gen_field_read(node, val, bitoffset, bitsize,
+        # cached
+        suffixes = {
+            1: 'ub',
+            2: 'uw',
+            4: 'l',
+            8: 'q'
+        }
+    ):
+        offset = bitoffset // BYTE_BITSIZE
+        env = OpAddr(OpSDeref(function.args[0], "env"))
+
+        cpu_ld = Call(
+            "cpu_ld%s_code" % suffixes[bitsize // BYTE_BITSIZE],
+            env,
+            OpAdd(ctx_pc, offset) if offset else ctx_pc
+        )
+
+        node(Declare(OpDeclareAssign(val, cpu_ld)))
+
+    def decode_opc_epilogue(node, instruction, operands, total_read, comment):
+        operands_to_args = [copy(o) for o in operands]
+        cputype.name_shortener(operands_to_args, comment)
+
+        func = Function(
+            name = instruction.name,
+            body = BodyTree()(
+                Comment(comment),
+                *instruction.semantics()
+            ),
+            args = [ Pointer(Type["DisasContext"])("ctx") ] + operands_to_args,
+            static = True,
+            inline = True
+        )
+        func.extra_references = set_pc_ref
+        h.add_type(func)
+
+        node(Call(func, ctx, *operands))
+
+        if DEBUG_DECODER:
+            node(
+                Call(
+                    "fprintf",
+                    MCall("stderr"),
+                    '\"%s[%s](%s)\\n\"' % (
+                        func.name,
+                        instruction.comment,
+                        ", ".join(["%llx"] * len(operands))
+                    ),
+                    *operands
+                )
+            )
+
+        if instruction.branch:
+            node(
+                OpAssign(
+                    OpSDeref(ctx, "bstate"),
+                    Type["BS_BRANCH"]
+                )
+            )
+
+        node(OpAssign(result, total_read))
+
+    unknown_instruction_case_nodes = [
+        Call("set_pc", ctx_pc),
+        Call("gen_helper_illegal", cpu_env),
+        OpAssign(
+            OpSDeref(ctx, "bstate"),
+            Type["BS_EXCP"]
+        )
+    ]
+
+    ParseTreeCodeBuilder(cputype, body, gen_field_read, decode_opc_epilogue,
+        unknown_instruction_case_nodes
+    )
+
+    body(Return(result))
+
+def fill_disas_set_info_body(cputype, function):
+    function.body = BodyTree()(
+        OpAssign(
+            OpSDeref(function.args[1], "mach"),
+            getattr(Type["bfd_architecture"], cputype.bfd_arch_name)
+        ),
+        OpAssign(
+            OpSDeref(function.args[1], "print_insn"),
+            Type[cputype.print_insn_name]
+        )
+    )
+
+def fill_disas_write_helper_body(function):
+    function.body = BodyTree()(Return(0))
+
+def fill_dump_state_body(cputype, function, reg_vars):
+    function.body = body = BodyTree()
+
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+    env = Pointer(Type[cputype.struct_name])("env")
+
+    out_file = function.args[1]
+    if get_vp("dump_state has cpu_fprintf argument"):
+        fprintf_func = function.args[2]
+    else:
+        fprintf_func = Type["qemu_fprintf"]
+    i = Type["int"]("i")
+
+    body(
+        Declare(
+            OpDeclareAssign(
+                cpu,
+                MCall(cputype.qtn.for_macros, function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                env,
+                OpAddr(OpSDeref(cpu, "env"))
+            )
+        ),
+        Declare(i),
+        NewLine()
+    )
+
+    for r, _, names_array in reg_vars:
+        if r.bank_size:
+            # Print a new line after the last register in the bank even if the
+            # bank_size is not a multiple of 4.
+            if r.bank_size % 4:
+                newline_cond = OpLogOr(
+                    OpEq(i, r.bank_size - 1),
+                    OpEq(OpRem(i, 4), 3)
+                )
+            else:
+                newline_cond = OpEq(OpRem(i, 4), 3)
+
+            body(
+                LoopFor(OpAssign(i, 0), OpLess(i, r.bank_size), OpPreInc(i))(
+                    Call(
+                        fprintf_func,
+                        out_file,
+                        "%s=0x%08x",
+                        OpIndex(names_array, i),
+                        OpIndex(OpSDeref(env, r.name), i)
+                    ),
+                    BranchIf(newline_cond)(
+                        Call(fprintf_func, out_file, "\\n"),
+                        BranchElse()(Call(fprintf_func, out_file, ' '))
+                    )
+                )
+            )
+        else:
+            body(
+                Call(
+                    fprintf_func,
+                    out_file,
+                    r.name + "=0x%08x\\n",
+                    OpSDeref(env, r.name)
+                )
+            )
+
+def fill_env_get_cpu_body(cputype, function):
+    function.body = BodyTree()(
+        Return(
+            MCall(
+                "container_of",
+                function.args[0],
+                Type[cputype.struct_instance_name],
+                Node("env")
+            )
+        )
+    )
+
+def fill_gdb_rw_register_body(cputype, function, comment):
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+    cc = Pointer(Type["CPUClass"])("cc")
+    env = Pointer(Type[cputype.struct_name])("env")
+
+    ret_0 = Return(0)
+
+    function.body = BodyTree()(
+        Comment(comment),
+        Declare(
+            OpDeclareAssign(
+                cpu,
+                MCall(cputype.qtn.for_macros, function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                cc,
+                MCall("CPU_GET_CLASS", function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                env,
+                OpAddr(OpSDeref(cpu, "env"))
+            )
+        ),
+        NewLine(),
+        BranchIf(
+            OpGreater(
+                function.args[2],
+                OpSDeref(cc, "gdb_num_core_regs")
+            )
+        )(ret_0),
+        ret_0
+    )
+
+def fill_gen_intermediate_code_body(cputype, function, cpu_env):
+    function.body = body = BodyTree()
+
+    if get_vp("gen_intermediate_code arg1 is generic"):
+        env = Pointer(Type[cputype.struct_name])("env")
+        body(
+            Declare(
+                OpDeclareAssign(
+                    env,
+                    OpSDeref(function.args[0], "env_ptr")
+                )
+            )
+        )
+    else:
+        env = function.args[0]
+
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+    ctx = Type["DisasContext"]("ctx")
+    ctx_pc = OpSDeref(ctx, "pc")
+    ctx_tb = OpSDeref(ctx, "tb")
+    set_pc = Call("set_pc", ctx_pc)
+    gen_helper_debug = Call("gen_helper_debug", cpu_env)
+    ctx_bstate = OpSDeref(ctx, "bstate")
+    tb = function.args[1]
+
+    body(
+        Declare(
+            OpDeclareAssign(
+                cpu,
+                Call(
+                    (
+                        "env_archcpu" if get_vp("env_archcpu exists") else
+                        cputype.env_get_cpu_name
+                    ),
+                    env
+                )
+            )
+        ),
+        Declare(ctx)
+    )
+
+    if get_vp("gen_intermediate_code arg1 is generic"):
+        cs = function.args[0]
+    else:
+        cs = Pointer(Type["CPUState"])("cs")
+        body(
+            Declare(
+                OpDeclareAssign(
+                    cs,
+                    MCall("CPU", cpu)
+                )
+            )
+        )
+
+    cs_bp = OpAddr(OpSDeref(cs, "breakpoints"))
+    bp = Pointer(Type["CPUBreakpoint"])("bp")
+    pc_start = Type["target_ulong"]("pc_start")
+    done_gen = Label("done_generating")
+    log_target_disas_args = [ cs, pc_start, OpSub(ctx_pc, pc_start) ]
+    if get_vp("log_target_disas has FLAGS argument"):
+        log_target_disas_args.append(0)
+    num_insns = Type["int"]("num_insns")
+    insns = [ num_insns ]
+    if get_vp("gen_intermediate_code has max_insns argument"):
+        max_insns = function.args[-1]
+    else:
+        max_insns = Type["int"]("max_insns")
+        insns.append(max_insns)
+
+    body(
+        Declare(bp),
+        Declare(pc_start),
+        Declare(*insns),
+        NewLine(),
+        OpAssign(pc_start, OpSDeref(tb, "pc")),
+        OpAssign(ctx_pc, pc_start),
+        OpAssign(ctx_tb, tb),
+        OpAssign(
+            ctx_bstate,
+            Type["BS_NONE"]
+        ),
+        OpAssign(num_insns, 0)
+    )
+
+    if not get_vp("gen_intermediate_code has max_insns argument"):
+        body(
+            OpAssign(
+                max_insns,
+                OpAnd(
+                    (
+                        Call("tb_cflags", tb) if get_vp("tb_cflags exists")
+                        else
+                        OpSDeref(tb, "cflags")
+                    ),
+                    MCall("CF_COUNT_MASK")
+                )
+            ),
+            BranchIf(OpEq(max_insns, 0))(
+                OpAssign(max_insns, MCall("CF_COUNT_MASK"))
+            ),
+            BranchIf(OpGreater(max_insns, MCall("TCG_MAX_INSNS")))(
+                OpAssign(max_insns, MCall("TCG_MAX_INSNS"))
+            )
+        )
+
+    tcg_gen_exit_tb_args = [ 0 ]
+    if get_vp("pass tb and index to tcg_gen_exit_tb separately"):
+        tcg_gen_exit_tb_args.insert(0, MCall("NULL"))
+
+    body(
+        NewLine(),
+        Call("gen_tb_start", tb),
+        LoopDoWhile(
+            OpLogAnd(
+                OpLogNot(Call("tcg_op_buf_full")),
+                OpLogAnd(
+                    OpLogNot(OpSDeref(cs, "singlestep_enabled")),
+                    OpLogAnd(
+                        OpLogNot(
+                            Header["exec/exec-all.h"].global_variables[
+                                "singlestep"
+                            ]
+                        ),
+                        OpLogAnd(
+                            OpEq(ctx_bstate, Type["BS_NONE"]),
+                            OpLess(num_insns, max_insns)
+                        )
+                    )
+                )
+            )
+        )(
+            Call("tcg_gen_insn_start", ctx_pc),
+            OpCombAssign(num_insns, 1, "+"),
+            BranchIf(
+                MCall(
+                    "unlikely",
+                    OpLogNot(MCall("QTAILQ_EMPTY", cs_bp))
+                )
+            )(
+                MacroBranch(
+                    MCall("QTAILQ_FOREACH", bp, cs_bp, Node("entry"))
+                )(BranchIf(OpEq(ctx_pc, OpSDeref(bp, "pc")))(
+                    set_pc,
+                    gen_helper_debug,
+                    OpAssign(
+                        ctx_bstate,
+                        Type["BS_EXCP"]
+                    ),
+                    # Note, there may be a grammatical error with
+                    # "in order to for it" but to preserve the identity with
+                    # the Qemu-master branch the comment is written as is.
+                    Comment("The address covered by the breakpoint must be"
+                        " included in [tb->pc, tb->pc + tb->size) in order"
+                        " to for it to be properly cleared -- thus we"
+                        " increment the PC here so that the logic setting"
+                        " tb->size below does the right thing."
+                    ),
+                    OpCombAssign(
+                        ctx_pc,
+# See https://lists.gnu.org/archive/html/qemu-devel/2015-10/msg03668.html
+                        cputype.min_instr_len // BYTE_BITSIZE,
+                        "+"
+                    ),
+                    Goto(done_gen)
+                ))
+            ),
+            OpCombAssign(
+                ctx_pc,
+                Call("decode_opc", cpu, OpAddr(ctx)),
+                "+"
+            ),
+            BranchIf(
+                OpEq(
+                    OpAnd(
+                        ctx_pc,
+                        OpSub(
+                            MCall("TARGET_PAGE_SIZE"),
+                            1,
+                            parenthesis = True
+                        ),
+                    ),
+                    0
+                )
+            )(Break()),
+        ),
+        BranchIf(OpSDeref(cs, "singlestep_enabled"))(
+            BranchIf(
+                OpLogOr(
+                    OpEq(ctx_bstate, Type["BS_NONE"]),
+                    OpEq(ctx_bstate, Type["BS_STOP"])
+                )
+            )(set_pc),
+            gen_helper_debug,
+            BranchElse()(
+                BranchSwitch(OpSDeref(ctx, "bstate"),
+                    cases = [
+                        SwitchCase(Type["BS_STOP"], add_break = False),
+                        SwitchCase(Type["BS_NONE"])(set_pc),
+                        SwitchCase(Type["BS_EXCP"], add_break = False),
+                        SwitchCase(Type["BS_BRANCH"], add_break = False)
+                    ]
+                ),
+                Call(
+                    "tcg_gen_exit_tb",
+                    *tcg_gen_exit_tb_args
+                )
+            )
+        ),
+        done_gen,
+        Call("gen_tb_end", tb, num_insns),
+        OpAssign(
+            OpSDeref(tb, "size"),
+            OpSub(ctx_pc, pc_start)
+        ),
+        OpAssign(
+            OpSDeref(tb, "icount"),
+            num_insns
+        ),
+        # Disas
+        Ifdef("DEBUG_DISAS")(
+            BranchIf(
+                OpLogAnd(
+                    Call("qemu_loglevel_mask", MCall("CPU_LOG_TB_IN_ASM")),
+                    Call("qemu_log_in_addr_range", pc_start)
+                )
+            )(
+                Call("qemu_log_lock"),
+                Call(
+                    "qemu_log",
+                    "IN: %s\\n",
+                    Call("lookup_symbol", pc_start)
+                ),
+                Call("log_target_disas", *log_target_disas_args),
+                Call("qemu_log", "\\n"),
+                Call("qemu_log_unlock")
+            )
+        )
+    )
+
+def fill_get_phys_page_debug_body(function):
+    function.body = BodyTree()(Return(function.args[1]))
+
+def fill_handle_mmu_fault_body(function):
+    prot = Type["int"]("prot")
+
+    function.body = BodyTree()(
+        Declare(
+            OpDeclareAssign(
+                prot,
+                OpOr(
+                    MCall("PAGE_READ"),
+                    OpOr(
+                        MCall("PAGE_WRITE"),
+                        MCall("PAGE_EXEC")
+                    )
+                )
+            )
+        ),
+        OpCombAssign(function.args[1], MCall("TARGET_PAGE_MASK"), "&"),
+        Call(
+            "tlb_set_page",
+            function.args[0],
+            function.args[1],
+            function.args[1],
+            prot,
+            function.args[-1],
+            MCall("TARGET_PAGE_SIZE")
+        ),
+        Return(0)
+    )
+
+def fill_has_work_body(function):
+    function.body = BodyTree()(
+        Return(
+            OpAnd(
+                OpSDeref(function.args[0], "interrupt_request"),
+                MCall("CPU_INTERRUPT_HARD")
+            )
+        )
+    )
+
+def fill_helper_debug_body(function):
+    function.body = BodyTree()(
+        Call(
+            "raise_exception",
+            function.args[0],
+            MCall("EXCP_DEBUG")
+        )
+    )
+
+def fill_helper_illegal_body(function):
+    function.body = BodyTree()(
+        Call(
+            "raise_exception",
+            function.args[0],
+            Type["EXCP_ILLEGAL"]
+        )
+    )
+
+def fill_initfn_body(cputype, function):
+    function.body = body = BodyTree()
+
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+    cs = Pointer(Type["CPUState"])("cs")
+    for_macros = cputype.qtn.for_macros
+
+    if get_vp("cpu_set_cpustate_pointers exists"):
+        body(
+            Declare(
+                OpDeclareAssign(
+                    cpu,
+                    MCall(for_macros, function.args[0])
+                )
+            ),
+            NewLine(),
+            Call(
+                "cpu_set_cpustate_pointers",
+                cpu
+            )
+        )
+    elif get_vp("Generic call to tcg_initialize"):
+        body(
+            Declare(
+                OpDeclareAssign(
+                    cs,
+                    MCall("CPU", function.args[0])
+                )
+            ),
+            Declare(
+                OpDeclareAssign(
+                    cpu,
+                    MCall(for_macros, function.args[0])
+                )
+            ),
+            NewLine(),
+            OpAssign(
+                OpSDeref(cs, "env_ptr"),
+                OpAddr(OpSDeref(cpu, "env"))
+            )
+        )
+    else:
+        inited = Type["int"]("inited", static = True)
+
+        body(
+            Declare(
+                OpDeclareAssign(
+                    cs,
+                    MCall("CPU", function.args[0])
+                )
+            ),
+            Declare(
+                OpDeclareAssign(
+                    cpu,
+                    MCall(for_macros, function.args[0])
+                )
+            ),
+            Declare(inited),
+            NewLine(),
+            OpAssign(
+                OpSDeref(cs, "env_ptr"),
+                OpAddr(OpSDeref(cpu, "env"))
+            ),
+            BranchIf(
+                OpLogAnd(
+                    Call("tcg_enabled"),
+                    OpLogNot(inited)
+                )
+            )(
+                OpAssign(inited, 1),
+                Call(cputype.tcg_init_name)
+            )
+        )
+
+def fill_print_insn_body(cputype, function):
+    function.body = body = BodyTree()
+
+    status = Type["int"]("status")
+    buffer_ = Type["bfd_byte"]("buffer",
+        # maximum size of one time reading
+        array_size = SUPPORTED_READ_BITSIZES[0] // BYTE_BITSIZE
+    )
+    length = Type["int"]("length")
+    stream = Pointer(Type["void"])("stream")
+    fpr = Type["fprintf_function"]("fpr")
+
+    body(
+        Declare(status),
+        Declare(buffer_),
+        Declare(
+            OpDeclareAssign(
+                length,
+                0
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                stream,
+                OpSDeref(function.args[1], "stream")
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                fpr,
+                OpSDeref(function.args[1], "fprintf_func")
+            )
+        ),
+        NewLine()
+    )
+
+    fail_lbl = Label("fail")
+
+    def gen_disas_opcode_read(node, val, bitoffset, bitsize):
+        offset = bitoffset // BYTE_BITSIZE
+        size = bitsize // BYTE_BITSIZE
+        addr = function.args[0]
+        info = function.args[1]
+
+        node(
+            OpAssign(
+                status,
+                Call(
+                    OpSDeref(info, "read_memory_func"),
+                    OpAdd(addr, offset) if offset else addr,
+                    buffer_,
+                    size,
+                    info
+                )
+            ),
+            BranchIf(status)(Goto(fail_lbl))
+        )
+
+        if size == 1:
+            bfd_get = OpIndex(buffer_, 0)
+        else:
+            bfd_get = Call(
+                "bfd_get%s%d" % (
+                    'b' if cputype.target_bigendian else 'l',
+                    bitsize
+                ),
+                buffer_
+            )
+            # shift result due to implementation of bfd_getb16
+            if cputype.target_bigendian and bitsize == 16:
+                bfd_get = OpRShift(bfd_get, 16)
+
+        node(Declare(OpDeclareAssign(val, bfd_get)))
+
+    def print_ins_epilogue(node, instruction, operands, total_read, _):
+        operands_dict = { o.name: o for o in operands }
+
+        format_line = ''
+        call_args = []
+        name_to_format = cputype.name_to_format
+        # TODO: `disas_format`'s format is not trivial, add a doc to
+        #       `Instruction` class
+        for m in re_disas_format.finditer(instruction.disas_format):
+            gr = m.group(1)
+            try:
+                fmt, adapter = name_to_format[gr]
+            except KeyError:
+                format_line += m.group(0)
+            else:
+                variables = []
+                for i in gr.split(','):
+                    name = i.strip().split('$')[0]
+                    variables.append(operands_dict.get(name, CINT(name)))
+
+                if fmt is None:
+                    if format_line:
+                        node(
+                            Call(fpr, stream, format_line, *call_args)
+                        )
+                        format_line = ''
+                        call_args = []
+                    node(Call(adapter, fpr, stream, *variables))
+                    continue
+                else:
+                    format_line += fmt
+
+                if adapter is None:
+                    for var in variables:
+                        if isinstance(var, Variable):
+                            call_args.append(OpCast("unsigned", var))
+                        else:
+                            call_args.append(var)
+                else:
+                    call_args.append(Call(adapter, *variables))
+
+        if format_line:
+            node(Call(fpr, stream, format_line, *call_args))
+
+        node(OpAssign(length, total_read))
+
+    unknown_instruction_case_nodes = [
+        Call("fprintf", MCall("stderr"), "Unknown instruction\\n"),
+        Call("abort")
+    ]
+
+    ParseTreeCodeBuilder(cputype, body, gen_disas_opcode_read,
+        print_ins_epilogue, unknown_instruction_case_nodes,
+        add_break = False
+    )
+
+    body(
+        Return(length),
+        fail_lbl,
+        Call(
+            OpSDeref(function.args[1], "memory_error_func"),
+            status,
+            function.args[0],
+            function.args[1]
+        ),
+        Return(-1)
+    )
+
+def fill_raise_exception_body(cputype, function):
+    cs = Pointer(Type["CPUState"])("cs")
+
+    function.body = BodyTree()(
+        Declare(
+            OpDeclareAssign(
+                cs,
+                (
+                    Call("env_cpu", function.args[0]) if get_vp(
+                        "env_cpu exists"
+                    ) else
+                    MCall(
+                        "CPU",
+                        Call(cputype.env_get_cpu_name, function.args[0])
+                    )
+                )
+            )
+        ),
+        NewLine(),
+        OpAssign(
+            OpSDeref(cs, "exception_index"),
+            function.args[1]
+        ),
+        Call("cpu_loop_exit", cs)
+    )
+
+def fill_realizefn_body(cputype, function):
+    cs = Pointer(Type["CPUState"])("cs")
+    cc = Pointer(Type[cputype.struct_class_name])("cc")
+    err = Pointer(Type["Error"])("local_err")
+    null = MCall("NULL")
+
+    function.body = BodyTree()(
+        Declare(
+            OpDeclareAssign(
+                cs,
+                MCall("CPU", function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                cc,
+                MCall(cputype.get_class_macro, function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                err,
+                null
+            )
+        ),
+        NewLine(),
+        Call("cpu_exec_realizefn", cs, OpAddr(err)),
+        BranchIf(OpNEq(err, null))(
+            Call("error_propagate", function.args[1], err),
+            Return()
+        ),
+        Call("qemu_init_vcpu", cs),
+        Call("cpu_reset", cs),
+        Call(
+            OpSDeref(cc, "parent_realize"),
+            function.args[0],
+            function.args[1]
+        )
+    )
+
+def fill_reset_body(cputype, function):
+    function.body = body = BodyTree()
+
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+    cc = Pointer(Type[cputype.struct_class_name])("cc")
+    env = Pointer(Type[cputype.struct_name])("env")
+
+    body(
+        Declare(
+            OpDeclareAssign(
+                cpu,
+                MCall(cputype.qtn.for_macros, function.args[0])
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                cc,
+                MCall(cputype.get_class_macro, cpu)
+            )
+        ),
+        Declare(
+            OpDeclareAssign(
+                env,
+                OpAddr(OpSDeref(cpu, "env"))
+            )
+        ),
+        NewLine(),
+        Call(
+            OpSDeref(cc, "parent_reset"),
+            function.args[0]
+        )
+    )
+
+    if get_vp("move tlb_flush to cpu_common_reset"):
+        body(
+            Call(
+                "memset",
+                env,
+                0,
+                MCall(
+                    "offsetof",
+                    Type[cputype.struct_name],
+                    Node("end_reset_fields")
+                )
+            ),
+            OpAssign(
+                OpSDeref(env, cputype.pc_register),
+                0
+            )
+        )
+    else:
+        body(
+            Call(
+                "memset",
+                env,
+                0,
+                OpSizeOf(
+                    Type[cputype.struct_name]
+                )
+            ),
+            OpAssign(
+                OpSDeref(env, cputype.pc_register),
+                0
+            ),
+            Call(
+                "tlb_flush",
+                function.args[0],
+                1
+            )
+        )
+
+def fill_restore_state_to_opc_body(cputype, function):
+    function.body = BodyTree()(
+        OpAssign(
+            OpSDeref(function.args[0], cputype.pc_register),
+            OpIndex(function.args[2], 0)
+        )
+    )
+
+def fill_set_pc_body(cputype, function):
+    cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
+
+    function.body = BodyTree()(
+        Declare(
+            OpDeclareAssign(
+                cpu,
+                MCall(cputype.qtn.for_macros, function.args[0])
+            )
+        ),
+        NewLine(),
+        OpAssign(
+            OpSDeref(OpSDeref(cpu, "env"), cputype.pc_register),
+            function.args[1]
+        )
+    )
+
+def fill_set_pc_inc_body(function, pc):
+    function.body = BodyTree()(OpAssign(pc, function.args[0]))
+
+def fill_tcg_init_body(cputype, function, reg_vars, cpu_env):
+    function.body = body = BodyTree()
+
+    i = Type["int"]("i")
+
+    if get_vp("Generic call to tcg_initialize"):
+        body(
+            Declare(i),
+            NewLine()
+        )
+    else:
+        done_init = Type["int"]("done_init", static = True)
+        body(
+            Declare(done_init),
+            Declare(i),
+            NewLine(),
+            BranchIf(done_init)(
+                Return()
+            )
+        )
+
+    if get_vp("Init cpu_env in arch"):
+        body(
+            OpAssign(
+                cpu_env,
+                Call("tcg_global_reg_new_ptr", MCall("TCG_AREG0"), "env")
+            ),
+            OpAssign(
+                OpSDeref(
+                    Header["tcg.h"].global_variables["tcg_ctx"],
+                    "tcg_env"
+                ),
+                cpu_env
+            )
+        )
+
+    cpu_arch_state = Type[cputype.struct_name]
+    for r, var, names_array in reg_vars:
+        if r.bank_size:
+            parent_node = LoopFor(
+                OpAssign(i, 0), OpLess(i, r.bank_size), OpPreInc(i)
+            )
+            body(parent_node)
+            v = OpIndex(var, i)
+            state_field = OpIndex(Node(r.name), i)
+            string_name = OpIndex(names_array, i)
+        else:
+            parent_node = body
+            v = var
+            state_field = Node(r.name)
+            string_name = r.name
+
+        parent_node(
+            OpAssign(
+                v,
+                Call(
+                    "tcg_global_mem_new_i" + str(r.field_bitsize),
+                    cpu_env,
+                    MCall("offsetof", cpu_arch_state, state_field),
+                    string_name
+                )
+            )
+        )
+
+    if not get_vp("Generic call to tcg_initialize"):
+        body(OpAssign(done_init, 1))
+
+def fill_tlb_fill_body(cputype, function):
+    function.body = body = BodyTree()
+
+    fn_name = cputype.gen_func_name
+
+    if get_vp("CPUClass has tlb_fill field"):
+        body(
+            Call(
+                fn_name("tlb_fill"),
+                function.args[0],
+                function.args[1],
+                function.args[2],
+                function.args[3],
+                function.args[4],
+                Type["false"],
+                function.args[5]
+            )
+        )
+    else:
+        ret = Type["int"]("ret")
+
+        body(
+            Declare(
+                OpDeclareAssign(
+                    ret,
+                    Call(
+                        fn_name("handle_mmu_fault"),
+                        *function.args[:-1]
+                    )
+                )
+            ),
+            BranchIf(MCall("unlikely", ret))(
+                Call(
+                    "cpu_loop_exit_restore",
+                    function.args[0],
+                    function.args[-1]
+                )
+            )
+        )

--- a/qemu/cpu/constants.py
+++ b/qemu/cpu/constants.py
@@ -1,0 +1,14 @@
+__all__ = [
+    "BYTE_BITSIZE"
+  , "OPERAND_MAX_BITSIZE"
+  , "SUPPORTED_READ_BITSIZES"
+]
+
+
+# Note, for code readability only
+BYTE_BITSIZE = 8
+
+OPERAND_MAX_BITSIZE = 64
+
+# Note, descending order is needed to correctly calculate the size of readings
+SUPPORTED_READ_BITSIZES = (64, 32, 16, 8)

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -1,0 +1,1281 @@
+__all__ = [
+    "CPUType"
+]
+
+from ..makefile_patching import (
+    patch_makefile,
+)
+from ..qom import (
+    QOMCPU,
+)
+from ..qom_desc import (
+    describable,
+)
+from ..version import (
+    get_vp,
+)
+from .constants import (
+    BYTE_BITSIZE,
+    SUPPORTED_READ_BITSIZES,
+)
+from .info import (
+    CPUInfo,
+)
+from .instruction import (
+    InstructionTreeNode,
+    build_instruction_tree,
+)
+from codecs import (
+    open,
+)
+from collections import (
+    OrderedDict,
+    defaultdict,
+)
+from common import (
+    execfile,
+    mlget as _,
+)
+from itertools import (
+    count,
+)
+from os import (
+    makedirs,
+    remove,
+    rename,
+)
+from os.path import (
+    basename,
+    isdir,
+    isfile,
+    join,
+    sep,
+    splitext,
+)
+from re import (
+    compile,
+)
+from source import (
+    Enumeration,
+    Function,
+    Header,
+    Initializer,
+    Macro,
+    Pointer,
+    Source,
+    Structure,
+    Type,
+    TypeAlias,
+)
+from traceback import (
+    print_exc,
+)
+
+
+spec_and_len2typename = {
+    ('d', 'i'): {
+        None: "int",
+        'hh': "signed char",
+        'h': "short int",
+        'l': "long int",
+        'll': "long long int",
+        'j': "intmax_t",
+        'z': "size_t",
+        't': "ptrdiff_t"
+    },
+    ('u', 'o', 'x', 'X'): {
+        None: "unsigned", # "unsigned int"
+        'hh': "unsigned char",
+        'h': "unsigned short int",
+        'l': "unsigned long int",
+        'll': "unsigned long long int",
+        'j': "uintmax_t",
+        'z': "size_t",
+        't': "ptrdiff_t"
+    },
+    ('f', 'F', 'e', 'E', 'g', 'G', 'a', 'A'): {
+        None: "double",
+        'L': "long double"
+    },
+    ('c',): {
+        None: "char", # "int"
+        'l': "wint_t"
+    },
+    ('s',): {
+        None: "const char*", # "char*"
+        'l': "wchar_t*"
+    },
+    ('p',): {
+        None: "void*"
+    },
+    ('n',): {
+        None: "int*",
+        'hh': "signed char*",
+        'h': "short int*",
+        'l': "long int*",
+        'll': "long long int*",
+        'j': "intmax_t*",
+        'z': 'size_t*',
+        't': "ptrdiff_t*"
+    }
+}
+
+
+re_format_specifier = compile("(?<!%)(?:%%)*(%(?:"
+    "(?:[-+ #0]{0,5})"         # flags
+    "(?:\d+|\*)?"              # width
+    "(?:\.(?:\d+|\*))?"        # precision
+    "(hh|h|l|ll|j|z|t|L)?"     # length
+    "([diuoxXfFeEgGaAcspn])))" # specifier
+)
+
+
+def fill_tree_reading_seq(node, read_bitsize, already_read = 0):
+    ins = node.instruction
+    limit_read = node.limit_read
+    del node.limit_read
+
+    if ins:
+        node.reading_seq = calc_node_reading_seq(ins.bitsize, already_read,
+            limit_read
+        )
+    else:
+        bitoffset, bitsize = node.interval
+
+        reading_seq = calc_node_reading_seq(bitoffset + bitsize, already_read,
+            limit_read
+        )
+
+        if reading_seq:
+            node.reading_seq = reading_seq
+            already_read = reading_seq[-1][0] + reading_seq[-1][1]
+
+        for subnode in node.subtree.values():
+            fill_tree_reading_seq(subnode, read_bitsize, already_read)
+
+
+def calc_node_reading_seq(need_read, already_read, limit_read):
+    if need_read <= already_read:
+        return []
+
+    result = []
+
+    for r_bitsize in SUPPORTED_READ_BITSIZES:
+        while (    need_read > already_read
+               and already_read + r_bitsize <= limit_read
+        ):
+            result.append((already_read, r_bitsize))
+            already_read += r_bitsize
+
+    return result
+
+
+def add_global_array_with_reg_names(reg, arr_name, f):
+    names_array = Pointer(Type["const char"])(arr_name,
+        initializer = Initializer(
+            # TODO: `Initializer` should support iterables as `code` for arrays
+            code = '{\n    "%s"\n}' % (
+                '",\n    "'.join(reg.reg_names)
+            )
+        ),
+        static = True,
+        array_size = reg.bank_size
+    )
+    f.add_global_variable(names_array)
+    return names_array
+
+
+@describable
+class CPUType(QOMCPU):
+    __attribute_info__ = OrderedDict([
+        ("target_bigendian", {
+            "short": _("Target is big-endian"),
+            "input": bool
+        }),
+        ("target_long_bits", {
+            "short": _("Target long size in bits"),
+            "input": int
+        }),
+        ("target_page_bits", {
+            "short": _("Log2 of target page size in bytes"),
+            "input": int
+        }),
+        ("target_phys_addr_space_bits", {
+            "short": _("Log2 of target physical address space size in bytes"),
+            "input": int
+        }),
+        ("target_virt_addr_space_bits", {
+            "short": _("Log2 of target virtual address space size in bytes"),
+            "input": int
+        }),
+        ("nb_mmu_modes", { "short": _("Number of MMU modes"), "input": int }),
+        ("info_path", {
+            "short": _("Path to file with CPU information"),
+            "input": str
+        })
+    ])
+
+    def __init__(self, name, directory,
+        target_bigendian = False,
+        target_long_bits = 32,
+        target_page_bits = 12,
+        target_phys_addr_space_bits = 32,
+        target_virt_addr_space_bits = 32,
+        nb_mmu_modes = 1,
+        info_path = None
+    ):
+        """ CPU description.
+
+    :param name:
+        name of CPU
+
+    :param directory:
+        name of Target architecture
+        """
+
+        super(CPUType, self).__init__(name, directory)
+
+        self.target_bigendian = target_bigendian
+
+        self.attributes = {
+            "TARGET_LONG_BITS": target_long_bits,
+            "TARGET_PAGE_BITS": target_page_bits,
+            "TARGET_PHYS_ADDR_SPACE_BITS": target_phys_addr_space_bits,
+            "TARGET_VIRT_ADDR_SPACE_BITS": target_virt_addr_space_bits,
+            "NB_MMU_MODES": nb_mmu_modes
+        }
+
+        self.info_path = info_path
+
+    def co_gen(self, src,
+        with_chunk_graph = False,
+        with_debug_comments = False,
+        **_
+    ):
+        import cpu_imports
+        loaded = dict(cpu_imports.__dict__)
+        try:
+            execfile(self.info_path, loaded)
+        except:
+            print_exc()
+            raise RuntimeError(
+                "Cannot load CPU info from '%s'" % self.info_path
+            )
+
+        for v in loaded.values():
+            if isinstance(v, CPUInfo):
+                info = v
+                break
+        else:
+            raise RuntimeError(
+                "Script '%s' does not define a CPU info" % self.info_path
+            )
+
+        self.registers = registers = info.registers
+        self.pc_register = info.pc_register
+
+        for reg in registers:
+            self.add_state_field_h("uint%d_t" % (reg.field_bitsize),
+                reg.name,
+                num = reg.bank_size,
+                save = True
+            )
+
+        self.name_to_format = info.name_to_format
+        self.instructions = instructions = info.instructions
+        self.read_bitsize = read_bitsize = info.read_size * BYTE_BITSIZE
+        self.reg_types = info.reg_types
+        self.name_shortener = info.name_shortener
+
+        if read_bitsize not in SUPPORTED_READ_BITSIZES:
+            raise RuntimeError(
+                "Valid `read_size` values are %s bytes" % (", ".join(
+                    i // BYTE_BITSIZE for i in SUPPORTED_READ_BITSIZES
+                ))
+            )
+
+        existing_instruction_names = defaultdict(lambda : count(0))
+        for i in instructions:
+            i.name = "%s_%d" % (
+                i.mnemonic, next(existing_instruction_names[i.mnemonic])
+            )
+            i.read_bitsize = read_bitsize
+
+        bitsizes = [i.bitsize for i in instructions]
+        try:
+            min_bitsize = min(bitsizes)
+            max_bitsize = max(bitsizes)
+        except ValueError:
+            min_bitsize = 0
+            max_bitsize = 0
+        is_fixed_bitsize = min_bitsize == max_bitsize
+
+        self.min_instr_len = min_bitsize
+
+        print("{arch} is a {endianess}-endian {is_fixed} instruction length"
+            " architecture with {bitsize_info}".format(
+            arch = self.target_name.upper(),
+            endianess = "big" if self.target_bigendian else "little",
+            is_fixed = "fixed" if is_fixed_bitsize else "variable",
+            bitsize_info = (
+                "length = %d bits" % min_bitsize if is_fixed_bitsize else
+                "minimum length = %d bits and maximum length = %d bits" % (
+                    min_bitsize, max_bitsize
+                )
+            )
+        ))
+
+        self.reg_types()
+
+        yield True
+
+        yield self._co_gen_target_code(src)
+
+        for f in self.gen_files.values():
+            path = join(src, f.path)
+            with open(path, mode = "wb", encoding = "utf-8") as f_writer:
+                sf = f.generate(inherit_references = isinstance(f, Header))
+
+                yield True
+
+                if with_chunk_graph:
+                    yield True
+                    sf.gen_chunks_gv_file(path + ".chunks.gv")
+
+                yield True
+
+                sf.generate(f_writer, gen_debug_comments = with_debug_comments)
+
+        path = self.gen_files["translate.inc.c"].path
+        old_path = join(src, path)
+        new_path = join(src, path[:-1] + "i3s.c")
+
+        if isfile(new_path):
+            remove(new_path)
+
+        rename(old_path, new_path)
+
+        if with_chunk_graph:
+            new_chunk_path = new_path + ".chunks.gv"
+
+            if isfile(new_chunk_path):
+                remove(new_chunk_path)
+
+            rename(old_path + ".chunks.gv", new_chunk_path)
+
+        yield True
+
+        with open(join(src, old_path), "w") as f:
+            f.write("""
+/* autogenerated temporary translate.inc.c */
+#ifndef INCLUDE_TEMPORARY_TRANSLATE_INC_C
+#define INCLUDE_TEMPORARY_TRANSLATE_INC_C
+
+#define tcg TCGv
+#include "translate.inc.i3s.c"
+
+#endif /* INCLUDE_TEMPORARY_TRANSLATE_INC_C */
+""")
+
+    def _co_gen_target_code(self, src):
+        if self.instructions:
+            read_bitsize = self.read_bitsize
+            node = InstructionTreeNode()
+            build_instruction_tree(node, self.instructions, read_bitsize)
+            fill_tree_reading_seq(node, read_bitsize)
+            self.instruction_tree_root = node
+        else:
+            self.instruction_tree_root = None
+
+        yield True
+
+        target_folder = get_vp("target folder") + self.target_name + sep
+        abs_target_folder = join(src, target_folder)
+
+        if not isdir(abs_target_folder):
+            makedirs(abs_target_folder)
+
+        yield True
+
+        create_default_config(src, self.target_name)
+
+        yield True
+
+        patch_configure(src, self.target_bigendian, self.target_name)
+
+        yield True
+
+        patch_arch_init_header(src, self.target_name)
+
+        yield True
+
+        patch_arch_init_source(src, self.target_name)
+
+        yield True
+
+        patch_disas_header(src, self.print_insn_name, self.bfd_arch_name)
+
+        yield True
+
+        patch_poison_header(src, self.target_arch, self.config_arch_dis)
+
+        yield True
+
+        self.gen_files = OrderedDict()
+        file_list = ["cpu.h", "translate.inc.c", "cpu.c", "helper.c",
+            "machine.c", "translate.c"
+        ]
+        if get_vp("cpu-param header exists"):
+            file_list = ["cpu-param.h"] + file_list
+        for file_name in file_list:
+            path = join(target_folder, file_name)
+            if file_name[-1] == "h" or file_name.find(".inc.c") != -1:
+                file_ = Header(path)
+            else:
+                file_ = Source(path)
+            self.gen_files[file_name] = file_
+
+            name = file_name.replace(".", "_").replace("-", "_")
+            getattr(self, "_gen_" + name)(file_)
+
+            yield True
+
+        self._gen_target_makefile(join(abs_target_folder, "Makefile.objs"))
+
+        yield True
+
+        self._gen_helper_h(join(abs_target_folder, "helper.h"))
+
+        yield True
+
+        abs_disas_folder = join(src, "disas")
+        disas_name = self.target_name + ".c"
+        disas = Source(join(abs_disas_folder, disas_name))
+        self.gen_files[disas_name] = disas
+
+        yield True
+
+        patch_makefile(
+            join(abs_disas_folder, "Makefile.objs"),
+            self.target_name + ".o",
+            "common-obj",
+            "$(" + self.config_arch_dis + ")"
+        )
+
+        yield True
+
+        self._gen_disas(disas)
+
+    def _gen_cpu_param_h(self, h):
+        for name, value in self.attributes.items():
+            m = Macro(name, text = value)
+            h.add_type(m)
+
+    def _gen_cpu_h(self, h):
+        fn_name = self.gen_func_name
+
+        # "cpu.h" header does not require anything from "cpu-all.h" header.
+        # "exec.c" source file include "cpu.h" header and require type
+        # "TARGET_PAGE_SIZE".
+        # Only "cpu.h" header can satisfy the dependency.
+        exec_c = Source("exec.c", locked = True)
+        exec_c.add_reference(Type["TARGET_PAGE_SIZE"])
+        exec_c.add_inclusion(h)
+
+        if not get_vp("cpu-param header exists"):
+            for name, value in self.attributes.items():
+                m = Macro(name, text = value)
+                h.add_type(m)
+
+            Header["exec/cpu-defs.h"].add_reference(Type["TARGET_LONG_BITS"])
+
+        cpu_arch_state = self.gen_state()
+        h.add_type(cpu_arch_state)
+
+        arch_cpu_fields = [
+            Type["CPUState"]("parent_obj"),
+            cpu_arch_state("env")
+        ]
+        if get_vp("CPUNegativeOffsetState exists"):
+            arch_cpu_fields.insert(1, Type["CPUNegativeOffsetState"]("neg"))
+        arch_cpu = Structure(self.struct_instance_name, *arch_cpu_fields)
+        h.add_type(arch_cpu)
+
+        if get_vp("typedef ArchCPU"):
+            arch = TypeAlias(arch_cpu, "ArchCPU")
+            h.add_type(arch)
+            Header["exec/cpu-all.h"].add_reference(arch)
+
+        if get_vp("typedef CPUArchState"):
+            arch_state = TypeAlias(cpu_arch_state, "CPUArchState")
+        else:
+            arch_state = Macro("CPUArchState",
+                text = "struct " + cpu_arch_state.c_name
+            )
+        h.add_type(arch_state)
+        Header["tcg.h"].add_reference(arch_state)
+        Header["exec/cpu-all.h"].add_references([
+            arch_state,
+            Type["TARGET_LONG_SIZE"]
+        ])
+        Header["exec/exec-all.h"].add_reference(arch_state)
+
+        h.add_global_variable(Type["VMStateDescription"](
+            "vmstate_" + self.qtn.for_id_name,
+            const = True
+        ))
+
+        if not get_vp("env_archcpu exists"):
+            env_get_cpu = Function(
+                name = self.env_get_cpu_name,
+                ret_type = Pointer(arch_cpu),
+                args = [ Pointer(cpu_arch_state)("env") ],
+                static = True,
+                inline = True
+            )
+            h.add_type(env_get_cpu)
+
+        h.add_type(Enumeration([("EXCP_ILLEGAL", 1)]))
+
+        if get_vp("CPUClass has tlb_fill field"):
+            h.add_type(
+                Type["CPUClass"].tlb_fill.gen_callback(fn_name("tlb_fill"))
+            )
+        else:
+            h.add_type(
+                Function(
+                    name = fn_name("handle_mmu_fault"),
+                    ret_type = Type["int"],
+                    args = [
+                        Pointer(Type["CPUState"])("cs"),
+                        Type["vaddr"]("address")
+                    ] +
+                    (
+                        [ Type["int"]("size") ] if get_vp(
+                            "tlb_fill has SIZE argument"
+                        )
+                        else
+                        []
+                    ) +
+                    [
+                        Type["int"]("rw"),
+                        Type["int"]("mmu_idx")
+                    ]
+                )
+            )
+
+        if not get_vp("env_cpu exists"):
+            h.add_type(
+                Macro("ENV_GET_CPU",
+                    args = [ "e" ],
+                    text = "CPU(%s(e))" % env_get_cpu.c_name
+                )
+            )
+
+        if not get_vp("ENV_OFFSET is generic"):
+            h.add_type(
+                Macro("ENV_OFFSET",
+                    text = "offsetof(%s, env)" % arch_cpu.c_name
+                )
+            )
+
+        cpu_mmu_index = Function(
+            name = "cpu_mmu_index",
+            ret_type = Type["int"],
+            args = [
+                Pointer(cpu_arch_state)("env"),
+                Type["bool"]("ifetch")
+            ],
+            static = True,
+            inline = True
+        )
+        h.add_type(cpu_mmu_index)
+
+        get_tb_cpu_state = Function(
+            name = "cpu_get_tb_cpu_state",
+            args = [
+                Pointer(cpu_arch_state)("env"),
+                Pointer(Type["target_ulong"])("pc"),
+                Pointer(Type["target_ulong"])("cs_base"),
+                Pointer(Type["uint32_t"])("flags")
+            ],
+            static = True,
+            inline = True
+        )
+        h.add_type(get_tb_cpu_state)
+
+        type_arch_cpu = Macro(self.qtn.type_macro,
+            text = '"%s"' % self.qtn.name
+        )
+        h.add_type(type_arch_cpu)
+
+        cpu_class = Structure(self.struct_class_name,
+            Type["CPUClass"]("parent_class"),
+            Type["DeviceRealize"]("parent_realize"),
+            Function(
+                args = [ Pointer(Type["CPUState"])("cpu") ]
+            )("parent_reset")
+        )
+        h.add_type(cpu_class)
+
+        class_check = Macro(self.class_macro,
+            args = [ "klass" ],
+            text = "OBJECT_CLASS_CHECK(%s, (klass), %s)" % (
+                cpu_class.c_name,
+                type_arch_cpu.c_name
+            )
+        )
+        class_check.extra_references = {type_arch_cpu}
+        h.add_type(class_check)
+
+        cpu = Macro(self.qtn.for_macros,
+            args = [ "obj" ],
+            text = "OBJECT_CHECK(%s, (obj), %s)" % (
+                arch_cpu.c_name,
+                type_arch_cpu.c_name
+            )
+        )
+        cpu.extra_references = {type_arch_cpu}
+        h.add_type(cpu)
+
+        get_class = Macro(self.get_class_macro,
+            args = [ "obj" ],
+            text = "OBJECT_GET_CLASS(%s, (obj), %s)" % (
+                cpu_class.c_name,
+                type_arch_cpu.c_name
+            )
+        )
+        get_class.extra_references = {type_arch_cpu}
+        h.add_type(get_class)
+
+        if get_vp("CPU_RESOLVING_TYPE exists"):
+            cpu_resolving_type = Macro("CPU_RESOLVING_TYPE",
+                text = type_arch_cpu.c_name
+            )
+            cpu_resolving_type.extra_references = {type_arch_cpu}
+            h.add_type(cpu_resolving_type)
+
+        if get_vp("cpu_arch_init exists"):
+            h.add_type(
+                Macro("cpu_init",
+                    args = [ "cpu_model" ],
+                    text = "CPU(%s(cpu_model))" % self.cpu_init_name
+                )
+            )
+        elif get_vp("cpu_init exists"):
+            cpu_init = Macro("cpu_init",
+                args = [ "cpu_model" ],
+                text = "cpu_generic_init(%s, cpu_model)" % (
+                    type_arch_cpu.c_name
+                )
+            )
+            cpu_init.extra_references = {type_arch_cpu}
+            h.add_type(cpu_init)
+
+        cpu_class = Type["CPUClass"]
+
+        h.add_types([
+            cpu_class.do_interrupt.gen_callback(fn_name("do_interrupt")),
+            cpu_class.get_phys_page_debug.gen_callback(
+                fn_name("get_phys_page_debug")
+            ),
+            cpu_class.dump_state.gen_callback(fn_name("dump_state")),
+            Function(name = self.tcg_init_name)
+        ])
+
+        if get_vp("cpu_arch_init exists"):
+            h.add_type(
+                Function(
+                    name = self.cpu_init_name,
+                    ret_type = Pointer(Type[self.struct_instance_name]),
+                    args = [ Pointer(Type["const char"])("cpu_model") ]
+                )
+            )
+
+    def _gen_translate_inc_c(self, h):
+        for reg in self.registers:
+            h.add_global_variable(
+                Type["tcg"](reg.name, array_size = reg.bank_size)
+            )
+
+        disas_context = Structure("DisasContext",
+            Pointer(Type["TranslationBlock"])("tb"),
+            Type["uint64_t"]("pc"),
+            Type["uint64_t"]("opcode"),
+            Type["int"]("bstate"),
+            Type["bool"]("singlestep_enabled")
+        )
+
+        set_pc = Function(
+            name = "set_pc",
+            ret_type = Type["void"],
+            args = [ Type["uint64_t"]("val") ],
+            static = True,
+            inline = True
+        )
+
+        h.add_types([
+            Enumeration([
+                ("BS_NONE", 0),
+                ("BS_STOP", 1),
+                ("BS_BRANCH", 2),
+                ("BS_EXCP", 3)
+            ]),
+            disas_context,
+            set_pc
+        ])
+
+        Header["exec/cpu_ldst.h"].add_reference(disas_context)
+
+    def _gen_cpu_c(self, c):
+        cpu_class = Type["CPUClass"]
+        type_info_type = Type["TypeInfo"]
+        fn_name = self.gen_func_name
+
+        reset = cpu_class.reset.gen_callback(fn_name("reset"), static = True)
+        c.add_type(reset)
+
+        disas_set_info = cpu_class.disas_set_info.gen_callback(
+            fn_name("disas_set_info"),
+            static = True
+        )
+        c.add_type(disas_set_info)
+
+        set_pc = cpu_class.set_pc.gen_callback(fn_name("set_pc"),
+            static = True
+        )
+        c.add_type(set_pc)
+
+        class_by_name = cpu_class.class_by_name.gen_callback(
+            fn_name("class_by_name"),
+            static = True
+        )
+        c.add_type(class_by_name)
+
+        has_work = cpu_class.has_work.gen_callback(
+            fn_name("has_work"),
+            static = True
+        )
+        c.add_type(has_work)
+
+        gdb_read_register = cpu_class.gdb_read_register.gen_callback(
+            fn_name("gdb_read_register"),
+            static = True
+        )
+        c.add_type(gdb_read_register)
+
+        gdb_write_register = cpu_class.gdb_write_register.gen_callback(
+            fn_name("gdb_write_register"),
+            static = True
+        )
+        c.add_type(gdb_write_register)
+
+        realizefn = Type["DeviceRealize"].type.use_as_prototype(
+            fn_name("realizefn"),
+            static = True
+        )
+        c.add_type(realizefn)
+
+        if get_vp("cpu_arch_init exists"):
+            cpu_init_def = Type[self.cpu_init_name].gen_definition()
+            c.add_type(cpu_init_def)
+
+        cpu_initfn = type_info_type.instance_init.gen_callback(
+            fn_name("initfn"),
+            static = True
+        )
+        c.add_type(cpu_initfn)
+
+        cpu_class_init = type_info_type.class_init.gen_callback(
+            fn_name("class_init"),
+            static = True
+        )
+        c.add_type(cpu_class_init)
+
+        type_info = type_info_type(self.type_info_name,
+            initializer = Initializer(
+                {
+                    "name": Type[self.qtn.type_macro],
+                    "parent": Type["TYPE_CPU"],
+                    # TODO: support `OpSizeOf` and other related function body
+                    #       classes in `Initializer`'s `code`
+                    "instance_size": "sizeof(%s)" % self.struct_instance_name,
+                    "instance_init": cpu_initfn,
+                    "class_size": "sizeof(%s)" % self.struct_class_name,
+                    "class_init": cpu_class_init
+                },
+                used_types = [
+                    Type[self.struct_instance_name],
+                    Type[self.struct_class_name]
+                ]
+            ),
+            static = True,
+            const = True
+        )
+        c.add_global_variable(type_info)
+
+        cpu_register_types = self.gen_register_types_fn(type_info)
+        c.add_type(cpu_register_types)
+
+        type_init_usage_init = Initializer({ "function": cpu_register_types })
+
+        c.add_type(
+            Type["type_init"].gen_type(initializer = type_init_usage_init)
+        )
+
+    def _gen_helper_c(self, c):
+        fn_name = self.gen_func_name
+
+        if get_vp("tlb_fill exists"):
+            tlb_fill = Type["tlb_fill"].gen_definition()
+            c.add_type(tlb_fill)
+
+        if get_vp("CPUClass has tlb_fill field"):
+            cpu_tlb_fill = Type[
+                fn_name("tlb_fill")
+            ].gen_definition()
+            c.add_type(cpu_tlb_fill)
+        else:
+            handle_mmu_fault = Type[
+                fn_name("handle_mmu_fault")
+            ].gen_definition()
+            c.add_type(handle_mmu_fault)
+
+        raise_exception = self.gen_raise_exception()
+        c.add_type(raise_exception)
+
+        helper_debug = self.gen_helper_debug()
+        c.add_type(helper_debug)
+
+        helper_illegal = self.gen_helper_illegal()
+        c.add_type(helper_illegal)
+
+        Header["exec/helper-gen.h"].add_types([
+            helper_debug.use_as_prototype("gen_" + helper_debug.name),
+            helper_illegal.use_as_prototype("gen_" + helper_illegal.name)
+        ])
+
+        phys_page_debug_def = Type[
+            fn_name("get_phys_page_debug")
+        ].gen_definition()
+        c.add_type(phys_page_debug_def)
+
+        c.add_type(Type[fn_name("do_interrupt")].gen_definition())
+
+    def _gen_machine_c(self, c):
+        cpu_arch_state = Type[self.struct_name]
+        vmstate = self.gen_vmstate_var(cpu_arch_state)
+        c.add_global_variable(vmstate)
+
+    def _gen_translate_c(self, c):
+        if get_vp("Init cpu_env in arch"):
+            cpu_env = Type["TCGv_env"]("cpu_env", static = True)
+            c.add_global_variable(cpu_env)
+            Header["exec/gen-icount.h"].add_reference(cpu_env)
+        else:
+            cpu_env = Header["tcg.h"].global_variables["cpu_env"]
+
+        reg_vars = []
+        for reg in self.registers:
+            var = Type["TCGv"](reg.name, array_size = reg.bank_size)
+            c.add_global_variable(var)
+
+            if reg.bank_size:
+                names_array = add_global_array_with_reg_names(
+                    reg, reg.name + "_names", c
+                )
+            else:
+                names_array = None
+
+            reg_vars.append((reg, var, names_array))
+
+        cpu_dump_state_def = Type[
+            self.gen_func_name("dump_state")
+        ].gen_definition()
+        c.add_type(cpu_dump_state_def)
+
+        tcg_init_def = Type[self.tcg_init_name].gen_definition()
+        c.add_type(tcg_init_def)
+
+        decode_opc = Function(
+            name = "decode_opc",
+            ret_type = Type["int"],
+            args = [
+                Pointer(Type[self.struct_instance_name])("cpu"),
+                Pointer(Type["DisasContext"])("ctx")
+            ],
+            static = True
+        )
+        c.add_type(decode_opc)
+
+        cpu_arch_state_p = Pointer(Type[self.struct_name])
+
+        gen_int_code_args = [ Pointer(Type["TranslationBlock"])("tb") ]
+        if get_vp("gen_intermediate_code arg1 is generic"):
+            gen_int_code_args.insert(0, Pointer(Type["CPUState"])("cs"))
+        else:
+            gen_int_code_args.insert(0, cpu_arch_state_p("env"))
+        if get_vp("gen_intermediate_code has max_insns argument"):
+            gen_int_code_args.append(Type["int"]("max_insns"))
+        gen_int_code_def = Function(
+            name = "gen_intermediate_code.definition",
+            args = gen_int_code_args
+        )
+        gen_int_code_def.declaration = Type["gen_intermediate_code"]
+        c.add_type(gen_int_code_def)
+
+        restore_state_to_opc = Function(
+            name = "restore_state_to_opc",
+            args = [
+                cpu_arch_state_p("env"),
+                Pointer(Type["TranslationBlock"])("tb"),
+                Pointer(Type["target_ulong"])("data")
+            ]
+        )
+        c.add_type(restore_state_to_opc)
+
+    def _gen_target_makefile(self, src):
+        with open(src, "w") as mkf:
+            mkf.write("obj-y +=")
+
+            for f in self.gen_files.values():
+                if type(f) is Source:
+                    mkf.write(" %s.o" % splitext(basename(f.path))[0])
+
+            mkf.write("\n")
+
+    def _gen_helper_h(self, src):
+        with open(src, "w") as h:
+            h.write("DEF_HELPER_1(debug, void, env)\n")
+            h.write("DEF_HELPER_1(illegal, void, env)\n")
+
+    def _gen_disas(self, c):
+        # TODO: this code is generic enough to be part of `source` module.
+        spec_and_len2type = {}
+        for specifiers, info in spec_and_len2typename.items():
+            len2type = {}
+
+            for length, typename in info.items():
+                if typename.endswith('*'):
+                    len2type[length] = Pointer(Type[typename[:-1]])
+                else:
+                    len2type[length] = Type[typename]
+
+            for specifier in specifiers:
+                spec_and_len2type[specifier] = len2type
+
+        reg_names_arrays = set()
+        for reg in self.registers:
+            if reg.bank_size:
+                reg_names_arrays.add(
+                    add_global_array_with_reg_names(reg, reg.name, c)
+                )
+
+        added = {}
+        for op_names, (fmt, adapter) in self.name_to_format.items():
+            if adapter is None:
+                continue
+
+            arg_count = op_names.count(',') + 1
+            if added.get(adapter) is None:
+                if fmt is not None:
+                    f_spec_match = re_format_specifier.search(fmt)
+                    if f_spec_match:
+                        length = f_spec_match.group(2)
+                        specifier = f_spec_match.group(3)
+                        try:
+                            ret_type = spec_and_len2type[specifier][length]
+                        except KeyError:
+                            raise Exception('Illegal format specifier "%s"' % (
+                                f_spec_match.group(1)
+                            ))
+                    else:
+                        raise Exception("Format specifier not found in string"
+                            ' "%s"' % fmt
+                        )
+                    args = []
+                else:
+                    args = [
+                        Type["fprintf_function"]("fpr"),
+                        Pointer(Type["void"])("stream")
+                    ]
+                    ret_type = Type["void"]
+
+                # TODO: can we derive argument names from `op_names`?
+                if arg_count == 1:
+                    args += [ Type["uint64_t"]("arg") ]
+                else:
+                    args += [ Type["uint64_t"]("arg" + str(i))
+                        for i in range(0, arg_count)
+                    ]
+
+                f = Function(
+                    name = adapter,
+                    # Note, the user will necessarily write the body of the
+                    # function after generation so that it will not be empty.
+                    # To simplify the work with git diff, the brackets will be
+                    # immediately placed as for a non-empty function.
+                    body = "",
+                    ret_type = ret_type,
+                    args = args,
+                    static = True
+                )
+
+                # Note, arrays with register names will be used for output
+                # with a high degree of probability. Therefore, they will
+                # immediately be placed above the helper functions.
+                f.extra_references = reg_names_arrays
+
+                c.add_type(f)
+
+                added[adapter] = (arg_count, fmt is None)
+            elif added[adapter] != (arg_count, fmt is None):
+                raise Exception('"%s": (%r, "%s") try to use function with'
+                    " another number of arguments or argument type than"
+                    " before" % (op_names, fmt, adapter)
+                )
+
+        print_insn_def = Type[self.print_insn_name].gen_definition()
+        c.add_type(print_insn_def)
+
+
+def create_default_config(src, target_name):
+    default_config = join(src, "default-configs", target_name + "-softmmu.mak")
+
+    with open(default_config, "w") as f:
+        f.write("# Default configuration for %s-softmmu\n" % target_name)
+
+
+def patch_configure(src, arch_bigendian, target_name):
+    configure_path = join(src, "configure")
+
+    with open(configure_path, "r") as f:
+        lines = f.readlines()
+
+    found_target_abi_dir = False
+    target_in_config = "  %s)\n" % target_name
+    inserted_target = False
+
+    found_disas_config = False
+    inserted_disas_config = False
+
+    fixed_target_bigendian = False
+
+    for i, line in enumerate(lines):
+        if line == 'TARGET_ABI_DIR=""\n':
+            found_target_abi_dir = True
+        if line == "disas_config() {\n":
+            found_disas_config = True
+
+        if not fixed_target_bigendian and line == 'target_bigendian="no"\n':
+            ind = i + get_vp("target_bigendian list offset")
+            bigendian_list = lines[ind].strip()[:-1].split("|")
+            if arch_bigendian:
+                if target_name not in bigendian_list:
+                    bigendian_list.append(target_name)
+            else:
+                if target_name in bigendian_list:
+                    bigendian_list.remove(target_name)
+            lines[ind] = "  " + "|".join(bigendian_list) + ")\n"
+            fixed_target_bigendian = True
+
+        if found_target_abi_dir and not inserted_target:
+            if line == target_in_config:
+                inserted_target = True
+            elif line == "  *)\n":
+                lines.insert(i,
+                    """\
+  {tn})
+    TARGET_ARCH={tn}
+    TARGET_BASE_ARCH={tn}
+  ;;
+""".format(tn = target_name)
+                )
+                inserted_target = True
+
+        if found_disas_config and not inserted_disas_config:
+            if line == target_in_config:
+                inserted_disas_config = True
+            if line == "  esac\n":
+                lines.insert(i,
+                    """\
+  %s)
+    disas_config "%s"
+  ;;
+""" % (target_name, target_name.upper())
+                )
+                inserted_disas_config = True
+
+        if (    fixed_target_bigendian
+            and inserted_target
+            and inserted_disas_config
+        ):
+            break
+
+    with open(configure_path, "w") as f:
+        f.write("".join(lines))
+
+
+def patch_arch_init_header(src, target_name):
+    arch_init_header = join(src, "include", "sysemu", "arch_init.h")
+    target_name_upper = target_name.upper()
+    qemu_arch = "QEMU_ARCH_" + target_name_upper
+
+    with open(arch_init_header, "r") as f:
+        lines = f.readlines()
+
+    index = 0
+    str_qemu_arch = "    %s = " % qemu_arch
+    found_arch_all = False
+
+    for i, line in enumerate(lines):
+        if found_arch_all:
+            if str_qemu_arch in line:
+                return
+            elif line == "};\n":
+                lines.insert(i, "%s(1 << %d),\n" % (str_qemu_arch, index))
+                break
+            else:
+                index += 1
+        elif line == "    QEMU_ARCH_ALL = -1,\n":
+            found_arch_all = True
+
+    with open(arch_init_header, "w") as f:
+        f.write("".join(lines))
+
+
+def patch_arch_init_source(src, target_name):
+    arch_init_source = join(src, "arch_init.c")
+    target_name_upper = target_name.upper()
+    qemu_arch = "QEMU_ARCH_" + target_name_upper
+
+    str_target = "TARGET_" + target_name_upper
+    found_target_defines = False
+
+    with open(arch_init_source, "r") as f:
+        lines = f.readlines()
+
+    for i, line in enumerate(lines):
+        if line[:19] == "#if defined(TARGET_":
+            found_target_defines = True
+            target_defines_start_idx = i
+
+        if found_target_defines:
+            if str_target in line:
+                # target already in file
+                return
+
+            if line == "#endif\n":
+                target_defines_end_idx = i
+                break
+
+    for i in range(target_defines_start_idx, target_defines_end_idx, 2):
+        if str_target < lines[i].split("defined(")[1][:-1]:
+            break
+    else:
+        i = target_defines_end_idx
+
+    if i == target_defines_start_idx:
+        lines[i] = lines[i][:1] + "el" + lines[i][1:]
+        prefix = ""
+    else:
+        prefix = "el"
+
+    lines.insert(i,
+        """\
+#%sif defined(%s)
+#define QEMU_ARCH %s
+""" % (prefix, str_target, qemu_arch)
+    )
+
+    with open(arch_init_source, "w") as f:
+        f.write("".join(lines))
+
+
+def patch_disas_header(src, print_insn_name, bfd_arch_name):
+    Header[get_vp("disas header")].add_types([
+        # not a real value
+        Enumeration([(bfd_arch_name, 0)], enum_name = "bfd_architecture"),
+        Function(
+            name = print_insn_name,
+            ret_type = Type["int"],
+            args = [
+                Type["bfd_vma"]("addr"),
+                Pointer(Type["disassemble_info"])("info")
+            ]
+        )
+    ])
+
+    disas_header = join(src, "include", get_vp("disas header"))
+
+    with open(disas_header, "r") as f:
+        lines = f.readlines()
+
+    str_bfd_arch_name = "  %s,\n" % bfd_arch_name
+    inserted_bfd_arch = str_bfd_arch_name in lines
+
+    found_print_insn = False
+    print_insn = "int {:28}(bfd_vma, disassemble_info*);\n".format(
+        print_insn_name
+    )
+    r = compile("^int %s *\(bfd_vma, disassemble_info\*\);$" % print_insn_name)
+    inserted_print_insn = any(r.match(line) for line in lines)
+
+    if inserted_bfd_arch and inserted_print_insn:
+        # Prevent file from being overwritten with the same content
+        return
+
+    for i, line in enumerate(lines):
+        if not inserted_bfd_arch and line == "  bfd_arch_last\n":
+            lines.insert(i, str_bfd_arch_name)
+            inserted_bfd_arch = True
+
+        if not found_print_insn and "print_insn_" in line:
+            found_print_insn = True
+        if found_print_insn and not inserted_print_insn and line == "\n":
+            lines.insert(i, print_insn)
+            inserted_print_insn = True
+
+        if inserted_bfd_arch and inserted_print_insn:
+            break
+
+    with open(disas_header, "w") as f:
+        f.write("".join(lines))
+
+
+def patch_poison_header(src, target_arch, config_arch_dis):
+    poison_header = join(src, "include", "exec", "poison.h")
+
+    with open(poison_header, "r") as f:
+        lines = f.readlines()
+
+    lines_group = 0
+
+    poison_target_arch = "#pragma GCC poison " + target_arch + "\n"
+    inserted_target_arch = poison_target_arch in lines
+
+    poison_config_arch_dis = "#pragma GCC poison " + config_arch_dis + "\n"
+    inserted_config_arch_dis = (poison_config_arch_dis in lines
+        or not get_vp("config_arch_dis poisoned")
+    )
+
+    if inserted_target_arch and inserted_config_arch_dis:
+        return
+
+    for i, line in enumerate(lines):
+        if line == "\n":
+            lines_group += 1
+
+        if lines_group == 3 and not inserted_target_arch:
+            lines.insert(i, poison_target_arch)
+            inserted_target_arch = True
+
+        if lines_group == 10 and not inserted_config_arch_dis:
+            lines.insert(i, poison_config_arch_dis)
+            inserted_config_arch_dis = True
+
+        if inserted_target_arch and inserted_config_arch_dis:
+            break
+
+    with open(poison_header, "w") as f:
+        f.write("".join(lines))

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -256,6 +256,7 @@ class CPUType(QOMCPU):
         import cpu_imports
         loaded = dict(cpu_imports.__dict__)
         try:
+            # TODO: use `QProject.lookup_path`
             execfile(self.info_path, loaded)
         except:
             print_exc()

--- a/qemu/cpu/helpers.py
+++ b/qemu/cpu/helpers.py
@@ -1,0 +1,39 @@
+__all__ = [
+    "underscored_name_shortener"
+]
+
+from collections import (
+    defaultdict,
+)
+from itertools import (
+    count,
+)
+
+def underscored_name_shortener(arguments, comment):
+    existing_names = defaultdict(lambda : count(0))
+    for a in arguments:
+        parts = a.name.split('_')
+        if len(parts) > 1:
+            # Argument names with underscores are shortened.
+            # Only the first and second part of the name are used.
+            # The first letter is taken from the first part.
+            # If the first part of the name ends with a number, then it
+            # is also taken.
+            i = len(parts[0]) - 1
+            while parts[0][i].isdigit():
+                i = i - 1
+            name = parts[0][0] + parts[0][i + 1:] + parts[1]
+        else:
+            name = a.name
+        # Getting a unique name among all arguments by adding a sequence
+        # number.
+        while True:
+            num = next(existing_names[name])
+            if num > 0:
+                print('Warning: auto-counter on the arg "%s" of the'
+                    ' "%s" instruction' % (a.name, comment)
+                )
+                name = name + str(num)
+            else:
+                break
+        a.name = name

--- a/qemu/cpu/info.py
+++ b/qemu/cpu/info.py
@@ -1,0 +1,100 @@
+__all__ = [
+    "CPUInfo"
+  , "CPURegister"
+  , "gen_reg_names_range"
+]
+
+from six import (
+    integer_types,
+)
+
+
+class CPURegister(object):
+    "Class is used to describe CPUState registers and register groups."
+
+    def __init__(self, name, bitsize, *reg_names):
+        """
+    :param reg_names:
+        if the tuple is not empty then the CPURegister describes a group of
+    registers
+        """
+        if bitsize > 64:
+            raise ValueError("Unsupported size %d bits for register %s" % (
+                bitsize, name
+            ))
+
+        self.name = name
+        # Note, possible values 32 or 64 bits
+        self.field_bitsize = (bitsize + 31) & ~31
+        self.reg_names = reg_names
+        self.bank_size = len(reg_names) if reg_names else None
+
+
+def gen_reg_names_range(base_name, suffix = "", start = 0, end = 1):
+    if type(start) is not type(end):
+        raise ValueError("Register names range generating error: range start"
+            " and end types differ"
+        )
+    if isinstance(start, integer_types):
+        func = str
+    elif isinstance(start, str) and len(start) == 1 and len(end) == 1:
+        func = chr
+        start = ord(start)
+        end = ord(end)
+    else:
+        raise ValueError("Register names range generating error: only integer"
+            " or one char ranges are allowed"
+        )
+    return [(base_name + func(i) + suffix) for i in range(start, end)]
+
+
+class CPUInfo(object):
+    "This class store CPU info which editing is not supported by the GUI."
+
+    def __init__(self,
+        registers = (),
+        pc_register = "pc",
+        name_to_format = {},
+        instructions = (),
+        read_size = 1,
+        reg_types = (lambda : None),
+        name_shortener = (lambda args, comment : None)
+    ):
+        """
+    :param registers:
+        tuple of `CPURegister`s used in CPU
+
+    :param pc_register:
+        the name of one of the registers specified above that will be
+        considered a program counter
+
+    :param name_to_format:
+        dictionary which describes instructions operands formatting rules for
+        disassembler
+
+    :param instructions:
+        tuple of `Instruction`s
+
+    :param read_size:
+        number of bytes of code to be read at one time during instruction
+        identification (support 1, 2, 4 or 8 bytes)
+
+    :param reg_types:
+        callable object which must register types that can be used in several
+        instruction semantics
+
+    :param name_shortener:
+        callable object that is may rename `args` (corresponding to the
+        `Instruction` operands) of semantics boilerplate `Function` from
+        generated `translate.inc.i3s.c` file (`comment` can be used to specify
+        instruction in user notifications)
+
+        """
+
+        self.registers = list(registers)
+        self.pc_register = pc_register
+        self.name_to_format = dict(name_to_format)
+        self.instructions = list(instructions)
+        self.read_size = read_size
+        self.reg_types = reg_types
+        self.name_shortener = name_shortener

--- a/qemu/cpu/instruction.py
+++ b/qemu/cpu/instruction.py
@@ -1,0 +1,231 @@
+__all__ = [
+#   InstructionField
+        "Operand"
+      , "Opcode"
+      , "Reserved"
+  , "re_disas_format"
+  , "Instruction"
+]
+
+from .constants import (
+    BYTE_BITSIZE,
+)
+from collections import (
+    OrderedDict,
+)
+from common import (
+    lazy,
+)
+from copy import (
+    deepcopy,
+)
+from re import (
+    compile,
+)
+from six import (
+    integer_types,
+)
+
+
+NON_OPCODE_BIT = "x"
+
+
+class InstructionDescriptionError(RuntimeError):
+    pass
+
+
+def integer_set(bitoffset, bitsize):
+    "Converts interval to bit numbers."
+
+    return set(range(bitoffset, bitoffset + bitsize))
+
+
+def iter_split_interval(interval, read_bitsize):
+    "Splits the interval by read_bitsize."
+
+    cur_bitoffset, bitsize = interval
+
+    if (cur_bitoffset // read_bitsize !=
+        (cur_bitoffset + bitsize - 1) // read_bitsize
+    ):
+        while bitsize > 0:
+            next_bitoffset = (
+                (cur_bitoffset // read_bitsize + 1) * read_bitsize
+            )
+            interval_bitsize = min(next_bitoffset - cur_bitoffset, bitsize)
+
+            yield cur_bitoffset, interval_bitsize
+
+            bitsize -= interval_bitsize
+            cur_bitoffset = next_bitoffset
+    else:
+        yield cur_bitoffset, bitsize
+
+
+class InstructionField(object):
+
+    def __init__(self, bitsize):
+        self.bitsize = bitsize
+
+
+class Operand(InstructionField):
+
+    def __init__(self, bitsize, name,
+        num = 0,
+        # Note, the following parameters are for internal usage only.
+        subnum = 0,
+        bitoffset = 0
+    ):
+        super(Operand, self).__init__(bitsize)
+
+        self.name = name
+
+        # user defined operand part number
+        self.num = num
+
+        # splitted operand part number
+        self.subnum = subnum
+
+        # bitoffset in instruction
+        self.bitoffset = bitoffset
+
+
+class Opcode(InstructionField):
+
+    def __init__(self, bitsize, val = None):
+        super(Opcode, self).__init__(bitsize)
+
+        if val is None:
+            val = "0" * bitsize
+        elif isinstance(val, integer_types):
+            val = "{1:0{0}b}".format(bitsize, val)
+
+        if len(val) > bitsize:
+            raise InstructionDescriptionError(
+                "Opcode value does not fit in available bitsize"
+            )
+
+        self.val = val
+
+
+class Reserved(InstructionField):
+    pass
+
+
+re_disas_format = compile("<(.+?)>|([^<>]+)")
+
+class Instruction(object):
+    """ This class store information about one instruction.
+
+:param branch:
+    flag marks a control flow branching instruction
+
+:param disas_format:
+    string that describes the disassembler output for this instruction
+
+:param comment:
+    string to be inserted into the generated semantic boilerplate code (the
+    leaves of the instruction tree)
+
+:param semantics:
+    callable object which must return list of function body tree elements that
+    describe the semantics of the instruction
+    """
+
+# TODO: an ASCII-art schematic with field layout (bit enumeration) relative to
+#       first byte of the instruction & other fields
+
+    def __init__(self, mnemonic, *raw_fields, **kw_args):
+        self.mnemonic = mnemonic
+        # `InstructionField` objects can be reused while defining similar
+        # instructions. As we going to modify them, the fields must be copied.
+        self.raw_fields = deepcopy(raw_fields)
+
+        self.branch = kw_args.get("branch", False)
+        self.disas_format = kw_args.get("disas_format", mnemonic)
+        self.comment = kw_args.get("comment", self.disas_format)
+        self.semantics = kw_args.get("semantics", lambda : [])
+
+    @lazy
+    def bitsize(self):
+        return sum(field.bitsize for field in self.fields)
+
+    @lazy
+    def fields(self):
+        return self.split_operands_fill_bitoffsets()
+
+    def split_operands_fill_bitoffsets(self):
+        """ Splits operands that cross read boundaries (defined by
+        `read_bitsize`). Fills bitoffsets for all fields.
+        """
+
+        read_bitsize = self.read_bitsize
+        fields = []
+        bitoffset = 0
+        for field in self.raw_fields:
+            bitsize = field.bitsize
+            if isinstance(field, Operand):
+                for subnum, (field_bitoffset, field_bitsize) in enumerate(
+                    iter_split_interval((bitoffset, bitsize), read_bitsize)
+                ):
+                    fields.append(
+                        Operand(field_bitsize, field.name,
+                            num = field.num,
+                            subnum = subnum,
+                            bitoffset = field_bitoffset
+                        )
+                    )
+            else:
+                field.bitoffset = bitoffset
+                fields.append(field)
+            bitoffset += bitsize
+
+        if bitoffset % read_bitsize:
+            raise InstructionDescriptionError(
+                'The instruction "%s" is not aligned by read_size %d' % (
+                    self.comment, self.read_bitsize // BYTE_BITSIZE
+                )
+            )
+
+        return tuple(fields)
+
+    def get_opcode_part(self, interval):
+        bitoffset, bitsize = interval
+        res = self.opcode_bits_string[bitoffset:bitoffset + bitsize]
+        if NON_OPCODE_BIT in res:
+            return None
+        return res
+
+    @lazy
+    def opcode_bits_string(self):
+        res = [NON_OPCODE_BIT] * self.bitsize
+        for f in self.fields:
+            if isinstance(f, Opcode):
+                for i, c in enumerate(f.val, f.bitoffset):
+                    res[i] = c
+        return "".join(res)
+
+    def field_class_bits(self, class_):
+        result = set()
+        for f in self.fields:
+            if isinstance(f, class_):
+                result |= integer_set(f.bitoffset, f.bitsize)
+        return result
+
+    @lazy
+    def opcode_bits(self):
+        return self.field_class_bits(Opcode)
+
+    @lazy
+    def operand_bits(self):
+        return self.field_class_bits(Operand)
+
+    def iter_operand_parts(self):
+        operands_dict = OrderedDict()
+
+        for f in self.fields:
+            if isinstance(f, Operand):
+                operands_dict.setdefault(f.name, []).append(f)
+
+        for name, parts in operands_dict.items():
+            yield name, sorted(parts, key = lambda x: (x.num, x.subnum))

--- a/qemu/cpu/parse_tree_code_builder.py
+++ b/qemu/cpu/parse_tree_code_builder.py
@@ -1,0 +1,216 @@
+__all__ = [
+    "ParseTreeCodeBuilder"
+]
+
+from .constants import (
+    BYTE_BITSIZE,
+    OPERAND_MAX_BITSIZE,
+)
+from source import (
+    BranchSwitch,
+    CINT,
+    Comment,
+    Declare,
+    OpAnd,
+    OpAssign,
+    OpDeclareAssign,
+    OpLShift,
+    OpOr,
+    OpRShift,
+    SwitchCase,
+    SwitchCaseDefault,
+    Type,
+)
+
+
+class ParseTreeCodeBuilder(object):
+    "This class traverses the instruction tree and builds the parsing code."
+
+    def __init__(self, cputype, gen_node, gen_field_read_cb, epilogue_cb,
+        unknown_instruction_case_nodes,
+        add_break = True
+    ):
+        """
+    :param cputype:
+        instance of `CPUType`
+
+    :param gen_node:
+        source.function.tree Node where to add code
+
+    :param gen_field_read_cb:
+        callback function that generates the code to readings
+
+    :param epilogue_cb:
+        callback function that generates processing of one instruction
+
+    :param unknown_instruction_case_nodes:
+        list of nodes to insert when there is no `default` opcode in the
+        instruction subtree
+
+    :param add_break:
+        flag indicating the need to add a break to the `default` branch made
+        from `unknown_instruction_case_nodes` list
+        """
+
+        instruction_tree_root = cputype.instruction_tree_root
+        if not instruction_tree_root:
+            gen_node(*unknown_instruction_case_nodes)
+            return
+
+        self.target_bigendian = cputype.target_bigendian
+        self.read_bitsize = cputype.read_bitsize
+        self.gen_field_read_cb = gen_field_read_cb
+        self.epilogue_cb = epilogue_cb
+        self.unknown_instruction_case = SwitchCaseDefault(
+            add_break = add_break
+        )(*unknown_instruction_case_nodes)
+
+        # divide vars by purpose
+        self.opcode_vars = set()
+        self.operand_vars = set()
+        self.vars = set()
+
+        self.gen_subtree_code(gen_node, instruction_tree_root)
+
+        # auto naming vars by purpose
+        for var in self.opcode_vars:
+            var.name = "opc" + var.name
+        for var in self.operand_vars - self.opcode_vars:
+            var.name = "val" + var.name
+        for var in self.vars - self.operand_vars - self.opcode_vars:
+            var.name = "res" + var.name
+
+    def gen_subtree_code(self, gen_node, instr_node, vars_desc = []):
+        ins = instr_node.instruction
+
+        if ins is not None:
+            comment = ins.comment
+            gen_node(Comment(comment))
+
+        new_vars = []
+        for bitoffset, bitsize in instr_node.reading_seq:
+            # Note, a variable name can't start with a digit but a semantic
+            # prefix will be assigned at the end of code generation.
+            var = Type["uint64_t"](
+                "%d_%d" % (bitoffset // BYTE_BITSIZE, bitsize)
+            )
+            var_desc = (var, bitoffset, bitsize)
+            new_vars.append(var_desc)
+            self.gen_field_read_cb(gen_node, *var_desc)
+
+        if new_vars:
+            vars_desc = vars_desc + new_vars
+            self.vars.update(v[0] for v in new_vars)
+
+        if ins is None:
+            bitoffset, bitsize = instr_node.interval
+            var, shift = self.get_var_and_shift(bitoffset, bitsize, vars_desc)
+
+            cases = []
+            default_sc = None
+            for opcode, node in instr_node.subtree.items():
+                if opcode == "default":
+                    sc = default_sc = SwitchCaseDefault()
+                else:
+                    sc = SwitchCase(
+                        CINT(
+                            int(opcode, base = 2) << shift,
+                            base = 16
+                        )
+                    )
+                    cases.append(sc)
+
+                self.gen_subtree_code(sc, node, vars_desc = vars_desc)
+
+            if default_sc is not None:
+                cases.append(default_sc)
+            else:
+                # If subtree hasn't `default` opcode we have to process an
+                # unknown instruction, that is, exit the cpu loop or print
+                # message about it in default branch.
+                cases.append(self.unknown_instruction_case)
+
+            opc_mask = ((1 << bitsize) - 1) << shift
+
+            self.opcode_vars.add(var)
+            gen_node(
+                BranchSwitch(
+                    OpAnd(var, CINT(opc_mask, base = 16)),
+                    cases = cases
+                )
+            )
+        else:
+            operands = self.get_operands(gen_node, ins, vars_desc)
+            total_read = (vars_desc[-1][1] + vars_desc[-1][2]) // BYTE_BITSIZE
+            self.epilogue_cb(gen_node, ins, operands, total_read, comment)
+
+    def get_var_and_shift(self, bitoffset, bitsize, vars_desc):
+        # looking for a variable that contains the desired interval
+        for var, var_bitoffset, var_bitsize in reversed(vars_desc):
+            if (    var_bitoffset <= bitoffset
+                and bitoffset + bitsize <= var_bitoffset + var_bitsize
+            ):
+                break
+        # else:
+        #     Note, an interval cannot cover several variables because it's
+        #     split by read_bitsize.
+
+        local_bitoffset = bitoffset - var_bitoffset
+
+        # We must account the endianness of CPU if the variable size is larger
+        # than the read size.
+        if self.target_bigendian:
+            shift = var_bitsize - bitsize - local_bitoffset
+        else:
+            swap_bitsize = self.read_bitsize
+            # TODO: explain the derivation of the formula
+            shift = (swap_bitsize + local_bitoffset -
+                2 * (local_bitoffset % swap_bitsize) - bitsize
+            )
+
+        return var, shift
+
+    def get_operands(self, node, instruction, vars_desc):
+        declarations = []
+        operands = []
+
+        for name, parts in instruction.iter_operand_parts():
+            shift = 0
+            rval = None
+            # TODO: this is a coding style feature,
+            #       generalize it inside source.function.tree
+            need_parenthesis = len(parts) > 1
+
+            for oper in parts:
+                var, shift_var = self.get_var_and_shift(
+                    oper.bitoffset, oper.bitsize, vars_desc
+                )
+                self.operand_vars.add(var)
+                oper_part = OpAnd(
+                    OpRShift(var, shift_var) if shift_var else var,
+                    CINT((1 << oper.bitsize) - 1, base = 16),
+                    # Prevent warning [-Wparentheses]
+                    # "suggest parentheses around arithmetic in operand of `|`"
+                    # when the operand is merged from several parts.
+                    parenthesis = need_parenthesis
+                )
+
+                if shift:
+                    oper_part = OpLShift(oper_part, shift)
+                rval = OpOr(rval, oper_part) if rval else oper_part
+                shift += oper.bitsize
+
+            if shift > OPERAND_MAX_BITSIZE:
+                raise NotImplementedError('The operand "%s" in the instruction'
+                    ' "%s" longer than %d bits. Please reduce the length'
+                    " manually by breaking it into several operands." % (
+                        name, instruction.mnemonic, OPERAND_MAX_BITSIZE
+                    )
+                )
+
+            res = Type["uint64_t"](name)
+            operands.append(res)
+            declarations.append(Declare(OpDeclareAssign(res, rval)))
+
+        node(*declarations)
+        return operands

--- a/qemu/project.py
+++ b/qemu/project.py
@@ -144,7 +144,8 @@ class QProject(object):
 
     def co_gen(self, desc, src,
         with_chunk_graph = False,
-        known_targets = None
+        known_targets = None,
+        with_debug_comments = False
     ):
         qom_t = desc.gen_type()
 
@@ -174,7 +175,7 @@ class QProject(object):
             f = s.generate(inherit_references = inherit_references)
 
             with open(spath, mode = "wb", encoding = "utf-8") as stream:
-                f.generate(stream)
+                f.generate(stream, gen_debug_comments = with_debug_comments)
 
             if with_chunk_graph:
                 yield True

--- a/qemu/project.py
+++ b/qemu/project.py
@@ -11,13 +11,22 @@ from os.path import (
     join,
     splitext,
     isdir,
+    isabs,
+    normpath,
+    relpath,
     isfile
 )
 from itertools import (
     count
 )
+from .cpu import (
+    CPUDescription
+)
 from .machine_description import (
     MachineNode
+)
+from .version_description import (
+    QemuVersionDescription
 )
 from common import (
     same_sets,
@@ -100,12 +109,27 @@ class QProject(object):
 
     def co_gen_all(self, qemu_src, **gen_cfg):
         disable_auto_lock_sources()
+        qvd = QemuVersionDescription.current
 
-        # First, generate all devices, then generate machines
+        # Firstly, generate all CPUs
         for desc in self.descriptions:
-            if not isinstance(desc, MachineNode):
+            if isinstance(desc, CPUDescription):
+                yield desc.gen_type().co_gen(qemu_src, **gen_cfg)
+
+                enable_auto_lock_sources()
+                # Re-init cache to prevent problems with same named types
+                qvd.forget_cache()
+                yield qvd.co_init_cache()
+                # Replace forgotten dirty cache with new clean one
+                qvd.qvc.use()
+                disable_auto_lock_sources()
+
+        # Secondly, generate all devices
+        for desc in self.descriptions:
+            if not isinstance(desc, (CPUDescription, MachineNode)):
                 yield self.co_gen(desc, qemu_src, **gen_cfg)
 
+        # Lastly, generate machines
         for desc in self.descriptions:
             if isinstance(desc, MachineNode):
                 desc.link()
@@ -197,6 +221,21 @@ class QProject(object):
             patch_makefile(Makefile_objs_class_path, object_name,
                 obj_var_names[desc.directory], config_flags[desc.directory]
             )
+
+    # TODO: add path to `QProject`
+    # TODO: def lookup_path
+
+    def replace_relpaths_to_abspaths(self, path):
+        for desc in self.descriptions:
+            if isinstance(desc, CPUDescription):
+                if not isabs(desc.info_path):
+                    desc.info_path = normpath(join(path, desc.info_path))
+
+    def replace_abspaths_to_relpaths(self, path):
+        for desc in self.descriptions:
+            if isinstance(desc, CPUDescription):
+                if isabs(desc.info_path):
+                    desc.info_path = relpath(desc.info_path, start = path)
 
     def __var_base__(self):
         return "project"

--- a/qemu/project_editing.py
+++ b/qemu/project_editing.py
@@ -466,6 +466,8 @@ class POp_AddDesc(ProjectOperation, QemuObjectCreationHelper):
                 if "SysBusDeviceDescription" in self.nc
             else _("PCI bus device template")
                 if "PCIExpressDeviceDescription" in self.nc
+            else _("CPU template")
+                if "CPUDescription" in self.nc
             else _("an auto generated code")
         )
 

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -600,12 +600,18 @@ class QOMType(object):
             array_size = 0
         )
 
-    def gen_vmstate_initializer(self, name, state_struct):
-        code = ("""{
-    .name@b=@s%s,
-    .version_id@b=@s1,
-    .fields@b=@s(VMStateField[])@b{
-""" % name
+    def gen_vmstate_initializer(self, name, state_struct,
+        min_version_id = None
+    ):
+        code = """{{
+    .name@b=@s{name},
+    .version_id@b=@s1,{min_version_id}
+    .fields@b=@s(VMStateField[])@b{{
+""".format(
+    name = name,
+    min_version_id = ("\n    .minimum_version_id@b=@s%d," % min_version_id
+        if min_version_id else ""
+    )
         )
 
         used_macros = set()

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -650,7 +650,9 @@ class QOMType(object):
             code += ",\n"
 
         # Generate VM state list terminator macro.
-        code += " " * 8 + Type["VMSTATE_END_OF_LIST"].gen_usage_string()
+        vms_macro = Type["VMSTATE_END_OF_LIST"]
+        used_macros.add(vms_macro)
+        code += " " * 8 + vms_macro.gen_usage_string()
 
         code += "\n    }\n}"
 

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -530,7 +530,7 @@ class QOMType(object):
                     self.add_state_field_h("uint8_t", name, num = size)
 
     def gen_state(self):
-        s = Structure(self.qtn.for_struct_name + "State")
+        s = Structure(self.struct_name)
         for f in self.state_fields:
             s.append_field(f.type(f.name, array_size = f.num))
         return s

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -635,7 +635,7 @@ class QOMType(object):
             except KeyError:
                 raise Exception(
                     "VMState generation for type %s is not implemented" % \
-                        f.type.name
+                        f.type
                 )
 
             if f.num is not None:

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -2,6 +2,7 @@ __all__ = [
     "QOMStateField"
   , "QOMType"
       , "QOMDevice"
+      , "QOMCPU"
   , "OpaqueRegister"
       , "Register"
 ]
@@ -13,6 +14,7 @@ from source import (
     Source,
     Header,
     Structure,
+    TopComment,
     TypeNotRegistered,
     Initializer,
     Function,
@@ -1292,4 +1294,83 @@ class QOMDevice(QOMType):
             self.net_client_info_name(index),
             initializer = Initializer(code, used_types = types),
             static = True
+        )
+
+
+class QOMCPU(QOMType):
+
+    def __init__(self, name, directory):
+        super(QOMCPU, self).__init__(name + "-cpu", directory)
+        self.cpu_name = name.lower()
+        self.target_name = directory
+
+        # redefinition of struct_name
+        self.struct_name = "CPU" + self.cpu_name.upper() + "State"
+
+        # all derived strings in one place
+        self.struct_instance_name = self.qtn.for_struct_name.upper()
+        self.struct_class_name = self.qtn.for_struct_name.upper() + "Class"
+        self.env_get_cpu_name = self.cpu_name.lower() + "_env_get_cpu"
+        self.tcg_init_name = self.cpu_name.lower() + "_tcg_init"
+        self.cpu_init_name = "cpu_" + self.cpu_name.lower() + "_init"
+        self.type_info_name = self.cpu_name.upper() + "_type_info"
+        self.print_insn_name = "print_insn_" + self.target_name
+        self.bfd_arch_name = "bfd_arch_" + self.target_name
+        self.class_macro = self.qtn.for_macros + "_CLASS"
+        self.get_class_macro =  self.qtn.for_macros + "_GET_CLASS"
+        self.target_arch = "TARGET_" + self.target_name.upper()
+        self.config_arch_dis = "CONFIG_" + self.target_name.upper() + "_DIS"
+
+    def gen_state(self):
+        s = super(QOMCPU, self).gen_state()
+        if get_vp("move tlb_flush to cpu_common_reset"):
+            s.append_field(TopComment(
+                "Fields up to this point are cleared by a CPU reset"
+            ))
+            s.append_field(Structure()("end_reset_fields"))
+        if get_vp("CPU_COMMON exists"):
+            cpu_common_usage = Type["CPU_COMMON"].gen_type()
+            s.append_field(cpu_common_usage)
+            # XXX: extra reference guarantiee that NB_MMU_MODES defined before
+            # CPU_COMMON usage
+            cpu_common_usage.extra_references = {Type["NB_MMU_MODES"]}
+        return s
+
+    def gen_vmstate_initializer(self, _, state_struct):
+        init = super(QOMCPU, self).gen_vmstate_initializer('"cpu"',
+            state_struct,
+            min_version_id = 1
+        )
+        return init
+
+    def gen_vmstate_var(self, state_struct):
+        vmstate = super(QOMCPU, self).gen_vmstate_var(state_struct)
+        vmstate.static = False
+        vmstate.used = True
+
+        return vmstate
+
+    def gen_func_name(self, func):
+        return self.qtn.for_id_name + '_' + func
+
+    def gen_raise_exception(self):
+        return Function(
+            name = "raise_exception",
+            args = [
+                Pointer(Type[self.struct_name])("env"),
+                Type["uint32_t"]("index")
+            ],
+            static = True
+        )
+
+    def gen_helper_debug(self):
+        return Function(
+            name = "helper_debug",
+            args = [ Pointer(Type[self.struct_name])("env") ]
+        )
+
+    def gen_helper_illegal(self):
+        return Function(
+            name = "helper_illegal",
+            args = [ Pointer(Type[self.struct_name])("env") ]
         )

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -121,7 +121,7 @@ def define_only_qemu_2_6_0_types():
         # variables which are to be replaced by this tool
         # preprocessor (still in progress)
         # tcg is then converted to some existing QEMU types
-        Type("tcg")
+        Type("tcg", incomplete = False)
     ])
 
     Header["qemu/osdep.h"].add_types([

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -95,7 +95,7 @@ def define_only_qemu_2_6_0_types():
         Type("TCGv_i64"),
         Type("TCGv_ptr"),
         Type("TCGv_env", incomplete = False),
-        Type("TCGv"),
+        Pointer(Type["void"], name = "TCGv"),
         Structure("TCGContext"),
         Function(name = "tcg_global_mem_new_i32"),
         Function(name = "tcg_global_mem_new_i64"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -89,16 +89,26 @@ def define_only_qemu_2_6_0_types():
             )
         ])
 
-    Header["tcg.h"].add_types([
+    tcg_header = Header["tcg.h"]
+    tcg_header.add_types([
         Type("TCGv_i32"),
         Type("TCGv_i64"),
         Type("TCGv_ptr"),
-        Type("TCGv_env"),
+        Type("TCGv_env", incomplete = False),
         Type("TCGv"),
+        Structure("TCGContext"),
         Function(name = "tcg_global_mem_new_i32"),
         Function(name = "tcg_global_mem_new_i64"),
         Function(name = "tcg_op_buf_full")
     ])
+
+    if get_vp("Init cpu_env in arch"):
+        # These are required fields only
+        Type["TCGContext"].append_field(Type["TCGv_env"]("tcg_env"))
+    else:
+        tcg_header.add_global_variable(Type["TCGv_env"]("cpu_env"))
+
+    tcg_header.add_global_variable(Type["TCGContext"]("tcg_ctx"))
 
     Header["tcg-op.h"].add_types([
         Function(name = "tcg_gen_insn_start"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -117,11 +117,11 @@ def define_only_qemu_2_6_0_types():
     ])
 
     Header["tcg-op.h"].add_types([
-        # HLTTemp is a fake type intended to mark
+        # tcg is a fake type intended to mark
         # variables which are to be replaced by this tool
         # preprocessor (still in progress)
-        # HLTTemp is then converted to some existing QEMU types
-        Type("HLTTemp")
+        # tcg is then converted to some existing QEMU types
+        Type("tcg")
     ])
 
     Header["qemu/osdep.h"].add_types([

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -135,6 +135,9 @@ def define_only_qemu_2_6_0_types():
         Type("hwaddr", False)
     ]).add_reference(osdep_fake_type)
 
+    tcg_target_header = Header["tcg-target.h"].add_reference(osdep_fake_type)
+    tcg_target_header.add_type(Macro("TCG_AREG0"))
+
     Header["exec/cpu-defs.h"].add_types([
         Type("target_ulong", False)
     ])
@@ -154,7 +157,17 @@ def define_only_qemu_2_6_0_types():
             # These are required fields only
             Pointer(Type["const char"])("name"),
             Pointer(Type["const char"])("parent"),
-            Pointer(Type["void"])("class_init"),
+            Type["size_t"]("instance_size"),
+            Function(
+                args = [ Pointer(Type["Object"])("obj") ]
+            )("instance_init"),
+            Type["size_t"]("class_size"),
+            Function(
+                args = [
+                    Pointer(Type["ObjectClass"])("oc"),
+                    Pointer(Type["void"])("data")
+                ]
+            )("class_init"),
             Pointer(Type["InterfaceInfo"])("interfaces")
         ),
         Type("Type", False),
@@ -183,17 +196,15 @@ def define_only_qemu_2_6_0_types():
         Type("fprintf_function", False)
     ]).add_reference(osdep_fake_type)
 
-    Header[get_vp("disas header")].add_types([
-        Type("disassemble_info", False)
-    ]).add_reference(osdep_fake_type)
-
-    Header[get_vp("disas header")].add_types([
+    disas_header = Header[get_vp("disas header")].add_reference(
+        osdep_fake_type
+    )
+    disas_header.add_types([
         Type("bfd_vma", False),
         Type("bfd_byte", False),
         Type("const bfd_byte", False)
     ])
-
-    Header[get_vp("disas header")].add_types([
+    disas_header.add_types([
         Function(
             name = name,
             ret_type = Type["bfd_vma"],
@@ -202,6 +213,37 @@ def define_only_qemu_2_6_0_types():
             "bfd_getb16"
         ]
     ])
+    dis_info = Structure("disassemble_info")
+    dis_info.append_fields([
+        # These are required fields only
+        Type["fprintf_function"]("fprintf_func"),
+        Pointer(Type["FILE"])("stream"),
+        Type["unsigned long"]("mach"),
+        Function(
+            ret_type = Type["int"],
+            args = [
+                Type["bfd_vma"]("memaddr"),
+                Pointer(Type["bfd_byte"])("myaddr"),
+                Type["int"]("length"),
+                Pointer(dis_info)("info")
+            ]
+        )("read_memory_func"),
+        Function(
+            args = [
+                Type["int"]("status"),
+                Type["bfd_vma"]("memaddr"),
+                Pointer(dis_info)("info")
+            ]
+        )("memory_error_func"),
+        Function(
+            ret_type = Type["int"],
+            args = [
+                Type["bfd_vma"]("addr"),
+                Pointer(dis_info)("info")
+            ]
+        )("print_insn")
+    ])
+    disas_header.add_type(dis_info)
 
     Header["migration/vmstate.h"].add_types([
         Type("VMStateDescription", False),
@@ -210,11 +252,87 @@ def define_only_qemu_2_6_0_types():
     ]).add_reference(osdep_fake_type)
 
     Header["qom/cpu.h"].add_types([
-        Type("CPUState", False),
-        Type("CPUClass", False),
         Type("vaddr", False),
         Type("MMUAccessType", False),
-        Type("CPUBreakpoint", False),
+        Structure("CPUBreakpoint",
+            # These are required fields only
+            Type["vaddr"]("pc")
+        ),
+        Structure("CPUState",
+            # These are required fields only
+            Type["uint32_t"]("interrupt_request"),
+            Type["int"]("singlestep_enabled"),
+            Pointer(Type["void"])("env_ptr"),
+            Type["QTAILQ_HEAD"]("breakpoints",
+                macro_initializer = Initializer({
+                    "name": "breakpoints_head",
+                    "type": Type["CPUBreakpoint"]
+                })
+            ),
+            Type["uint32_t"]("exception_index")
+        ),
+        Structure("CPUClass",
+            # These are required fields only
+            Function(
+                ret_type = Pointer(Type["ObjectClass"]),
+                args = [ Pointer(Type["const char"])("cpu_model") ]
+            )("class_by_name"),
+            Function(
+                args = [ Pointer(Type["CPUState"])("cs") ]
+            )("reset"),
+            Function(
+                ret_type = Type["bool"],
+                args = [ Pointer(Type["CPUState"])("cs") ]
+            )("has_work"),
+            Function(
+                args = [ Pointer(Type["CPUState"])("cs") ]
+            )("do_interrupt"),
+            Function(
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Pointer(Type["FILE"])("f"),
+                    Type["fprintf_function"]("cpu_fprintf"),
+                    Type["int"]("flags")
+                ]
+            )("dump_state"),
+            Function(
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Type["vaddr"]("value")
+                ]
+            )("set_pc"),
+            Function(
+                ret_type = Type["hwaddr"],
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Type["vaddr"]("addr")
+                ]
+            )("get_phys_page_debug"),
+            Function(
+                ret_type = Type["int"],
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Pointer(Type["uint8_t"])("mem_buf"),
+                    Type["int"]("n")
+                ]
+            )("gdb_read_register"),
+            Function(
+                ret_type = Type["int"],
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Pointer(Type["uint8_t"])("mem_buf"),
+                    Type["int"]("n")
+                ]
+            )("gdb_write_register"),
+            Pointer(Type["VMStateDescription"])("vmsd"),
+            Type["int"]("gdb_num_core_regs"),
+            Function(
+                args = [
+                    Pointer(Type["CPUState"])("cpu"),
+                    Pointer(Type["disassemble_info"])("info")
+                ]
+            )("disas_set_info")
+        ),
         Function(
             name = "qemu_init_vcpu",
             args = [ Pointer(Type["CPUState"])("cpu") ]
@@ -225,8 +343,12 @@ def define_only_qemu_2_6_0_types():
         Function(name = "cpu_generic_init")
     ]).add_reference(osdep_fake_type)
 
+    if get_vp("Generic call to tcg_initialize"):
+        Type["CPUClass"].append_field(Function()("tcg_initialize"))
+
     Header["qapi/error.h"].add_types([
-        Structure("Error")
+        Structure("Error"),
+        Function(name = "error_propagate")
     ]).add_reference(osdep_fake_type)
 
     # Move typedefs.h upper forcing headers below to use declarations from it
@@ -239,8 +361,15 @@ def define_only_qemu_2_6_0_types():
         Structure("I2CBus") # the structure is defined in .c file
     ]).add_reference(osdep_fake_type)
 
-    Header["exec/exec-all.h"].add_types([
-        Type("TranslationBlock", False),
+    exec_all_header = Header["exec/exec-all.h"].add_reference(osdep_fake_type)
+    exec_all_header.add_types([
+        Structure("TranslationBlock",
+            # These are required fields only
+            Type["target_ulong"]("pc"),
+            Type["uint16_t"]("size"),
+            Type["uint16_t"]("icount"),
+            Type["uint32_t"]("cflags")
+        ),
         Function(
             name = "tlb_fill",
             args = [
@@ -263,8 +392,10 @@ def define_only_qemu_2_6_0_types():
         Function(name = "cpu_restore_state"),
         Function(name = "cpu_loop_exit"),
         Function(name = "cpu_loop_exit_restore"),
-        Function(name = "tlb_set_page")
-    ]).add_reference(osdep_fake_type)
+        Function(name = "tlb_set_page"),
+        Function(name = "tlb_flush"),
+    ])
+    exec_all_header.add_global_variable(Type["int"]("singlestep"))
 
     Header["exec/gen-icount.h"].add_types([
         Function(name = "gen_tb_start"),
@@ -402,8 +533,20 @@ def define_only_qemu_2_6_0_types():
     ]).add_reference(osdep_fake_type)
 
     Header["hw/qdev-core.h"].add_types([
-        Type("DeviceClass", False),
         Type("DeviceState", False),
+        Pointer(
+            Function(
+                args = [
+                    Pointer(Type["DeviceState"])("dev"),
+                    Pointer(Pointer(Type["Error"]))("errp")
+                ]
+            ),
+            name = "DeviceRealize"
+        ),
+        Structure("DeviceClass",
+            # These are required fields only
+            Type["DeviceRealize"]("realize")
+        ),
         Type("Property", False),
         Function(
             name = "qdev_init_gpio_in",
@@ -413,15 +556,6 @@ def define_only_qemu_2_6_0_types():
                 Type["qemu_irq_handler"]("handler"),
                 Type["int"]("n")
             ]
-        ),
-        Pointer(
-            Function("device_realize pointee",
-                args = [
-                    Pointer(Type["DeviceState"])("dev"),
-                    Pointer(Pointer(Type["Error"]))("errp")
-                ]
-            ),
-            name = "DeviceRealize",
         ),
         Function(name = "qdev_create"),
         Function(name = "qdev_init_nofail"),

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -117,10 +117,13 @@ def define_only_qemu_2_6_0_types():
     ])
 
     Header["tcg-op.h"].add_types([
-        # tcg is a fake type intended to mark
-        # variables which are to be replaced by this tool
-        # preprocessor (still in progress)
-        # tcg is then converted to some existing QEMU types
+        # `tcg` is a fake type intended to mark variables which are to be
+        # replaced by this tool preprocessor (still in progress).
+        # `tcg` is then converted to some existing QEMU types (`TCGv_i32`,
+        # `TCGv_i64` or `TCGv`). Therefore this type should be placed in the
+        # `tcg.h` header (where these types are declared). But this type helps
+        # to add the `tcg-op.h` header inclusion into the `translate.inc.c`
+        # header. This inclusion is necessary for future function bodies.
         Type("tcg", incomplete = False)
     ])
 

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -179,6 +179,36 @@ def define_only_qemu_2_6_0_types():
         Function(name = "object_class_is_abstract")
     ]).add_reference(osdep_fake_type)
 
+    Header[get_vp("fprintf_function definer")].add_types([
+        Type("fprintf_function", False)
+    ]).add_reference(osdep_fake_type)
+
+    Header[get_vp("disas header")].add_types([
+        Type("disassemble_info", False)
+    ]).add_reference(osdep_fake_type)
+
+    Header[get_vp("disas header")].add_types([
+        Type("bfd_vma", False),
+        Type("bfd_byte", False),
+        Type("const bfd_byte", False)
+    ])
+
+    Header[get_vp("disas header")].add_types([
+        Function(
+            name = name,
+            ret_type = Type["bfd_vma"],
+            args = [ Pointer(Type["const bfd_byte"])("addr") ]
+        ) for name in ["bfd_getl64", "bfd_getl32", "bfd_getb32", "bfd_getl16",
+            "bfd_getb16"
+        ]
+    ])
+
+    Header["migration/vmstate.h"].add_types([
+        Type("VMStateDescription", False),
+        Type("VMStateField", False),
+        Function(name = "vmstate_register_ram_global")
+    ]).add_reference(osdep_fake_type)
+
     Header["qom/cpu.h"].add_types([
         Type("CPUState", False),
         Type("CPUClass", False),
@@ -207,14 +237,6 @@ def define_only_qemu_2_6_0_types():
         # be used instead.
         Structure("BlockBackend"),
         Structure("I2CBus") # the structure is defined in .c file
-    ]).add_reference(osdep_fake_type)
-
-    Header[get_vp("disas header")].add_types([
-        Type("disassemble_info", False)
-    ]).add_reference(osdep_fake_type)
-
-    Header[get_vp("fprintf_function definer")].add_types([
-        Type("fprintf_function", False)
     ]).add_reference(osdep_fake_type)
 
     Header["exec/exec-all.h"].add_types([
@@ -411,12 +433,6 @@ def define_only_qemu_2_6_0_types():
         Function(name = "qdev_connect_gpio_out_named")
     ]).add_reference(osdep_fake_type)
 
-    Header["migration/vmstate.h"].add_types([
-        Type("VMStateDescription", False),
-        Type("VMStateField", False),
-        Function(name = "vmstate_register_ram_global")
-    ]).add_reference(osdep_fake_type)
-
     Header["qemu/module.h"].add_reference(osdep_fake_type)
 
     Header["hw/pci/pci.h"].add_types([
@@ -583,22 +599,6 @@ def define_only_qemu_2_6_0_types():
         ),
     ]).add_references([
         osdep_fake_type
-    ])
-
-    Header[get_vp("disas header")].add_types([
-        Type("bfd_vma", False),
-        Type("bfd_byte", False),
-        Type("const bfd_byte", False)
-    ])
-
-    Header[get_vp("disas header")].add_types([
-        Function(
-            name = name,
-            ret_type = Type["bfd_vma"],
-            args = [ Pointer(Type["const bfd_byte"])("addr") ]
-        ) for name in ["bfd_getl64", "bfd_getl32", "bfd_getb32", "bfd_getl16",
-            "bfd_getb16"
-        ]
     ])
 
     Header["disas/disas.h"].add_types([

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -81,15 +81,19 @@ def define_only_qemu_2_6_0_types():
     # TODO: the tweak must be handled using version API.
     osdep_fake_type = Type("FAKE_TYPE_IN_QEMU_OSDEP")
 
+    Header["qemu/osdep.h"].add_types([
+        osdep_fake_type
+    ])
+
     if not get_vp("tcg_enabled is macro"):
         Header["qemu-common.h"].add_types([
             Function(
                 name = "tcg_enabled",
                 ret_type = Type["bool"]
             )
-        ])
+        ]).add_reference(osdep_fake_type)
 
-    tcg_header = Header["tcg.h"]
+    tcg_header = Header["tcg.h"].add_reference(osdep_fake_type)
     tcg_header.add_types([
         Type("TCGv_i32"),
         Type("TCGv_i64"),
@@ -116,10 +120,7 @@ def define_only_qemu_2_6_0_types():
     Header["tcg-op.h"].add_types([
         Function(name = "tcg_gen_insn_start"),
         Function(name = "tcg_gen_goto_tb"),
-        Function(name = "tcg_gen_exit_tb")
-    ])
-
-    Header["tcg-op.h"].add_types([
+        Function(name = "tcg_gen_exit_tb"),
         # `tcg` is a fake type intended to mark variables which are to be
         # replaced by this tool preprocessor (still in progress).
         # `tcg` is then converted to some existing QEMU types (`TCGv_i32`,
@@ -128,11 +129,7 @@ def define_only_qemu_2_6_0_types():
         # to add the `tcg-op.h` header inclusion into the `translate.inc.c`
         # header. This inclusion is necessary for future function bodies.
         Type("tcg", incomplete = False)
-    ])
-
-    Header["qemu/osdep.h"].add_types([
-        osdep_fake_type
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["exec/hwaddr.h"].add_types([
         Type("hwaddr", False)
@@ -156,7 +153,7 @@ def define_only_qemu_2_6_0_types():
         Function(name = "cpu_lduw_code", ret_type = Type["uint16_t"]),
         Function(name = "cpu_ldl_code", ret_type = Type["uint32_t"]),
         Function(name = "cpu_ldq_code", ret_type = Type["uint64_t"]),
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["qom/object.h"].add_types([
         Type("ObjectClass", False),
@@ -448,7 +445,7 @@ def define_only_qemu_2_6_0_types():
     Header["exec/gen-icount.h"].add_types([
         Function(name = "gen_tb_start"),
         Function(name = "gen_tb_end")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["exec/address-spaces.h"].add_types([
         Function(name = "get_system_memory")
@@ -727,12 +724,13 @@ def define_only_qemu_2_6_0_types():
 
     Header["hw/isa/isa.h"].add_types([
         Type("IsaDmaTransferHandler")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     if get_vp("include/hw/isa/i8257.h have IsaDmaTransferHandler reference"):
         Header[get_vp("i8257.h path")].add_references([
             Type["IsaDmaTransferHandler"],
-            Type["MemoryRegion"]
+            Type["MemoryRegion"],
+            osdep_fake_type
         ])
 
     Header["qapi/qapi-types-net.h"].add_types([
@@ -742,7 +740,7 @@ def define_only_qemu_2_6_0_types():
             enum_name = "NetClientDriver",
             typedef_name = "NetClientDriver"
         )
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["net/net.h"].add_types([
         Type("qemu_macaddr_default_if_unset"),
@@ -790,7 +788,7 @@ def define_only_qemu_2_6_0_types():
 
     Header["disas/disas.h"].add_types([
         Function(name = "lookup_symbol")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["qemu/log.h"].add_types([
         Function(name = "qemu_loglevel_mask"),
@@ -798,11 +796,11 @@ def define_only_qemu_2_6_0_types():
         Function(name = "qemu_log_lock"),
         Function(name = "qemu_log_unlock"),
         Function(name = "qemu_log")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["exec/log.h"].add_types([
         Function(name = "log_target_disas")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     Header["sysemu/reset.h"].add_types([
         # XXX: It's neither a function nor a function pointer. It's something
@@ -812,7 +810,7 @@ def define_only_qemu_2_6_0_types():
             args = [ Pointer(Type["void"])("opaque") ]
         ),
         Function(name = "qemu_register_reset")
-    ])
+    ]).add_reference(osdep_fake_type)
 
     if get_vp("qemu_fprintf exists"):
         Header["qemu/qemu-print.h"].add_types([
@@ -844,7 +842,7 @@ def define_qemu_2_6_5_types():
                 ret_type = Type["int"],
                 args = [ Pointer(Type["void"])("opaque") ]
             )
-        )
+        ).add_reference(Type["FAKE_TYPE_IN_QEMU_OSDEP"])
 
 def define_qemu_2_6_0_types():
     add_base_types()

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -108,7 +108,10 @@ def define_only_qemu_2_6_0_types():
     else:
         tcg_header.add_global_variable(Type["TCGv_env"]("cpu_env"))
 
-    tcg_header.add_global_variable(Type["TCGContext"]("tcg_ctx"))
+    t = Type["TCGContext"]
+    if get_vp("tcg_ctx is pointer"):
+        t = Pointer(t)
+    tcg_header.add_global_variable(t("tcg_ctx"))
 
     Header["tcg-op.h"].add_types([
         Function(name = "tcg_gen_insn_start"),
@@ -138,9 +141,15 @@ def define_only_qemu_2_6_0_types():
     tcg_target_header = Header["tcg-target.h"].add_reference(osdep_fake_type)
     tcg_target_header.add_type(Macro("TCG_AREG0"))
 
-    Header["exec/cpu-defs.h"].add_types([
+    cpu_defs_header = Header["exec/cpu-defs.h"].add_reference(osdep_fake_type)
+    cpu_defs_header.add_inclusion(tcg_target_header)
+    cpu_defs_header.add_types([
         Type("target_ulong", False)
     ])
+    if get_vp("CPUNegativeOffsetState exists"):
+        cpu_defs_header.add_type(
+            Structure("CPUNegativeOffsetState")
+        )
 
     Header["exec/cpu_ldst.h"].add_types([
         Function(name = "cpu_ldub_code", ret_type = Type["uint8_t"]),
@@ -251,7 +260,7 @@ def define_only_qemu_2_6_0_types():
         Function(name = "vmstate_register_ram_global")
     ]).add_reference(osdep_fake_type)
 
-    Header["qom/cpu.h"].add_types([
+    Header[get_vp("cpu header")].add_types([
         Type("vaddr", False),
         Type("MMUAccessType", False),
         Structure("CPUBreakpoint",
@@ -290,8 +299,16 @@ def define_only_qemu_2_6_0_types():
             Function(
                 args = [
                     Pointer(Type["CPUState"])("cs"),
-                    Pointer(Type["FILE"])("f"),
-                    Type["fprintf_function"]("cpu_fprintf"),
+                    Pointer(Type["FILE"])("f")
+                ] +
+                (
+                    [ Type["fprintf_function"]("cpu_fprintf") ] if get_vp(
+                        "dump_state has cpu_fprintf argument"
+                    )
+                    else
+                    []
+                ) +
+                [
                     Type["int"]("flags")
                 ]
             )("dump_state"),
@@ -346,6 +363,22 @@ def define_only_qemu_2_6_0_types():
     if get_vp("Generic call to tcg_initialize"):
         Type["CPUClass"].append_field(Function()("tcg_initialize"))
 
+    if get_vp("CPUClass has tlb_fill field"):
+        Type["CPUClass"].append_field(
+            Function(
+                ret_type = Type["bool"],
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Type["vaddr"]("address"),
+                    Type["int"]("size"),
+                    Type["MMUAccessType"]("access_type"),
+                    Type["int"]("mmu_idx"),
+                    Type["bool"]("probe"),
+                    Type["uintptr_t"]("retaddr")
+                ]
+            )("tlb_fill")
+        )
+
     Header["qapi/error.h"].add_types([
         Structure("Error"),
         Function(name = "error_propagate")
@@ -371,17 +404,6 @@ def define_only_qemu_2_6_0_types():
             Type["uint32_t"]("cflags")
         ),
         Function(
-            name = "tlb_fill",
-            args = [
-                Pointer(Type["CPUState"])("cs"),
-                Type["target_ulong"]("addr"),
-                Type["MMUAccessType"]("access_type"),
-                Type["int"]("mmu_idx"),
-                Type["uintptr_t"]("retaddr")
-            ],
-            used_types = []
-        ),
-        Function(
             name = "cpu_exec_init",
             args = [
                 Pointer(Type["CPUState"])("cs"),
@@ -396,6 +418,32 @@ def define_only_qemu_2_6_0_types():
         Function(name = "tlb_flush"),
     ])
     exec_all_header.add_global_variable(Type["int"]("singlestep"))
+    if get_vp("tb_cflags exists"):
+        exec_all_header.add_type(
+            Function(name = "tb_cflags")
+        )
+    if get_vp("tlb_fill exists"):
+        exec_all_header.add_type(
+            Function(
+                name = "tlb_fill",
+                args = [
+                    Pointer(Type["CPUState"])("cs"),
+                    Type["target_ulong"]("addr")
+                ] +
+                (
+                    [ Type["int"]("size") ] if get_vp(
+                        "tlb_fill has SIZE argument"
+                    ) else
+                    []
+                ) +
+                [
+                    Type["MMUAccessType"]("access_type"),
+                    Type["int"]("mmu_idx"),
+                    Type["uintptr_t"]("retaddr")
+                ],
+                used_types = []
+            )
+        )
 
     Header["exec/gen-icount.h"].add_types([
         Function(name = "gen_tb_start"),
@@ -532,7 +580,8 @@ def define_only_qemu_2_6_0_types():
         Function(name = "qemu_irq_split")
     ]).add_reference(osdep_fake_type)
 
-    Header["hw/qdev-core.h"].add_types([
+    qdev_core_header = Header["hw/qdev-core.h"].add_reference(osdep_fake_type)
+    qdev_core_header.add_types([
         Type("DeviceState", False),
         Pointer(
             Function(
@@ -565,7 +614,11 @@ def define_only_qemu_2_6_0_types():
         Function(name = "qdev_get_gpio_in_named"),
         Function(name = "qdev_connect_gpio_out"),
         Function(name = "qdev_connect_gpio_out_named")
-    ]).add_reference(osdep_fake_type)
+    ])
+    if get_vp("device_class_set_parent_realize exists"):
+        qdev_core_header.add_type(
+            Function(name = "device_class_set_parent_realize")
+        )
 
     Header["qemu/module.h"].add_reference(osdep_fake_type)
 
@@ -760,6 +813,25 @@ def define_only_qemu_2_6_0_types():
         ),
         Function(name = "qemu_register_reset")
     ])
+
+    if get_vp("qemu_fprintf exists"):
+        Header["qemu/qemu-print.h"].add_types([
+            Function(name = "qemu_fprintf")
+        ]).add_reference(osdep_fake_type)
+
+    cpu_all_header = Header["exec/cpu-all.h"].add_reference(osdep_fake_type)
+    if get_vp("env_cpu exists"):
+        cpu_all_header.add_type(
+            Function(name = "env_cpu")
+        )
+    if get_vp("env_archcpu exists"):
+        cpu_all_header.add_type(
+            Function(name = "env_archcpu")
+        )
+    if get_vp("cpu_set_cpustate_pointers exists"):
+        cpu_all_header.add_type(
+            Function(name = "cpu_set_cpustate_pointers")
+        )
 
 def define_qemu_2_6_5_types():
     add_base_types()
@@ -1091,7 +1163,264 @@ qemu_heuristic_db = {
             old_value = True,
             new_value = False
         )
-    ]
+    ],
+    u'9c489ea6bed134fecfd556b439c68bba48fbe102':
+    [
+        # first argument of the `gen_intermediate_code` function was became a
+        # generic `CPUState` instead of target specific `CPUArchState`
+        QEMUVersionParameterDescription(
+            "gen_intermediate_code arg1 is generic",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'0dacec874fa3b3fd34b0d0670fa257efdcbbebd0':
+    [
+        # `CPU_RESOLVING_TYPE` macro was added
+        QEMUVersionParameterDescription("CPU_RESOLVING_TYPE exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'3f71e724e283233753f1b5b3d6a30948d3084636':
+    [
+        # `cpu_init(cpu_model)` was replaced by `cpu_create(cpu_type)`, so
+        # `cpu_init` macro was removed
+        QEMUVersionParameterDescription("cpu_init exists",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'98670d47cd8d63a529ff230fd39ddaa186156f8c':
+    [
+        # `size` parameter was added to `tlb_fill` function arguments
+        QEMUVersionParameterDescription("tlb_fill has SIZE argument",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'1d48474d8e9eff9d08ad43477043d95789b96a40':
+    [
+        # `flags` parameter was removed from `log_target_disas` function
+        # arguments
+        QEMUVersionParameterDescription("log_target_disas has FLAGS argument",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'55c3ceef61fcf06fc98ddc752b7cce788ce7680b':
+    [
+        # target cpu tcg initialization was moved to a common code
+        QEMUVersionParameterDescription("Generic call to tcg_initialize",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'1f5c00cfdb8114c1e3a13426588ceb64f82c9ddb':
+    [
+        # `tlb_flush` call was moved to a common code
+        QEMUVersionParameterDescription("move tlb_flush to cpu_common_reset",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'32f0f68bb77289b75a82925f712bb52e16eac3ba':
+    [
+        # `cpu_arch_init` call was replaced by `cpu_generic_init` call, so
+        # `cpu_arch_init` function was removed
+        QEMUVersionParameterDescription("cpu_arch_init exists",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'19aaa4c3fd15eeb82f10c35ffc7d53e103d10787':
+    [
+        # `qemu_fprintf` function was added
+        QEMUVersionParameterDescription("qemu_fprintf exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'90c84c56006747537e9e4240271523c4c3b7a481':
+    [
+        # `cpu_fprintf` parameter was removed from `dump_state` function
+        # arguments
+        QEMUVersionParameterDescription("dump_state has cpu_fprintf argument",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'74433bf083b0766aba81534f92de13194f23ff3e':
+    [
+        # few target-specific macros was moved to a new `cpu-param.h` header
+        QEMUVersionParameterDescription("cpu-param header exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'52bf9771fdfce98e98cea36a17a18915be6f6b7f':
+    [
+        # the commit touched the `configure` file and deleted one new line from
+        # it
+        QEMUVersionParameterDescription("target_bigendian list offset",
+            old_value = 3,
+            new_value = 2
+        )
+    ],
+    u'4f7c64b3819d559417615ed2b1d028ebc1a49580':
+    [
+        # `CPUArchState` macro was replaced by `CPUArchState` definition 
+        QEMUVersionParameterDescription("typedef CPUArchState",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'2161a612b4e1d388046320bc464adefd6bba01a0':
+    [
+        # `ArchCPU` definition was added
+        QEMUVersionParameterDescription("typedef ArchCPU",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'29a0af618ddd21f55df5753c3e16b0625f534b3c':
+    [
+        # `ENV_GET_CPU` macro usage was replaced by `env_cpu` call, so
+        # `ENV_GET_CPU` macro was removed
+        QEMUVersionParameterDescription("env_cpu exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'083dc73d7a3cf2a75b5625fd8f0669b57a855d16':
+    [
+        # target-specific `env_get_cpu` function was replaced with a generic
+        # `env_archcpu` function
+        QEMUVersionParameterDescription("env_archcpu exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'677c4d69ac21961e76a386f9bfc892a44923acc0':
+    [
+        # `ENV_OFFSET` macro was moved to a common code
+        QEMUVersionParameterDescription("ENV_OFFSET is generic",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'5b146dc716cfd247f99556c04e6e46fbd67565a0':
+    [
+        # `CPUNegativeOffsetState` structure was added and used as a type of
+        # the `neg` field in the `ArchCPU`
+        QEMUVersionParameterDescription("CPUNegativeOffsetState exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'e8b5fae5161c48e0d0e8b35eaf9dd8f35d692088':
+    [
+        # `CPU_COMMON` macro was removed
+        QEMUVersionParameterDescription("CPU_COMMON exists",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'2e5b09fd0e766434962327db4678ce1cda0c7241':
+    [
+        # `cpu.h` header was moved from `qom/` to `hw/core/` folder
+        QEMUVersionParameterDescription("cpu header",
+            old_value = "qom/cpu.h",
+            new_value = "hw/core/cpu.h"
+        )
+    ],
+    u'8301ea444abb49f7b7fb939b09c1e23b22977f30':
+    [
+        # `cpu_model` null check was moved to a generic `cpu_class_by_name`
+        # function
+        QEMUVersionParameterDescription("cpu_model null check",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'46795cf2e2f643ace9454822022ba8b1e9c0cf61':
+    [
+        # `device_class_set_parent_realize` function was added
+        QEMUVersionParameterDescription(
+            "device_class_set_parent_realize exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'7506ed902eb97fe4e2a1dd16766c621d32ecc40d':
+    [
+        # `cpu_set_cpustate_pointers` function was added
+        QEMUVersionParameterDescription("cpu_set_cpustate_pointers exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'c5a49c63fa26e8825ad101dfe86339ae4c216539':
+    [
+        # `tb_cflags` function was added few commits earlier but this commit
+        # start use it
+        QEMUVersionParameterDescription("tb_cflags exists",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'b1311c4acf503dc9c1a310cc40b64f05b08833dc':
+    [
+        # `tcg_ctx` was defined as a pointer to `TCGContext`
+        QEMUVersionParameterDescription("tcg_ctx is pointer",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'07ea28b41830f946de3841b0ac61a3413679feb9':
+    [
+        QEMUVersionParameterDescription(
+            "pass tb and index to tcg_gen_exit_tb separately",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'8b86d6d25807e13a63ab6ea879f976b9f18cc45a':
+    [
+        # `max_insns` parameter was added to `gen_intermediate_code` function,
+        # so there is no need to calculate it inside this function
+        QEMUVersionParameterDescription(
+            "gen_intermediate_code has max_insns argument",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'da6bbf8513e621a8fc2fd315d77318f36547474d':
+    [
+        # `tlb_fill` callback was added to `CPUClass` structure
+        QEMUVersionParameterDescription("CPUClass has tlb_fill field",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u'c319dc13579a92937bffe02ad2c9f1a550e73973':
+    [
+        # `CPUClass.tlb_fill` callback was used instead of `tlb_fill` function,
+        # so this function was removed from a target code
+        QEMUVersionParameterDescription("tlb_fill exists",
+            old_value = True,
+            new_value = False
+        )
+    ],
+    u'067b913619ac36299be5ab23921fd19a0347df60':
+    [
+        # `CONFIG_ARCH_DIS` macro was poisoned to prevent usage in a common
+        # code
+        QEMUVersionParameterDescription("config_arch_dis poisoned",
+            old_value = False,
+            new_value = True
+        )
+    ],
 }
 
 version_parameters = None
@@ -1116,4 +1445,3 @@ def get_vp(heuristic_name = None):
         return version_parameters
     else:
         return version_parameters[heuristic_name]
-

--- a/qemu_device_creator.py
+++ b/qemu_device_creator.py
@@ -109,7 +109,8 @@ def main():
         qvd.qvc.stc.gen_header_inclusion_dot_file(arguments.gen_header_tree)
 
     project.gen_all(qvd.src_path,
-        with_chunk_graph = arguments.gen_chunk_graphs
+        with_chunk_graph = arguments.gen_chunk_graphs,
+        known_targets = qvd.qvc.known_targets
     )
 
     return 0

--- a/qemu_device_creator.py
+++ b/qemu_device_creator.py
@@ -60,6 +60,12 @@ def main():
     )
 
     parser.add_argument(
+        "--gen-debug-comments",
+        action = "store_true",
+        help = "Generate source files with debug comments."
+    )
+
+    parser.add_argument(
         "script",
         help = "A Python script containing definition of a project to generate."
     )
@@ -110,7 +116,8 @@ def main():
 
     project.gen_all(qvd.src_path,
         with_chunk_graph = arguments.gen_chunk_graphs,
-        known_targets = qvd.qvc.known_targets
+        known_targets = qvd.qvc.known_targets,
+        with_debug_comments = arguments.gen_debug_comments
     )
 
     return 0

--- a/qemu_device_creator.py
+++ b/qemu_device_creator.py
@@ -5,6 +5,8 @@ from argparse import (
     ArgumentParser
 )
 from os.path import (
+    abspath,
+    dirname,
     isdir
 )
 from qemu import (
@@ -89,6 +91,8 @@ def main():
     else:
         print("Script '%s' does not define a project to generate." % script)
         return -1
+
+    project.replace_relpaths_to_abspaths(abspath(dirname(script)))
 
     if arguments.qemu_build is None:
         qemu_build_path = getattr(project, "build_path", None)

--- a/source/base_types.py
+++ b/source/base_types.py
@@ -14,8 +14,20 @@ def add_base_types():
     Type(name = "int", incomplete = False, base = True)
     Type(name = "unsigned", incomplete = False, base = True)
     Type(name = "unsigned int", incomplete = False, base = True)
+    Type(name = "short int", incomplete = False, base = True)
+    Type(name = "unsigned short int", incomplete = False, base = True)
+    Type(name = "long int", incomplete = False, base = True)
+    Type(name = "unsigned long", incomplete = False, base = True)
+    Type(name = "unsigned long int", incomplete = False, base = True)
+    Type(name = "long long int", incomplete = False, base = True)
+    Type(name = "unsigned long long", incomplete = False, base = True)
+    Type(name = "unsigned long long int", incomplete = False, base = True)
     Type(name = "const char", incomplete = False, base = True)
     Type(name = "char", incomplete = False, base = True)
+    Type(name = "signed char", incomplete = False, base = True)
+    Type(name = "unsigned char", incomplete = False, base = True)
+    Type(name = "double", incomplete = False, base = True)
+    Type(name = "long double", incomplete = False, base = True)
 
     try:
         h = Header["stdint.h"]
@@ -33,6 +45,8 @@ def add_base_types():
         , Type(name = "int32_t", incomplete = False, base = False)
         , Type(name = "int16_t", incomplete = False, base = False)
         , Type(name = "int8_t", incomplete = False, base = False)
+        , Type(name = "intmax_t", incomplete = False, base = False)
+        , Type(name = "uintmax_t", incomplete = False, base = False)
     ])
 
     try:
@@ -45,6 +59,7 @@ def add_base_types():
 
     h.add_types([
         Type(name = "size_t", incomplete = False, base = False),
+        Type(name = "ptrdiff_t", incomplete = False, base = False)
     ])
 
     try:
@@ -79,6 +94,7 @@ def add_base_types():
         h = Header("string.h", is_global = True)
 
     h.add_types([
+        Function(name = "memset"),
         Function(name = "memcpy")
     ])
 
@@ -103,4 +119,14 @@ def add_base_types():
 
     h.add_types([
         Function(name = "abort")
+    ])
+
+    try:
+        h = Header["wchar.h"]
+    except:
+        h = Header("wchar.h", is_global = True)
+
+    h.add_types([
+        Type(name = "wint_t", incomplete = False, base = False),
+        Type(name = "wchar_t", incomplete = False, base = False)
     ])

--- a/widgets/add_desc_dialog.py
+++ b/widgets/add_desc_dialog.py
@@ -74,7 +74,8 @@ class AddDescriptionDialog(GUIDialog):
             values = [
                 _("System bus device template"),
                 _("Machine draft"),
-                _("PCI(E) function template")
+                _("PCI(E) function template"),
+                _("CPU template")
             ],
             state = "readonly"
         )
@@ -150,6 +151,9 @@ class AddDescriptionDialog(GUIDialog):
         elif kind == 2:
             class_name = "PCIExpressDeviceDescription"
             directory = "pci"
+        elif kind == 3:
+            class_name = "CPUDescription"
+            directory = cur_name
 
         add_op = self.pht.stage(POp_AddDesc, class_name,
             self.pht.p.next_serial_number(),


### PR DESCRIPTION
This series of patches adds the ability to generate CPU.

### v5:
- delete unused imports
- add `bit` prefixes to variables to distinguish work with bytes and bits
- fix newline print condition in `cpu_dump_state` function
- take into account CLI singlestep in `gen_intermediate_code` function
- rename `default_switch` -> `unknown_instruction` to clarify purpose
- add caching variables to remove access to `self` fields
- add `InstructionDescriptionError`
- move same code from `split_operands_fill_bitoffsets` and `split_intervals` to `iter_split_interval` generator function
- add `subnum` and `bitoffset` arguments to `Operand` initialization
- make `Instruction.fields` lazy
- remove `build_instruction_tree_root` method

### v4.1:
- review
- add some comments
- rework some docstrings
- add a `RuntimeError` to `calc_node_reading_seq`

### v4:
- move `ParseTreeCodeBuilder` class into separate module
- move name shortening code into separate helper function (shortening argument names for functions from `translate.inc.c` file)
- replace the `size` suffix with the `bitsize` suffix for all variables that store the size in bits
- add few explanatory comments
- reorder and eliminate some methods of `ParseTreeCodeBuilder` to simplify
- reorder methods of `CPUType` by call order
- rename `opcode` field of `InstructionTreeNode` into `interval`
- rename `reads_desc` field of `InstructionTreeNode` into `reading_seq` (and all related functions)
- replace few properties of `CPURegister` by attributes
- add parameter `name_shortener` to `CPUInfo`

### v3.1:
- review
- `pe_flag` -> `potential_error`

### v <= 3.0:
- [intensive internal development]