### PR TITLE
Late binding

### DIFF
--- a/c2t/tests/_readme_u32_.c
+++ b/c2t/tests/_readme_u32_.c
@@ -5,23 +5,33 @@ int main(void) {
 
     for (i = 0; i < 20; i++) {
         if (i % 2) {
+            c = b - a;
+
             // breakpoint lives on the first iteration
-            c = b - a; //$br
+            c = 0; //$br
         } else {
+            c = b + a;
+
             // breakpoint lives on the all iterations
-            c = b + a; //$brc
+            c = 0; //$brc
         }
 
         // Note: value of variable on the one line is checked on the next line
 
         // check values of the all variables on the first iteration
-        c = b & a; //$ch
+        c = b & a;
+
+        c = 0; //$ch
 
         // check just value of 'c' on the first iteration
-        c = b | a; //$ch.c
+        c = b | a;
+
+        c = 0; //$ch.c
 
         // check just value of 'c' on the all iterations
-        c = b ^ a; //$chc.c
+        c = b ^ a;
+
+        c = 0; //$chc.c
 
         /* combination of commands is possible
             on the first iteration: check line number, values of 'a' and 'b'

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -717,6 +717,10 @@ class OpSDeref(Operator):
     def type(self):
         return self.struct.fields[self.field].type
 
+    @property
+    def container(self):
+        return self.children[0]
+
 
 class UnaryOperator(Operator):
 

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -692,7 +692,8 @@ class OpSDeref(Operator):
         _type = value.type
 
         struct = _type
-        while isinstance(struct, Pointer):
+        # Note, pointer nesting must be at most 1.
+        if isinstance(struct, Pointer):
             struct = struct.type
 
         if OPSDEREF_FROM_DEFINITION:

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -698,7 +698,7 @@ class OpSDeref(Operator):
             struct = struct.type
 
         if OPSDEREF_FROM_DEFINITION:
-            struct = struct._definition or struct
+            struct = struct.definition
 
         try:
             struct.fields[self.field]

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -188,6 +188,14 @@ class CNode(Node):
     def out_child(child, writer):
         child.__c__(writer)
 
+    def iter_local_variables(self):
+        for child in self.children:
+            if isinstance(child, OpDeclareAssign):
+                yield child.variable
+            elif isinstance(child, Declare):
+                for var in child.iter_variables():
+                    yield var
+
 
 class Comment(Node):
 

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -689,9 +689,7 @@ class OpSDeref(Operator):
 
         self.field = field
 
-        _type = value.type
-
-        struct = _type
+        struct = value.type
         # Note, pointer nesting must be at most 1.
         if isinstance(struct, Pointer):
             struct = struct.type
@@ -709,14 +707,16 @@ class OpSDeref(Operator):
                 struct, field
             ))
 
-        if isinstance(_type, Pointer):
-            self.suffix = "->" + field
-        else:
-            self.suffix = "." + field
-
     @lazy
     def type(self):
         return self.struct.fields[self.field].type
+
+    @property
+    def suffix(self):
+        if isinstance(self.container.type, Pointer):
+            return "->" + self.field
+        else:
+            return "." + self.field
 
     @property
     def container(self):

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -689,7 +689,10 @@ class OpSDeref(Operator):
 
         self.field = field
 
-        struct = value.type
+    # for type collection
+    @property
+    def struct(self):
+        struct = self.container.type
         # Note, pointer nesting must be at most 1.
         if isinstance(struct, Pointer):
             struct = struct.type
@@ -697,15 +700,14 @@ class OpSDeref(Operator):
         if OPSDEREF_FROM_DEFINITION:
             struct = struct._definition or struct
 
-        # for type collection
-        self.struct = struct
-
         try:
-            struct.fields[field]
+            struct.fields[self.field]
         except KeyError:
             raise RuntimeError('Structure "%s" has no field "%s"' % (
-                struct, field
+                struct, self.field
             ))
+
+        return struct
 
     @lazy
     def type(self):

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -84,6 +84,9 @@ from common import (
 from six import (
     integer_types
 )
+from ..late_link import (
+    LateLink
+)
 
 
 # OpSDeref is automatically re-directed to definition of structure if
@@ -679,10 +682,20 @@ class OpSDeref(Operator):
     # for type collection
     @property
     def struct(self):
-        struct = self.container.type
+        container = self.container
+
+        # Late links are allowed during model construction but they must
+        # be replaced before the code generation.
+        if isinstance(container, LateLink):
+            return None
+
+        struct = container.type
         # Note, pointer nesting must be at most 1.
         if isinstance(struct, Pointer):
             struct = struct.type
+
+        if isinstance(struct, LateLink):
+            return None
 
         if OPSDEREF_FROM_DEFINITION:
             struct = struct.definition

--- a/source/late_link.py
+++ b/source/late_link.py
@@ -1,0 +1,40 @@
+__all__ = [
+    "LateLink"
+]
+
+
+class LateLink(object):
+    """ A placeholder for an entity that does not exist yet (or reference is
+inaccessible). It will be replaced with a reference to the entity.
+    """
+
+    def __init__(self, key):
+        """
+:param key:
+    A key to search the entity.
+    Type and interpretation depend on lookup scope.
+
+    `BodyTree`/`ConditionalBlock` `children` scope:
+      - locally `Declare`d `Variable`
+
+    `Function.body` scope:
+      - `int`eger index of an argument
+      - `str`ing name of an argument
+
+    `Source` `types` and `global_variables` scopes:
+      - `str`ing name of a global `Variable`
+      - `str`ing name of a `Type` in the `Source`
+
+    Current `SourceTreeContainer` scope:
+      - `str`ing name of a global `Type`
+
+    * Lookup order is from inner scope to outer (top-down in the list).
+
+        """
+        self.key = key
+
+    def gen_defining_chunk_list(self, *_, **__):
+        raise RuntimeError("Late link '%s' is not resolved" % self.key)
+
+    def __c__(self, *__):
+        raise RuntimeError("Late link '%s' is not resolved" % self.key)

--- a/source/model.py
+++ b/source/model.py
@@ -268,6 +268,11 @@ class Structure(Type):
         self._fields = OrderedDict()
         self.append_fields(fields)
 
+    @property
+    def definition(self):
+        # Note, be careful defining __bool__ or __len__.
+        return self._definition or self
+
     def gen_forward_declaration(self):
         if not self.is_named:
             raise RuntimeError(

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -6,6 +6,8 @@ from six import (
     StringIO
 )
 from source import (
+    LateLink,
+    BranchIf,
     Return,
     OpSDeref,
     disable_auto_lock_sources,
@@ -997,6 +999,89 @@ class TestOptimizeInclusions(SourceModelTestHelper, TestCase):
 
 typedef c *cpointer;
 """.format(src.path)
+
+        self.files = [
+            (src, src_content)
+        ]
+
+
+class TestLateBinding(SourceModelTestHelper, TestCase):
+
+    def setUp(self):
+        super(TestLateBinding, self).setUp()
+        name = type(self).__name__
+
+        # Late binding testing is based on `OpSDeref`'s checking of `struct`ure
+        # field existence. We create variables with same name but using
+        # `struct`ures with different fields. Variables are created and used
+        # in different namespaces. `OpSDeref` checks if late binding find out
+        # right `Variable`.
+
+        src = Source(name.lower() + ".c")
+        src.add_types([
+            Structure("A", Type["int"]("a")),
+            Structure("B", Type["int"]("b")),
+            Structure("C", Type["int"]("c")),
+        ])
+        src.add_global_variable(
+            Type["A"]("struct_var")
+        )
+        src.add_types([
+            Function("a_function",
+                body = BodyTree()(
+                    BranchIf(OpSDeref(LateLink("struct_var"), "b"))(
+                        Declare(Type["C"]("struct_var")),
+                        OpAssign(OpSDeref(LateLink("struct_var"), "c"), 1)
+                    )
+                ),
+                args = [Pointer(Type["B"])("struct_var")]
+            ),
+            Function("another_function",
+                body = BodyTree()(
+                    BranchIf(OpSDeref(LateLink("struct_var"), "a"))(
+                        Declare(Type["C"]("struct_var")),
+                        OpAssign(OpSDeref(LateLink("struct_var"), "c"), 1)
+                    ),
+                    Return(OpSDeref(LateLink("struct_var"), "a"))
+                ),
+                ret_type = Type["int"],
+            ),
+        ])
+
+        src_content = "/* " + src.path + """ */
+
+typedef struct A {
+    int a;
+} A;
+
+typedef struct B {
+    int b;
+} B;
+
+typedef struct C {
+    int c;
+} C;
+
+void a_function(B *struct_var)
+{
+    if (struct_var->b) {
+        C struct_var;
+        struct_var.c = 1;
+    }
+}
+
+A struct_var;
+
+int another_function(void)
+{
+    if (struct_var.a) {
+        C struct_var;
+        struct_var.c = 1;
+    }
+    return struct_var.a;
+}
+
+"""
 
         self.files = [
             (src, src_content)

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -7,6 +7,7 @@ from six import (
 )
 from source import (
     Return,
+    OpSDeref,
     disable_auto_lock_sources,
     OpaqueCode,
     Type,
@@ -507,6 +508,65 @@ Private *handler __attribute__((unused));
 
 """ % (name.lower() + ".c")
 
+        self.files = [
+            (src, src_content)
+        ]
+
+
+class TestReplacementWithDefinition(SourceModelTestHelper, TestCase):
+
+    def setUp(self):
+        from source.function.tree import (
+            OPSDEREF_FROM_DEFINITION
+        )
+        if not OPSDEREF_FROM_DEFINITION:
+            self.skipTest("re-direction to structure definition is disabled")
+
+        super(TestReplacementWithDefinition, self).setUp()
+        name = type(self).__name__
+        src = Source(name.lower() + ".c")
+
+        struct = Structure("A",
+            Type["int"]("a")
+        )
+        fwd = struct.gen_forward_declaration()
+        var = fwd("a_global")
+
+        src.add_global_variable(var)
+
+        src.add_types([
+            struct,
+            fwd,
+            Function("a_function",
+                body = BodyTree()(
+                    # Using a forward structure declaration as type of the
+                    # `var`iable must not result in a field existence check
+                    # error because of auto re-direction.
+                    # But currently variable "a_global" depends on forward
+                    # structure declaration which is wrong and will be
+                    # fixed soon.
+                    Return(OpSDeref(var, "a"))
+                ),
+                ret_type = Type["int"]
+            )
+        ])
+
+        src_content = "/* " + src.path + """ */
+
+struct A {
+    int a;
+};
+
+typedef struct A A;
+
+A a_global;
+
+int a_function(void)
+{
+    return a_global.a;
+}
+
+"""
         self.files = [
             (src, src_content)
         ]


### PR DESCRIPTION
The patch series mainly adds capability to use `str`ings and
sometimes `int`egers to refer `Variable`s and `Type`s when
a regular reference is not available (the entity may not yet exist).
The system inserts actual references just before chunks generation.

This also tear source/model.py apart several files according
to semantic.

Function body model is also got some tweaks.

### v3 (not ready):
- move generic patches to amother MR #74
- move model refactoring code to another MR #61
- rebase onto new master
- fixup returns of functions in new tests for model
- `LateLink` reports resolution error in `__c__` too
- patches about `OpSDeref` are redesigned
- `OpSDeref` explicitly handle `LateLink`s

### v2:
- auto re-direction from forward structure declaration to the
  structure definition (by `OpSDeref`) is moved to `TypeFixerVisitor`
- add a test for that re-direction
- `sys.stdout` is saved in `co_build_inclusions` kw defaults, i.e. near its usage
- remove unused import of `path2tuple`
- fixup typos & coding style