### PR TITLE
No-stop mode for c2t

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ its explanation):
 
 ```bash
 sudo python -m pip install --upgrade gitpython six graphviz \
-  path.py construct serial
+  path.py construct serial psutil
 ```
 
 Use `python2` or `python3` explicitly when there are several Python
@@ -208,6 +208,8 @@ Embedded `pyrsp` and `pyelftools` require some packages.
 sudo pip install --upgrade construct serial
 sudo pip3 install --upgrade construct serial
 ```
+
+`psutil` provides cross-platform process manipulations (e.g. by c2t)
 
 Now the all environment prerequisites are satisfied.
 

--- a/c2t.py
+++ b/c2t.py
@@ -31,6 +31,9 @@ from multiprocessing import (
     Queue,
     Process
 )
+from threading import (
+    Thread
+)
 from six.moves.queue import (
     Empty
 )
@@ -274,10 +277,10 @@ class TargetSession(DebugSession):
         self.rt.target.run(setpc = False)
 
 
-class ProcessWithErrCatching(Process):
+class ProcessWithErrCatching(Thread):
 
     def __init__(self, command):
-        Process.__init__(self)
+        Thread.__init__(self)
         self.cmd = command
         self.prog = command.split(' ')[0]
 
@@ -311,7 +314,6 @@ def oracle_tests_run(tests_queue, port_queue, res_queue, is_finish, verbose):
                 test_dir = C2T_TEST_DIR
             )
         )
-        gdbserver.daemon = True
         gdbserver.start()
 
         if not wait_for_tcp_port(gdbserver_port):
@@ -349,7 +351,6 @@ def run_qemu(test_elf, qemu_port, qmp_port, verbose):
         print(cmd)
 
     qemu = ProcessWithErrCatching(cmd)
-    qemu.daemon = True
     qemu.start()
     return qemu
 

--- a/c2t.py
+++ b/c2t.py
@@ -564,9 +564,8 @@ def start_cpu_testing(tests, jobs, reuse, verbose):
         target_trp.start()
 
     dc = DebugComparator(res_queue, jobs, c2t_cfg.rsp_target.test_timeout)
-    try:
-        dc.start()
-    except RuntimeError:
+    for err in dc.start():
+        print(err)
         killpg(0, SIGKILL)
 
     oracle_tb.join()

--- a/c2t.py
+++ b/c2t.py
@@ -39,6 +39,9 @@ from psutil import (
 from threading import (
     Thread
 )
+from traceback import (
+    print_exc
+)
 from six.moves.queue import (
     Empty
 )
@@ -121,6 +124,48 @@ class DebugSession(object):
         self.queue = queue
         self.reset(srcfile, elffile)
         self.session_type = None
+
+    def run(self, timeout):
+        """ Run the testing through the debug session.
+
+:returns: was timeout expired
+        """
+        # RSP.run is blocking. Running it in a dedicated thread allows to
+        # stop it after a timeout.
+
+        t = Thread(
+            name = "RSP-" + self.session_type + "-" + str(self.port),
+            target = self.thread_main
+        )
+        t.start()
+        t.join(timeout = timeout)
+
+        timeout_expired = t.is_alive()
+
+        if timeout_expired:
+            self._handling_timeout = True
+            # Closing the socket will result in `RSP.run` failure in the
+            # `t`hread soon.
+            self.port_close()
+            t.join()
+
+            self._handling_timeout = False
+
+        return timeout_expired
+
+    def thread_main(self):
+        queue = self.queue
+        queue.put((self.session_type, self.srcfile, "TEST_RUN"))
+        try:
+            self.main()
+        except:
+            if self._handling_timeout:
+                queue.put((self.session_type, self.srcfile, "TEST_TIMEOUT"))
+            else:
+                # TODO: pass session error to `queue`
+                print_exc()
+        else:
+            queue.put((self.session_type, self.srcfile, "TEST_END"))
 
     def reset(self, srcfile, elffile):
         self.srcfile = srcfile
@@ -249,7 +294,7 @@ class OracleSession(DebugSession):
         super(OracleSession, self).__init__(*args)
         self.session_type = "oracle"
 
-    def run(self):
+    def main(self):
         self._execute_debug_comment()
         self.rt.target.run(setpc = False)
 
@@ -268,7 +313,7 @@ class TargetSession(DebugSession):
         for data, addr in loading:
             self.rt.target.store(data, addr)
 
-    def run(self):
+    def main(self):
         self._execute_debug_comment()
         if not c2t_cfg.rsp_target.user:
             self.load()
@@ -327,7 +372,9 @@ class ProcessWithErrCatching(Thread):
         self.join()
 
 
-def oracle_tests_run(tests_queue, port_queue, res_queue, is_finish, verbose):
+def oracle_tests_run(tests_queue, port_queue, res_queue, is_finish, verbose,
+    timeout
+):
     while True:
         try:
             test_src, test_elf = tests_queue.get(timeout = 0.1)
@@ -355,15 +402,12 @@ def oracle_tests_run(tests_queue, port_queue, res_queue, is_finish, verbose):
             str(gdbserver_port), test_elf, res_queue, verbose
         )
 
-        res_queue.put((session.session_type, test_src, "TEST_RUN"))
-
-        session.run()
-
-        res_queue.put((session.session_type, test_src, "TEST_END"))
-
-        session.kill()
-        gdbserver.join()
-        session.port_close()
+        if session.run(timeout):
+            gdbserver.wipe()
+        else:
+            session.kill()
+            gdbserver.join()
+            session.port_close()
 
     res_queue.put(("oracle", None, "TEST_EXIT"))
 
@@ -388,7 +432,7 @@ def run_qemu(test_elf, qemu_port, qmp_port, verbose):
 
 
 def target_tests_run(tests_queue, port_queue, res_queue, is_finish, reuse,
-    verbose
+    verbose, timeout
 ):
     qemu = None
     session = None
@@ -439,16 +483,17 @@ def target_tests_run(tests_queue, port_queue, res_queue, is_finish, reuse,
                 )
                 qmp("system_reset")
 
-            res_queue.put((session.session_type, test_src, "TEST_RUN"))
+            if session.run(timeout):
+                qemu.wipe()
 
-            session.run()
-
-            res_queue.put((session.session_type, test_src, "TEST_END"))
-
-            if not reuse:
-                session.kill()
-                qemu.join()
-                session.port_close()
+                # Qemu has been terminated and cannot be reused
+                session = None
+                qmp = None
+            else:
+                if not reuse:
+                    session.kill()
+                    qemu.join()
+                    session.port_close()
 
 
 class FreePortFinder(Process):
@@ -546,18 +591,20 @@ def start_cpu_testing(tests, jobs, reuse, verbose, errors2stop = 1):
     if jobs > len(tests):
         jobs = len(tests)
 
+    timeout = float(c2t_cfg.rsp_target.test_timeout)
+
     tests_run_processes = []
     for i in range(0, jobs):
         oracle_trp = Process(
             target = oracle_tests_run,
             args = [oracle_tests_queue, port_queue, res_queue,
-                is_finish_oracle, verbose
+                is_finish_oracle, verbose, timeout
             ]
         )
         target_trp = Process(
             target = target_tests_run,
             args = [target_tests_queue, port_queue, res_queue,
-                is_finish_target, reuse, verbose
+                is_finish_target, reuse, verbose, timeout
             ]
         )
         tests_run_processes.append((oracle_trp, target_trp))
@@ -567,7 +614,7 @@ def start_cpu_testing(tests, jobs, reuse, verbose, errors2stop = 1):
     # Tests we are waiting for
     tests_left = set(tests)
 
-    dc = DebugComparator(res_queue, jobs, c2t_cfg.rsp_target.test_timeout)
+    dc = DebugComparator(res_queue, jobs)
     for err in dc.start():
         test = relpath(err.test, C2T_TEST_DIR)
         tests_left.discard(test)

--- a/c2t.py
+++ b/c2t.py
@@ -279,17 +279,20 @@ class TargetSession(DebugSession):
 
 class ProcessWithErrCatching(Thread):
 
-    def __init__(self, command):
+    def __init__(self, *popen_args, **popen_kw):
         Thread.__init__(self)
-        self.cmd = command
-        self.prog = command.split(' ')[0]
+
+        popen_kw.setdefault("shell", True)
+        popen_kw["stdout"] = popen_kw["stderr"] = PIPE
+
+        self.popen_args = popen_args
+        self.popen_kw = popen_kw
+
+        cmd = popen_args[0]
+        self.prog = cmd.split(' ')[0] if isinstance(cmd, str) else cmd[0]
 
     def run(self):
-        process = Popen(self.cmd,
-            shell = True,
-            stdout = PIPE,
-            stderr = PIPE
-        )
+        process = Popen(*self.popen_args, **self.popen_kw)
         _, err = process.communicate()
         if process.returncode != 0:
             c2t_exit(err, prog = self.prog)

--- a/c2t/debug_cmp.py
+++ b/c2t/debug_cmp.py
@@ -62,7 +62,7 @@ comparison report
             )
         )
 
-    def _print_report(self, msg, dump):
+    def _format_report(self, msg, dump):
         report = msg
 
         for key, val in dump.items():
@@ -80,7 +80,10 @@ comparison report
                     regs = self._prepare_regs4print(val["regs"])
                 )
             )
-        print(report)
+        return report
+
+    def _print_report(self, *a, **kw):
+        print(self._format_report(*a, **kw))
 
     def compare(self, test, sender, dump, cmp_sender, cmp_dump):
         if dump["lineno"] != cmp_dump["lineno"]:

--- a/c2t/debug_cmp.py
+++ b/c2t/debug_cmp.py
@@ -143,8 +143,14 @@ comparison report
                 self.end -= 1
             elif dump == "TEST_RUN" and cmp_dump == "TEST_RUN":
                 print("%s: RUN" % test)
-            elif dump == "TEST_END" and cmp_dump == "TEST_END":
-                print("%s: OK" % test)
+            elif dump == "TEST_END":
+                if dump == cmp_dump:
+                    print("%s: OK" % test)
+                else:
+                    yield TestMismatch(test, sender + " ended earlier")
+            elif cmp_dump == "TEST_END":
+                # dump != "TEST_END"
+                yield TestMismatch(test, cmp_sender + " ended earlier")
             else:
                 for res in self.compare(test, sender, dump, cmp_sender,
                     cmp_dump

--- a/c2t/debug_cmp.py
+++ b/c2t/debug_cmp.py
@@ -10,9 +10,6 @@ from collections import (
     defaultdict,
     deque
 )
-from time import (
-    time
-)
 from six.moves.queue import (
     Empty
 )
@@ -28,10 +25,9 @@ class DebugComparator(object):
 comparison report
     """
 
-    def __init__(self, dump_queue, count, timeout):
+    def __init__(self, dump_queue, count):
         self.end = count
         self.dump_queue = dump_queue
-        self.timeout = timeout
 
     @staticmethod
     def _format_variables(_vars):
@@ -114,17 +110,15 @@ comparison report
         """ Start debug comparison """
         oracle_dump_cache = defaultdict(deque)
         target_dump_cache = defaultdict(deque)
-        tests_timings = {}
 
         while self.end:
-            for test, start in tuple(tests_timings.items()):
-                if time() - start > self.timeout:
-                    tests_timings.pop(test)
-                    yield TestTimeout(test)
-
             try:
                 sender, test, dump = self.dump_queue.get(timeout = 0.1)
             except Empty:
+                continue
+
+            if dump == "TEST_TIMEOUT":
+                yield TestTimeout(test)
                 continue
 
             if sender == "oracle":
@@ -148,10 +142,8 @@ comparison report
             if dump == "TEST_EXIT" and cmp_dump == "TEST_EXIT":
                 self.end -= 1
             elif dump == "TEST_RUN" and cmp_dump == "TEST_RUN":
-                tests_timings[test] = time()
                 print("%s: RUN" % test)
             elif dump == "TEST_END" and cmp_dump == "TEST_END":
-                tests_timings.pop(test)
                 print("%s: OK" % test)
             else:
                 for res in self.compare(test, sender, dump, cmp_sender,


### PR DESCRIPTION
Allows to get many failures per launch.

### v3:
- remove unused `time` import
- fix typos

### v2:
- more clean timeout handling