### PR TITLE
Remove `TypeReference`s

### DIFF
--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -343,7 +343,7 @@ class CPUType(QOMCPU):
                 graphs_prefix = None
 
             with open(path, mode = "wb", encoding = "utf-8") as f_writer:
-                sf = f.generate(inherit_references = isinstance(f, Header))
+                sf = f.generate()
 
                 yield True
 

--- a/qemu/project.py
+++ b/qemu/project.py
@@ -193,11 +193,7 @@ class QProject(object):
 
             yield True
 
-            # TODO: current value of inherit_references is dictated by Qemu
-            # coding policy. Hence, version API must be used there.
-            inherit_references = type(s) is Header
-
-            f = s.generate(inherit_references = inherit_references)
+            f = s.generate()
 
             if intermediate_chunk_graphs:
                 graphs_prefix = spath + ".chunks"

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -69,7 +69,6 @@ from ..c_const import (
 )
 from ..model import (
     Type,
-    TypeReference,
     Pointer,
     Macro,
     NodeVisitor,
@@ -693,7 +692,7 @@ class OpSDeref(Operator):
         _type = value.type
 
         struct = _type
-        while isinstance(struct, (Pointer, TypeReference)):
+        while isinstance(struct, Pointer):
             struct = struct.type
 
         if OPSDEREF_FROM_DEFINITION:

--- a/source/model.py
+++ b/source/model.py
@@ -271,36 +271,6 @@ class TypeReference(Type):
     def get_definers(self):
         return self.type.get_definers()
 
-    def gen_chunks(self, generator):
-        if self.definer_references is None:
-            raise RuntimeError("Attempt to generate chunks for reference to"
-                " type %s without the type reference adjusting"
-                " pass." % self
-            )
-
-        definer = self.type.definer
-
-        refs = []
-        for r in self.definer_references:
-            chunks = generator.provide_chunks(r)
-
-            if not chunks:
-                continue
-
-            # not only `HeaderInclusion` can satisfies reference
-            if isinstance(chunks[0], HeaderInclusion):
-                chunks[0].add_reason(r, kind = "satisfies %s by" % definer)
-
-            refs.extend(chunks)
-
-        if definer is CPP:
-            return refs
-        else:
-            inc = HeaderInclusion(definer)
-            inc.add_references(refs)
-            inc.add_reason(self.type)
-            return [inc]
-
     def gen_var(self, *args, **kw):
         raise ValueError("Attempt to generate variable of type %s"
             " using a reference" % self.type

--- a/source/model.py
+++ b/source/model.py
@@ -693,7 +693,6 @@ class Function(Type):
             inline = inline,
             used_types = used_types
         )
-        CopyFixerVisitor(new_f).visit()
         return new_f
 
     def gen_definition(self,
@@ -711,7 +710,6 @@ class Function(Type):
             used_types = used_types,
             used_globals = used_globals
         )
-        CopyFixerVisitor(new_f).visit()
         new_f.declaration = self
         return new_f
 
@@ -1240,27 +1238,6 @@ class Variable(object):
 
 
 # Type inspecting
-
-
-class CopyFixerVisitor(TypeReferencesVisitor):
-    """
-    CopyFixerVisitor is now used for true copying function body arguments
-    in order to prevent wrong TypeReferences among them
-    because before function prototype and body had the same args
-    references (in terms of python references)
-    """
-
-    def on_visit(self):
-        t = self.cur
-
-        if (not isinstance(t, Type)
-            or (isinstance(t, (Pointer, MacroUsage)) and not t.is_named)
-        ):
-            new_t = copy(t)
-
-            self.replace(new_t, skip_trunk = False)
-        else:
-            raise BreakVisiting()
 
 
 def gen_function_decl_ref_chunks(function, generator):

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -1,7 +1,6 @@
 __all__ = [
     "disable_auto_lock_sources"
   , "enable_auto_lock_sources"
-  , "AddTypeRefToDefinerException"
   , "Source"
       , "Header"
   , "SourceFile"
@@ -99,10 +98,6 @@ OPTIMIZE_INCLUSIONS = ee("QDT_OPTIMIZE_INCLUSIONS", "True")
 # Skip global headers inclusions. All needed global headers included in
 # "qemu/osdep.h".
 SKIP_GLOBAL_HEADERS = ee("QDT_SKIP_GLOBAL_HEADERS", "True")
-
-
-class AddTypeRefToDefinerException(RuntimeError):
-    pass
 
 
 class Source(object):

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -430,15 +430,6 @@ class TypeFixerVisitor(TypeReferencesVisitor):
             if t.definer is self.source:
                 return
 
-            # Make TypeReference to declaration instead of definition:
-            # In a case when a declaration and a definition are in
-            # different files, it is necessary to include the file with
-            # the declaration
-            if isinstance(t, Function) and t.declaration is not None:
-                t = t.declaration
-                if type(t) is TypeReference:
-                    t = t.type
-
             # A type defined inside another type is not subject of this fixer.
             # Because internal type is always defined within its container and,
             # hence, never defined by a header inclusion or directly by a
@@ -885,6 +876,17 @@ class ChunkGenerator(object):
         current_references = current.references
 
         foreign_type = type_ref.type
+
+        # In a case when declaration and definition of a function are in
+        # different files, it is necessary to include the file with
+        # the declaration.
+        if (    isinstance(foreign_type, Function)
+            and foreign_type.declaration is not None
+        ):
+            foreign_type = foreign_type.declaration
+            if type(foreign_type) is TypeReference:
+                foreign_type = foreign_type.type
+
         if foreign_type in current_references:
             return []
 

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -62,7 +62,7 @@ class SourceModelTestHelper(object):
         for file_, content in self.files:
             kw = {}
             if isinstance(file_, Header):
-                kw["inherit_references"] = self.inherit_references
+                file_.inherit_references = self.inherit_references
             sf = file_.generate(**kw)
 
             if SAVE_CHUNK_GRAPH:


### PR DESCRIPTION
First patches do some refactoring for final code to be more pretty.
"source: remove `TypeReference`" does the main things.
Last patch does some cleanup.

### v2
- remove `AddTypeRefToDefinerException`
- remove unused imports from "source/source_file.py"
- fixup `TestReferencingToTypeInAnotherHeader` by adding foreign types to
  to `Source`'s `types` registry.
- `TypeFixerVisitor` breaks on first foreign type (previously it stopped on
  a `TypeReference`).
- some refactoring
- fixup typos