### PR TITLE
Foreign types and variables in `extra_references` attribute

### DIFF
--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -75,6 +75,9 @@ from ..model import (
     Function,
     Variable
 )
+from ..type_container import (
+    TypeContainer,
+)
 from common import (
     ee,
     BreakVisiting,
@@ -102,7 +105,7 @@ class DeclarationSearcher(NodeVisitor):
             raise BreakVisiting()
 
 
-class Node(object):
+class Node(TypeContainer):
 
     # traverse order indicator for `ObjectVisitor`
     __node__ = ("children",)
@@ -114,6 +117,8 @@ class Node(object):
         indent_children = True,
         children = []
     ):
+        super(Node, self).__init__()
+
         self.val = val
         self.new_line = new_line
         self.indent_children = indent_children
@@ -214,7 +219,7 @@ class MacroBranch(Node):
     """ MacroBranch describes construction like MACRO(x, y) { ... } """
 
     __node__ = ("children", "macro_call")
-    __type_references__ = __node__
+    __type_references__ = ("macro_call",)
 
     def __init__(self, macro_call):
         super(MacroBranch, self).__init__()
@@ -230,7 +235,7 @@ class MacroBranch(Node):
 class LoopWhile(CNode):
 
     __node__ = ("children", "cond")
-    __type_references__ = __node__
+    __type_references__ = ("cond",)
 
     def __init__(self, cond):
         super(LoopWhile, self).__init__()
@@ -247,7 +252,7 @@ class LoopWhile(CNode):
 class LoopDoWhile(CNode):
 
     __node__ = ("children", "cond")
-    __type_references__ = __node__
+    __type_references__ = ("cond",)
 
     def __init__(self, cond):
         super(LoopDoWhile, self).__init__()
@@ -264,7 +269,7 @@ class LoopDoWhile(CNode):
 class LoopFor(CNode):
 
     __node__ = ("children", "init", "cond", "step")
-    __type_references__ = __node__
+    __type_references__ = ("init", "cond", "step")
 
     def __init__(self, init = None, cond = None, step = None):
         super(LoopFor, self).__init__()
@@ -292,7 +297,7 @@ class LoopFor(CNode):
 class BranchIf(CNode):
 
     __node__ = ("children", "cond", "else_blocks")
-    __type_references__ = __node__
+    __type_references__ = ("cond", "else_blocks")
 
     def __init__(self, cond):
         super(BranchIf, self).__init__()
@@ -327,7 +332,7 @@ class BranchElse(CNode):
     """ BranchElse must be added to parent BranchIf node using `add_else`. """
 
     __node__ = ("children", "cond")
-    __type_references__ = __node__
+    __type_references__ = ("cond",)
 
     def __init__(self, cond = None):
         super(BranchElse, self).__init__()
@@ -346,7 +351,7 @@ class BranchElse(CNode):
 class BranchSwitch(CNode):
 
     __node__ = ("children", "var")
-    __type_references__ = __node__
+    __type_references__ = ("var",)
 
     def __init__(self, var,
         add_break_in_default = True,
@@ -600,7 +605,7 @@ class Declare(SemicolonPresence):
 
 class MCall(SemicolonPresence):
 
-    __type_references__ = ("children", "type")
+    __type_references__ = ("type",)
 
     def __init__(self, macro, *args):
         super(MCall, self).__init__(children = args)
@@ -677,7 +682,7 @@ class OpIndex(Operator):
 
 class OpSDeref(Operator):
 
-    __type_references__ = Operator.__type_references__ + ("struct",)
+    __type_references__ = ("struct",)
 
     def __init__(self, value, field):
         super(OpSDeref, self).__init__(value)
@@ -765,7 +770,7 @@ class OpPreInc(UnaryOperator):
 
 class OpCast(UnaryOperator):
 
-    __type_references__ = ("children", "type")
+    __type_references__ = ("type",)
 
     def __init__(self, type_name, arg):
         super(OpCast, self).__init__("(" + type_name + ")", arg)

--- a/source/model.py
+++ b/source/model.py
@@ -453,14 +453,17 @@ class Structure(Type):
             return definition.fields
 
     @property
-    def __type_references__(self):
+    def _fields_tr(self):
+        "Fields for type references analysis."
         if self._definition is None:
             # It's a definition. A forward declaration cannot have fields.
             # Hence, all fields are in _and only in_ `self._fields`.
             # And the `property`s logic is not required for this case.
-            return ["_fields"]
+            return self._fields
         else:
             return []
+
+    __type_references__ = ["_fields_tr"]
 
     def __c__(self, writer):
         writer.write(self.c_name)

--- a/source/model.py
+++ b/source/model.py
@@ -1122,8 +1122,6 @@ class Initializer(object):
         self.used_types = set(used_types)
         self.used_variables = used_variables
         if isinstance(code, dict):
-            self.__type_references__ = self.__type_references__ + ["code"]
-
             # automatically get types used in the code
             self.used_types.update(TypesCollector(code).visit().used_types)
 
@@ -1142,7 +1140,8 @@ class Initializer(object):
 
         return val_str
 
-    __type_references__ = ["used_types", "used_variables"]
+    # Note, if `code` is a `str`ing, the type analysis just ignore it.
+    __type_references__ = ["used_types", "used_variables", "code"]
 
 
 class Variable(object):

--- a/source/model.py
+++ b/source/model.py
@@ -61,6 +61,9 @@ from .chunks import (
     FunctionDefinition,
     OpaqueChunk,
 )
+from .type_container import (
+    TypeContainer,
+)
 
 
 # List of coding style specific code generation settings.
@@ -113,7 +116,7 @@ class TypeNotRegistered(RuntimeError):
 
 
 @add_metaclass(registry)
-class Type(object):
+class Type(TypeContainer):
     reg = {}
 
     @staticmethod
@@ -137,6 +140,8 @@ class Type(object):
         incomplete = True,
         base = False
     ):
+        super(Type, self).__init__()
+
         self.is_named = name is not None
 
         self.incomplete = incomplete
@@ -598,9 +603,11 @@ class EnumerationElement(Type):
     __type_references__ = ["initializer"]
 
 
-class FunctionBodyString(object):
+class FunctionBodyString(TypeContainer):
 
     def __init__(self, body = None, used_types = None, used_globals = None):
+        super(FunctionBodyString, self).__init__()
+
         self.body = body
         self.used_types = set() if used_types is None else set(used_types)
         self.used_globals = [] if used_globals is None else list(used_globals)
@@ -1057,7 +1064,7 @@ class TypeReferencesVisitor(ObjectVisitor):
 
     def __init__(self, root):
         super(TypeReferencesVisitor, self).__init__(root,
-            field_name = "__type_references__"
+            field_name = "__type_attributes__"
         )
 
 
@@ -1117,10 +1124,12 @@ class ForwardDeclarator(TypeReferencesVisitor):
             self.replace(decl)
 
 
-class Initializer(object):
+class Initializer(TypeContainer):
 
     # code is string for variables and dictionary for macros
     def __init__(self, code, used_types = [], used_variables = []):
+        super(Initializer, self).__init__()
+
         self.code = code
         self.used_types = set(used_types)
         self.used_variables = used_variables
@@ -1147,7 +1156,7 @@ class Initializer(object):
     __type_references__ = ["used_types", "used_variables", "code"]
 
 
-class Variable(object):
+class Variable(TypeContainer):
 
     def __init__(self, name, _type,
         initializer = None,
@@ -1156,6 +1165,8 @@ class Variable(object):
         array_size = None,
         used = False
     ):
+        super(Variable, self).__init__()
+
         self.name = name
         self.type = _type if isinstance(_type, Type) else Type[_type]
         self.initializer = initializer

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -752,7 +752,9 @@ class ChunkGenerator(object):
                             chunks = self.chunk_cache[declarer]
                         except KeyError:
                             chunks = [
-                                HeaderInclusion(declarer).add_reason(origin)
+                                HeaderInclusion(declarer).add_reason(origin,
+                                    kind = "declares"
+                                )
                             ]
                     else:
                         # A variable in a header does always have `extern`

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -62,6 +62,9 @@ from .model import (
 from .tools import (
     get_cpp_search_paths,
 )
+from .type_container import (
+    TypeContainer,
+)
 with pypath("..ply"):
     # PLY`s C preprocessor is used for several QEMU code analysis
     from ply.lex import (
@@ -100,12 +103,14 @@ OPTIMIZE_INCLUSIONS = ee("QDT_OPTIMIZE_INCLUSIONS", "True")
 SKIP_GLOBAL_HEADERS = ee("QDT_SKIP_GLOBAL_HEADERS", "True")
 
 
-class Source(object):
+class Source(TypeContainer):
 
     # Only header can do it, see `Header`.
     inherit_references = False
 
     def __init__(self, path, locked = None):
+        super(Source, self).__init__()
+
         self.path = path
         self.types = {}
         self.inclusions = {}

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -742,6 +742,12 @@ class ChunkGenerator(object):
 
                     if foreign:
                         declarer = origin.declarer
+                        if declarer is None:
+                            raise RuntimeError("Variable '%s' is only defined"
+                                " in '%s' but not declared in any header" % (
+                                    origin, origin.definer.path
+                                )
+                            )
                         try:
                             chunks = self.chunk_cache[declarer]
                         except KeyError:

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -813,11 +813,19 @@ class ChunkGenerator(object):
             else:
                 chunks = origin.gen_defining_chunk_list(self, **kw)
 
+            # All chunks of the `origin` has been generated at this point.
             self.stack.pop()
 
             # Note that conversion to a tuple is performed to prevent further
             # modifications of chunk list.
             self.chunk_cache[key] = tuple(chunks)
+
+            # Some `TypeContainer`'s can require extra types when the model is
+            # not suitable enough.
+            if not foreign:
+                for ref in origin.extra_references:
+                    # Assume that first chunk is "main".
+                    chunks[0].add_references(self.provide_chunks(ref))
         else:
             if isinstance(origin, Type) and foreign:
                 if chunks:

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -1078,6 +1078,7 @@ digraph Chunks {
 
     def add_chunk(self, chunk):
         if chunk.source is None:
+            chunk.source = self
             self.sort_needed = True
             self.chunks.add(chunk)
 

--- a/source/type_container.py
+++ b/source/type_container.py
@@ -1,0 +1,47 @@
+__all__ = (
+    "TypeContainer",
+)
+
+from common import (
+    lazy,
+)
+from inspect import (
+    getmro,
+)
+
+
+class TypeContainer(object):
+    """ A superclass for everything that can contain `Type`s or
+`TypeContainer`s in its attributes.
+
+It accounts `__type_references__` attribute in entire inheritance chain.
+
+Extra references may be used to apply extended (semantic) order when syntax
+order does not meet all requirements.
+    """
+
+    def __init__(self):
+        self.extra_references = set()
+
+    __type_references__ = ("extra_references",)
+
+    @lazy
+    def __type_attributes__(self):
+        return type_referencing_attributes(type(self))
+
+
+def type_referencing_attributes(cls, cache = {}):
+    try:
+        ret = cache[cls]
+    except KeyError:
+        ret = cache[cls] = tuple(iter_type_referencing_attributes(cls))
+    return ret
+
+
+# TODO: there are too many `EMPTY` constants in the project already...
+EMPTY = tuple()
+
+def iter_type_referencing_attributes(cls):
+    for superclass in getmro(cls):
+        for t in superclass.__dict__.get("__type_references__", EMPTY):
+            yield t

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -862,6 +862,8 @@ class TestOpaqueCode(SourceModelTestHelper, TestCase):
             opaque_top
         ])
 
+        hdr.add_global_variable(test_var)
+
         hdr_content = """\
 /* {path} */
 


### PR DESCRIPTION
This series of patches adds the ability to use types and variables from other modules as extra dependencies.

### v3
- the local variable chunks generation attempt error message: Try -> Attempt
- clarify comments

### v2
- Improve variables chunk generation in `ChunkGenerator.provide_chunks`.
- Properly register global variable in `TestOpaqueCode` test.

### v1.1
- Fix the bug with duplicating entries in `TypeContainer.__type_attributes__`
  resulting in too slow operation on real projects.
- `ChunkGenerator.provide_chunks` pops `stack` before `extra_references` processing.
  That fixes incorrect behavior of "main" `if` block of that method which depends ot `stack`
  during recursive calls.
- Squash some `extra_references` processing patches.
- Optimize `TypeContainer`.