### PR TITLE
MSP430 example

### DIFF
--- a/c2t/tests/a_add_8_2.c
+++ b/c2t/tests/a_add_8_2.c
@@ -1,0 +1,14 @@
+/* Arithmetic instruction */
+
+#include <stdint.h>
+
+void main(void)
+{
+    volatile int8_t a = 0x4e, *b, c;
+    b = &a;
+
+    c = a + *b;
+    c = 0;     //$ch.c
+
+    return;    //$bre
+}

--- a/c2t/tests/a_add_bcd_u16_1.c
+++ b/c2t/tests/a_add_bcd_u16_1.c
@@ -1,0 +1,36 @@
+/* Arithmetic instruction */
+
+#include <stdint.h>
+
+#if __MSP430__ == 1
+#include "msp430.h"
+#else
+// https://stackoverflow.com/questions/29875541/binary-coded-decimal-addition-using-integer
+uint16_t median(uint16_t x, uint16_t y, uint16_t z)
+{
+    return (x & (y | z)) | (y & z);
+}
+
+uint16_t bcd_add_knuth(uint16_t x, uint16_t y)
+{
+    uint16_t z, u, t;
+    z = y + 0x6666;
+    u = x + z;
+    t = median(~x, ~z, u) & 0x8888;
+    return u - t + (t >> 2);
+}
+#endif
+
+void main(void)
+{
+    volatile uint16_t a = 0x1234, b = 0x3456, c;
+
+#if __MSP430__ == 1
+    c = __bcd_add_short(a, b);
+#else
+    c = bcd_add_knuth(a, b);
+#endif
+    c = 0;     //$ch.c
+
+    return;    //$bre
+}

--- a/c2t/tests/c_bit_jc_u16_1.c
+++ b/c2t/tests/c_bit_jc_u16_1.c
@@ -7,11 +7,11 @@ int main(void)
     volatile uint16_t a = 0x8, b = 0xaa, c;
 #if __MSP430__ == 1
     asm volatile goto (
-        "bit.w %[src], %[dst] \n\
+        "bit.w %[src_a], %[dst_b] \n\
          jc %l[label]"
         :
-        : [dst] "rm" (b),
-          [src] "rm" (a)
+        : [dst_b] "rm" (b),
+          [src_a] "rm" (a)
         : "cc"
         : label
     );

--- a/c2t/tests/c_bit_jc_u8_1.c
+++ b/c2t/tests/c_bit_jc_u8_1.c
@@ -7,11 +7,11 @@ int main(void)
     volatile uint8_t a = 0x8, b = 0xaa, c;
 #if __MSP430__ == 1
     asm volatile goto (
-        "bit.b %[src], %[dst] \n\
+        "bit.b %[src_a], %[dst_b] \n\
          jc %l[label]"
         :
-        : [dst] "rm" (b),
-          [src] "rm" (a)
+        : [dst_b] "rm" (b),
+          [src_a] "rm" (a)
         : "cc"
         : label
     );

--- a/c2t/tests/c_cmp_jn_16_1.c
+++ b/c2t/tests/c_cmp_jn_16_1.c
@@ -1,0 +1,28 @@
+/* Control flow instruction */
+
+#include <stdint.h>
+
+int main(void)
+{
+    volatile int16_t a = 0x1234, b = 0x123, c;
+#if __MSP430__ == 1
+    asm volatile goto (
+        "cmp %[src_a], %[dst_b] \n\
+         jn %l[label]"
+        :
+        : [dst_b] "rm" (b),
+          [src_a] "rm" (a)
+        : "cc"
+        : label
+    );
+#else
+    if (b - a < 0) {
+        goto label;
+    }
+#endif
+    c = a;  //$br
+label:
+    c = b;  //$br
+
+    return 0;   //$bre
+}

--- a/c2t/tests/c_loop_16_2.c
+++ b/c2t/tests/c_loop_16_2.c
@@ -1,0 +1,36 @@
+/* Control flow instruction */
+
+#include <stdint.h>
+
+volatile int16_t a[4] = {1, 2, 3, 0};
+
+void main(void)
+{
+    volatile int16_t c;
+    volatile int16_t *pa = a;
+
+#if __MSP430__ == 1
+    asm volatile (
+        "loop_start: cmp #0, @%[src_pa] \n\
+        jz loop_end \n\
+        add @%[src_pa]+, %[dst_c] \n\
+        jmp loop_start \n\
+        loop_end:"
+        : [dst_c] "=&r" (c)
+        : [src_pa] "r" (pa)
+        : "cc"
+    );
+#else
+loop_start:
+    if (*pa == 0) {
+        goto loop_end;
+    }
+    c += *(pa++);
+    goto loop_start;
+loop_end:
+#endif
+    c = 0; //$ch.c
+
+    return;    //$bre
+}
+

--- a/c2t/tests/c_loop_16_3.c
+++ b/c2t/tests/c_loop_16_3.c
@@ -1,0 +1,37 @@
+/* Control flow instruction */
+
+#include <stdint.h>
+
+volatile int16_t a[6] = {1, 2, 3, 4, 5, 0};
+
+void main(void)
+{
+    volatile int16_t *pa = a;
+    volatile int16_t c;
+
+#if __MSP430__ == 1
+    asm volatile (
+        "loop_start: cmp #0, @%[src_pa] \n\
+        jz loop_end \n\
+        rra @%[src_pa]+ \n\
+        jmp loop_start \n\
+        loop_end:"
+        :
+        : [src_pa] "r" (pa)
+        : "cc", "memory"
+    );
+#else
+loop_start:
+    if (*pa == 0) {
+        goto loop_end;
+    }
+    *(pa++) = *pa / 2;
+    goto loop_start;
+loop_end:
+#endif
+    c = a[3];
+    c = 0; //$ch.c
+
+    return;    //$bre
+}
+

--- a/c2t/tests/l_bic_16_1.c
+++ b/c2t/tests/l_bic_16_1.c
@@ -4,12 +4,12 @@
 
 int main(void)
 {
-    volatile int8_t a = 0x2a, b = 0x5, c;
+    volatile int16_t a = 0xedcb, b = 0x1234, c;
 
 #if __MSP430__ == 1
     asm volatile (
-        "mov.b %[src_b], %[dst_c] \n\
-         bic.b %[src_a], %[dst_c]"
+        "mov %[src_b], %[dst_c] \n\
+         bic %[src_a], %[dst_c]"
         : [dst_c] "=rm" (c)
         : [src_a] "rm" (a),
           [src_b] "rm" (b)

--- a/c2t/tests/l_bswap_u16_1.c
+++ b/c2t/tests/l_bswap_u16_1.c
@@ -1,0 +1,21 @@
+/* Logical instruction */
+
+#include <stdint.h>
+
+#if __MSP430__ == 1
+#include "msp430.h"
+#endif
+
+void main(void)
+{
+    volatile uint16_t a = 0x1234, c;
+
+#if __MSP430__ == 1
+    c = __swap_bytes(a);
+#else
+    c = ((a >> 8) & 0xFF) | ((a & 0xFF) << 8);
+#endif
+    c = 0;     //$ch.c
+
+    return;    //$bre
+}

--- a/common/cleaner.py
+++ b/common/cleaner.py
@@ -29,6 +29,9 @@ from six.moves.queue import (
 from os import (
     name as os_name
 )
+from six import (
+    PY2,
+)
 
 
 if os_name == "nt":
@@ -156,6 +159,20 @@ def get_cleaner(*default_args, **default_kw):
     if _current_cleaner is None:
         _current_cleaner = Cleaner(*default_args, **default_kw)
         _current_cleaner.start()
+
+        # XXX: rough hack for Windows that excludes the cleaner from the
+        # children of the current process.
+        if os_name == "nt":
+            if PY2:
+                from multiprocessing import (
+                    current_process
+                )
+                current_process()._children.discard(_current_cleaner)
+            else:
+                from multiprocessing.process import (
+                    _children
+                )
+                _children.discard(_current_cleaner)
 
     return _current_cleaner
 

--- a/common/port_pool.py
+++ b/common/port_pool.py
@@ -1,0 +1,81 @@
+__all__ = [
+    "PortPool"
+]
+
+from .pypath import (
+    pypath,
+)
+from collections import (
+    namedtuple,
+)
+from socket import (
+    socket,
+    AF_INET,
+    SOCK_STREAM,
+    SOL_SOCKET,
+    SO_REUSEADDR,
+)
+from threading import (
+    Lock,
+)
+# use ours pyrsp
+with pypath("..pyrsp"):
+    from pyrsp.utils import (
+        find_free_port,
+    )
+
+
+class PortPool(object):
+    """ Grabs TCP ports from OS on demand and distribute them across customers
+within the process.
+    """
+
+    MIN_PORT = 1024 # from user range
+    MAX_PORT = 65535
+
+    def __init__(self):
+        self.lock = Lock()
+        self.free_ports = []
+        # Free ports must remains ours.
+        # For that purposes we `bind`s `socket`s to them.
+        self.sockets = {}
+        self.next_port = self.MIN_PORT
+
+    def alloc_port(self):
+        with self.lock:
+            if self.free_ports:
+                port = self.free_ports.pop()
+                sock = self.sockets.pop(port)
+                sock.close()
+            else:
+                port = find_free_port(self.next_port)
+                while port is None:
+                    # block until a port become free
+                    port = find_free_port(self.MIN_PORT)
+
+                next_port = port + 1
+                if next_port > self.MAX_PORT:
+                    next_port = self.MIN_PORT
+
+                self.next_port = next_port
+            return port
+
+    def free_port(self, port):
+        with self.lock:
+            self.sockets[port] = s = socket(AF_INET, SOCK_STREAM)
+            s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+            s.bind(("localhost", port))
+            self.free_ports.append(port)
+
+    def __call__(self):
+        "Use as `with port_pool() as port:`"
+        return _PortLease(self, self.alloc_port())
+
+
+class _PortLease(namedtuple("_PortLease_", "pool port")):
+
+    def __enter__(self):
+        return self.port
+
+    def __exit__(self, *__):
+        self.pool.free_port(self.port)

--- a/common/shadow_open.py
+++ b/common/shadow_open.py
@@ -1,0 +1,40 @@
+__all__ = [
+    "shadow_open"
+]
+
+from codecs import (
+    open
+)
+from contextlib import (
+    contextmanager
+)
+from os.path import (
+    isfile
+)
+from six import (
+    StringIO
+)
+
+
+@contextmanager
+def shadow_open(filename):
+    """ This context manager prevents the file from being overwritten with the
+same content.
+    """
+
+    if isfile(filename):
+        writer = StringIO()
+        yield writer
+
+        new_data = writer.getvalue().encode("utf-8")
+
+        with open(filename, mode = "rb") as f:
+            old_data = f.read()
+
+        if old_data != new_data:
+            with open(filename, mode = "wb") as f:
+                f.write(new_data)
+    else:
+        f = open(filename, mode = "wb", encoding = "utf-8")
+        yield f
+        f.close()

--- a/common/thread_stream_copier.py
+++ b/common/thread_stream_copier.py
@@ -1,0 +1,83 @@
+__all__ = [
+    "ThreadStreamCopier"
+]
+
+from collections import (
+    namedtuple,
+)
+from threading import (
+    current_thread,
+    Lock,
+)
+
+
+class ThreadStreamCopier(object):
+    """ A stream wrapper that can copy data originated from different
+threads to different streams. Wrapped stream is also given the data.
+    """
+
+    def __init__(self, stream):
+        self.stream = stream
+        self.thread_streams = {} # Thread -> stream
+        self._lock = Lock()
+
+    def write(self, *a):
+        with self._lock:
+            self.stream.write(*a)
+            try:
+                thread_stream = self.thread_streams[current_thread()]
+            except KeyError:
+                pass
+            else:
+                thread_stream.write(*a)
+
+    def flush(self, *a):
+        with self._lock:
+            self.stream.flush(*a)
+            try:
+                thread_stream = self.thread_streams[current_thread()]
+            except KeyError:
+                pass
+            else:
+                thread_stream.flush(*a)
+
+    def __setitem__(self, thread, stream):
+        self.thread_streams[thread] = stream
+
+    def __getitem__(self, thread):
+        return self.thread_streams[thread]
+
+    def __delitem__(self, thread):
+        del self.thread_streams[thread]
+
+    def __contains__(self, thread):
+        return thread in self.thread_streams
+
+    def __call__(self, stream):
+        "Use as `with copier(stream):`"
+        return _CopyContext(self, current_thread(), stream)
+
+    @classmethod
+    def catch_stdout(cls):
+        import sys
+        copier = ThreadStreamCopier(sys.stdout)
+        sys.stdout = copier
+        return copier
+
+    def release_stdout(self):
+        import sys
+        sys.stdout = self.stream
+
+
+class _CopyContext(namedtuple("_CopyContext_", "copier thread stream")):
+
+    def __enter__(self):
+        copier, thread, stream = self
+        assert thread not in copier
+        copier[thread] = stream
+        return self
+
+    def __exit__(self, *__):
+        copier, thread, stream = self
+        assert copier[thread] is stream
+        del copier[thread]

--- a/examples/MSP430/msp430/config_msp430g2553.py
+++ b/examples/MSP430/msp430/config_msp430g2553.py
@@ -1,0 +1,102 @@
+from os import (
+    environ
+)
+from os.path import (
+    join
+)
+
+try:
+    TOOLCHAIN = environ["MSP430_TOOLCHAIN"]
+except:
+    print("""MSP430_TOOLCHAIN environment variable should point to folder \
+with compiler toolchain. Ex. /home/user/msp430-gcc-7.3.2.154_linux64.
+Toolchain available at: \
+http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/6_1_1_0/\
+index_FDS.html"""
+    )
+    raise
+
+try:
+    SUPPORT = environ["MSP430_SUPPORT"]
+except:
+    print("""MSP430_SUPPORT environment variable should point to folder with \
+headers. Ex. /home/user/msp430-gcc-support-files.
+Support files available at: \
+http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/6_1_1_0/\
+exports/msp430-gcc-support-files-1.207.zip"""
+    )
+    raise
+
+try:
+    QEMU = environ["MSP430_QEMU"]
+except:
+    print("""MSP430_QEMU environment variable should point to Qemu binaries. \
+Ex. /home/user/qemu/bin/qemu-system-msp430.
+Qemu MSP430 available on github: \
+https://github.com/dimas3452/qemu/tree/target-msp430"""
+    )
+    raise
+
+QLOG = bool(eval(environ.get("MSP430_QEMU_LOG", "False")))
+
+"""
+Test selection args:
+
+-t ^.+\\.c$
+
+-s ^_readme_.*$
+Because some breakpoints have multiple adresses and that confuses c2t.
+
+-s ^.*m_stack_u?((32)|(64)).*$
+Because machine have only 512 bytes of RAM.
+There is 50 variables & 50 function
+arguments. Each 4 bytes (8 bytes in 64 tests). Total 400 bytes (theoretically).
+Compiller generates the code of `main` that using 23Ch bytes of stack, it's
+572 bytes...
+
+"""
+
+qemu_args = "-M msp430_test -S -gdb tcp:localhost:{port} -nographic"
+if QLOG:
+    qemu_args += " -singlestep -d in_asm,cpu,exec -D {bin}.qlog"
+
+c2t_cfg = C2TConfig(
+    rsp_target = DebugClient(
+        march = "msp430g2553",
+        new_rsp = get_new_rsp(
+            regs = list("r%d" % i for i in range(16)),
+            pc = "r0",
+            regsize = 16
+        ),
+        # Some tests run long enough.
+        test_timeout = 40.,
+        sp = "r1"
+    ),
+    qemu = DebugServer(
+        Run(
+            executable = QEMU,
+            args = qemu_args
+        )
+    ),
+    gdbserver = DebugServer(Run(
+            executable = "/usr/bin/gdbserver",
+            args = "localhost:{port} {bin}"
+    )),
+    target_compiler = TestBuilder(
+        Run(
+            executable = join(TOOLCHAIN, "bin", "msp430-elf-gcc"),
+            args = "-I{0} -L{0} -mmcu=msp430g2553 -g -O0"
+                " -o {{bin}} {{src}}".format(join(SUPPORT, "include"))
+        ),
+        Run(
+            executable = join(TOOLCHAIN, "bin", "msp430-elf-objdump"),
+            args = "-D {bin} > {ir}.disas"
+        )
+    ),
+    oracle_compiler = TestBuilder(
+        Run(
+            executable = "/usr/bin/gcc",
+            args = "-g -O0 {src} -o {bin} -no-pie"
+        )
+    )
+)

--- a/examples/MSP430/msp430/msp430_project.py
+++ b/examples/MSP430/msp430/msp430_project.py
@@ -1,0 +1,179 @@
+msp430 = CPUDescription(
+    name = "msp430",
+    directory = "msp430",
+    target_bigendian = False,
+    target_long_bits = 0x20,
+    target_page_bits = 0x8,
+    target_phys_addr_space_bits = 0x20,
+    target_virt_addr_space_bits = 0x20,
+    nb_mmu_modes = 0x1,
+    info_path = "msp430_sem.py"
+)
+
+msp430_hwm = SysBusDeviceDescription(
+    name = "MSP430 HWM",
+    directory = "msp430-all",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'MPY', reset = None, full_name = '16-bit operand one - multiply'),
+            Register(2, name = 'MPYS', reset = None, full_name = '16-bit operand one - signed multiply'),
+            Register(2, name = 'MAC', reset = None, full_name = '16-bit operand one - multiply accumulate'),
+            Register(2, name = 'MACS', reset = None, full_name = '16-bit operand one - signed multiply accumulate'),
+            Register(2, name = 'OP2', reset = None, full_name = '16-bit operand two'),
+            Register(2, name = 'RESLO', reset = None, full_name = '16x16-bit result low word'),
+            Register(2, name = 'RESHI', reset = None, full_name = '16x16-bit result high word'),
+            Register(2, name = 'SUMEXT', access = 'r', reset = None, full_name = '16x16-bit sum extension register'),
+            Register(2, name = 'MPY32L', reset = None, full_name = '32-bit operand 1 - multiply - low word'),
+            Register(2, name = 'MPY32H', reset = None, full_name = '32-bit operand 1 - multiply - high word'),
+            Register(2, name = 'MPYS32L', reset = None, full_name = '32-bit operand 1 - signed multiply - low word'),
+            Register(2, name = 'MPYS32H', reset = None, full_name = '32-bit operand 1 - signed multiply - high word'),
+            Register(2, name = 'MAC32L', reset = None, full_name = '32-bit operand 1 - multiply accumulate - low word'),
+            Register(2, name = 'MAC32H', reset = None, full_name = '32-bit operand 1 - multiply accumulate - high word'),
+            Register(2, name = 'MACS32L', reset = None, full_name = '32-bit operand 1 - signed multiply accumulate - low word'),
+            Register(2, name = 'MACS32H', reset = None, full_name = '32-bit operand 1 - signed multiply accumulate - high word'),
+            Register(2, name = 'OP2L', reset = None, full_name = '32-bit operand 2 - low word'),
+            Register(2, name = 'OP2H', reset = None, full_name = '32-bit operand 2 - high word'),
+            Register(2, name = 'RES0', reset = None, full_name = '32x32-bit result 0 - least significant word'),
+            Register(2, name = 'RES1', reset = None, full_name = '32x32-bit result 1'),
+            Register(2, name = 'RES2', reset = None, full_name = '32x32-bit result 2'),
+            Register(2, name = 'RES3', reset = None, full_name = '32x32-bit result 3 - most significant word'),
+            Register(2, name = 'MPY32CTL0', full_name = 'MPY32 control register 0', wmask = CINT(0x03FD, 16, 4))
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+cpu = CPUNode(
+    qom_type = "msp430-cpu"
+)
+
+bus = SystemBusNode()
+
+hwm = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_HWM",
+    system_bus = bus,
+    mmio = [
+        0x138
+    ],
+    var_base = "hwm"
+)
+
+hwm.properties.extend([
+    QOMPropertyValue(QOMPropertyTypeBoolean, "op-32-bit", True)
+])
+
+mem = MemorySASNode(
+    name = CSTR('System address space')
+)
+
+ram = MemoryRAMNode(
+    name = CSTR('RAM'),
+    size = CINT(512, 10, 3),
+    var_base = "ram"
+)
+mem.add_child(
+    child = ram,
+    offset = CINT(0x200, 16, 3),
+    priority = CINT(1, 10, 0)
+)
+
+rom = MemoryRAMNode(
+    name = CSTR('ROM'),
+    size = CINT(0xFC00, 16, 4),
+    var_base = "rom"
+)
+mem.add_child(
+    child = rom,
+    offset = CINT(0x400, 16, 3),
+    priority = CINT(1, 10, 0)
+)
+
+msp430_test = MachineDescription(
+    name = "msp430-test",
+    directory = "msp430"
+)
+msp430_test.add_node(bus, with_id = 0)
+msp430_test.add_node(cpu, with_id = 1)
+msp430_test.add_node(hwm, with_id = 2)
+msp430_test.add_node(mem, with_id = 3)
+msp430_test.add_node(ram, with_id = 4)
+msp430_test.add_node(rom, with_id = 6)
+
+msp430_hwm_l0 = GUILayout(
+    desc_name = "MSP430 HWM",
+    opaque = {},
+    shown = False
+)
+msp430_hwm_l0.lid = 0
+
+msp430_l0 = GUILayout(
+    desc_name = "msp430",
+    opaque = {},
+    shown = False
+)
+msp430_l0.lid = 0
+
+obj = MachineWidgetLayout(
+    mdwl = {
+        -1: {
+            "IRQ lines points": {},
+            "mesh step": 0x14,
+            "physical layout": False,
+            "show mesh": False
+        },
+        0: (
+            322.0,
+            300.0
+        ),
+        0x1: (
+            300.0,
+            200.0
+        ),
+        0x2: (
+            360.0,
+            380.0
+        )
+    },
+    mtwl = {
+        -1: {
+            "columns width": {
+                "#0": 0xc8,
+                "id": 0xc8,
+                "offset": 0xc8,
+                "size": 0xc8,
+                "type": 0xc8
+            }
+        }
+    },
+    use_tabs = True
+)
+
+msp430_test_l0 = GUILayout(
+    desc_name = "msp430-test",
+    opaque = obj,
+    shown = True
+)
+msp430_test_l0.lid = 0
+
+project = GUIProject(
+    layouts = [
+        msp430_hwm_l0,
+        msp430_l0,
+        msp430_test_l0
+    ],
+    target_version = "v5.1.0",
+    descriptions = [
+        msp430,
+        msp430_hwm,
+        msp430_test
+    ]
+)
+

--- a/examples/MSP430/msp430/msp430_sem.py
+++ b/examples/MSP430/msp430/msp430_sem.py
@@ -1,0 +1,19 @@
+from msp430x import (
+    msp430_reg_types,
+    name_to_format,
+    gen_msp430_instructions,
+)
+
+registers = [
+    CPURegister("pc", 16),
+    CPURegister("regs", 16, *gen_reg_names_range('r', start = 1, end = 16))
+]
+
+# Overall instruction syntax information
+info = CPUInfo(
+    registers = registers,
+    name_to_format = name_to_format,
+    instructions = gen_msp430_instructions(),
+    read_size = 2, # word size of provided encoding definition
+    reg_types = msp430_reg_types
+)

--- a/examples/MSP430/msp430/msp430x.py
+++ b/examples/MSP430/msp430/msp430x.py
@@ -1,0 +1,2842 @@
+from source import *
+from qemu import *
+
+from functools import (
+    wraps,
+)
+
+# TODO: source.function.tree.Node:
+#     * / % > < >= <= == != : to corresponding operators
+#     += -= *= /= %= <<= >>= &= ^= |= : to corresponding CombAssign operators
+
+
+# shortcuts
+c = Opcode
+o = Operand
+
+
+# cache some types
+tcg = Type["tcg"]
+MemOp = Type[get_vp("memop")]
+MO_UB = MemOp.MO_UB
+MO_UW = MemOp.MO_UW
+MO_UL = MemOp.MO_UL
+MO_TE = MemOp.MO_TE
+int_ = Type["int"]
+uint32_t = Type["uint32_t"]
+uint64_t = Type["uint64_t"]
+
+
+# Temporal storage for instructions descriptions during generation.
+instructions = list()
+
+# Do generate MSP430X (eXtended) instructions descriptions?
+with_ext = True
+
+
+def i(name, *a, **kw):
+    instr = Instruction(name, *a, **kw)
+    instructions.append(instr)
+    return instr
+
+
+class FI(object):
+
+    def __init__(self, opcode,
+        changes_dst = True,
+        reads_dst = True,
+        # Flags mark usage by semantics code
+        msb_used = True,
+        mask_used = True,
+        carry_used = True
+    ):
+        self.opcode = opcode
+        self.changes_dst = changes_dst
+        self.reads_dst = reads_dst
+        self.msb_used = msb_used
+        self.mask_used = mask_used
+        self.carry_used = carry_used
+
+    def __call__(self, sem):
+        append_FI(self.opcode, sem.__name__.lower(), sem, self.changes_dst,
+            self.reads_dst, self.msb_used, self.mask_used, self.carry_used
+        )
+        return sem
+
+
+class FII(object):
+
+    def __init__(self, opcode,
+        changes_dst = True,
+        has_ext = True,
+        sub_sp = False,
+        save_pc = False,
+        # Flags mark usage by semantics code
+        msb_used = True,
+        mask_used = True,
+        carry_used = True
+    ):
+        self.opcode = opcode
+        self.changes_dst = changes_dst
+        self.has_ext = has_ext
+        self.sub_sp = sub_sp # Note, True for PUSH and CALL only
+        self.save_pc = save_pc # Note, True for CALL only
+        self.msb_used = msb_used
+        self.mask_used = mask_used
+        self.carry_used = carry_used
+
+    def __call__(self, sem):
+        append_FII(self.opcode, sem.__name__.lower(), self.has_ext, sem,
+            self.changes_dst, self.sub_sp, self.save_pc, self.msb_used,
+            self.mask_used, self.carry_used
+        )
+        return sem
+
+
+class J(object):
+
+    def __init__(self, opcode):
+        self.opcode = opcode
+
+    def __call__(self, sem):
+        append_J(self.opcode, sem.__name__.lower(), sem)
+        return sem
+
+
+class R(object):
+
+    def __init__(self, opcode):
+        self.opcode = opcode
+
+    def __call__(self, sem):
+        append_R(self.opcode, sem.__name__.lower(), sem)
+        return sem
+
+
+def append_FI(opcode, base_name, semantics, changes_dst, reads_dst, msb_used,
+    mask_used, carry_used, **kw
+):
+    "Double-Operand Instruction, Format I"
+
+    # Addressing modes
+    # # Source addressing modes, As
+    # 00 - register
+    # 01 - indexed (X(Rn)), symbolic (X(PC)), absolute (X(SR)) (extra word)
+    # 10 - indirect register @Rn
+    # 11 - indirect autoincrement @Rn+
+    #    - immediate @PC+, #N (extra word) - looks like PC is incremented
+    #      before extra destination (if Ad) word is read, so the destination
+    #      word location depends on Rn == PC (0) when As == 11b
+    # # Destination addressing modes, Ad
+    # 0 - register
+    # 1 - indexed X(Rn), symbolic X(PC), absolute X(SR) (extra word)
+
+    for ext in ((True, False) if with_ext else (False,)):
+        # common for all instructions
+        if ext:
+            name = base_name + "x"
+            # ext_word is defined depending on instruction variant
+            fmt_bwa = ".<bw, al>"
+        else:
+            name = base_name
+            ext_word = []
+            fmt_bwa = ".<bw>" # al field exists in extension word only
+
+        for ad in (
+            0, # dst: register
+            1 # dst: indexed/symbolic/absolute (extra word)
+        ):
+            if ad:
+                dst_offset = [o(16, "doff")]
+                dst_suffix = "_idx"
+                dst_fmt = "<dst, doff>"
+                # only used for Non-Register Mode Extension Word
+                ext_word_dst_suffix = [o(4, "doff", 1)]
+            else:
+                dst_offset = []
+                dst_suffix = "_reg"
+                dst_fmt = "<dst>"
+                ext_word_dst_suffix = [c(4, 0)]
+
+            NAME = name.upper()
+            common_format = NAME + fmt_bwa + "\\t "
+
+            # src: immediate
+            if ext:
+                # Non-Register Mode Extension Word
+                ext_word = [
+                    c(5, 0b00011),
+                    o(4, "soff", 1),
+                    o(1, "al"),
+                    c(2, 0)
+                ] + ext_word_dst_suffix
+
+            kw["disas_format"] = common_format + "#<soff>, " + dst_fmt
+
+            fields = ext_word + [
+                c(4, opcode),
+                c(4, 0), # src is PC
+                c(1, ad),
+                o(1, "bw"), # B/W
+                c(2, 3), # As == 11b, immediate as src == 0
+                o(4, "dst"),
+                o(16, "soff")
+            ] + dst_offset
+
+            kw["priority"] = 1
+
+            @i(name + "_imm" + dst_suffix, *fields, **kw)
+            @wraps(semantics)
+            @flat_list
+            def src_imm_sem(f, s, ad = ad, ext = ext):
+                src_val = tcg("src_val")
+                tcg_mem_size = MemOp("size")
+                mem_addr = None
+
+                bits = []
+                yield gen_define_size_bits(f, s, ext, bits, msb_used,
+                    mask_used or changes_dst, # because `mask` used
+                    carry_used
+                )
+
+                if reads_dst or changes_dst:
+                    yield gen_set_mem_size(f, s, ad, ext, tcg_mem_size)
+                    if ad:
+                        mem_addr = tcg("mem_addr")
+                        yield Call(
+                            "get_dst_mem_addr",
+                            mem_addr,
+                            f["ctx"],
+                            f["dst"],
+                            f["doff"],
+                            6 if ext else 4
+                        )
+
+                if reads_dst:
+                    dst_val = tcg("dst_val")
+                    yield gen_get_dst_code(f, s, ext, ad, dst_val,
+                        tcg_mem_size, mem_addr, 6 if ext else 4
+                    )
+                else:
+                    dst_val = None
+
+                yield OpAssign(src_val, f["soff"])
+
+                res = tcg("res")
+                yield semantics(f, s, src_val, dst_val, res, *bits)
+
+                if changes_dst:
+                    yield OpCombAssign(res, bits[1], "&") # mask
+                    yield gen_set_dst_code(f, s, ad, res, tcg_mem_size,
+                        mem_addr
+                    )
+
+            # src: src == R3 (CG2)
+            # There is no soff at end of the instruction
+            kw["disas_format"] = common_format + "#<as>, " + dst_fmt
+
+            fields = ext_word + [
+                c(4, opcode),
+                c(4, 3), # src == 3
+                c(1, ad),
+                o(1, "bw"), # B/W
+                o(2, "as"),
+                o(4, "dst")
+            ] + dst_offset
+
+            kw["priority"] = 2
+
+            @i(name + "_cg2" + dst_suffix, *fields, **kw)
+            @wraps(semantics)
+            @flat_list
+            def src_cg2_sem(f, s, ad = ad, ext = ext):
+                src_val = tcg("src_val")
+                tcg_mem_size = MemOp("size")
+                mem_addr = None
+
+                bits = []
+                yield gen_define_size_bits(f, s, ext, bits, msb_used,
+                    True, # `mask_used` is ignored because the `gen_set_cg2`
+                    # uses `mask`
+                    carry_used
+                )
+
+                yield gen_set_cg2(f, s, src_val, f["as"], *bits)
+
+                if reads_dst or changes_dst:
+                    yield gen_set_mem_size(f, s, ad, ext, tcg_mem_size)
+                    if ad:
+                        mem_addr = tcg("mem_addr")
+                        yield Call(
+                            "get_dst_mem_addr",
+                            mem_addr,
+                            f["ctx"],
+                            f["dst"],
+                            f["doff"],
+                            4 if ext else 2
+                        )
+
+                if reads_dst:
+                    dst_val = tcg("dst_val")
+                    yield gen_get_dst_code(f, s, ext, ad, dst_val,
+                        tcg_mem_size, mem_addr, 4 if ext else 2
+                    )
+                else:
+                    dst_val = None
+
+                res = tcg("res")
+                yield semantics(f, s, src_val, dst_val, res, *bits)
+
+                if changes_dst:
+                    yield OpCombAssign(res, bits[1], "&") # mask
+                    yield gen_set_dst_code(f, s, ad, res, tcg_mem_size,
+                        mem_addr
+                    )
+
+            # src: indexed/symbolic/absolute
+            # if ext: ext_word is same as previously
+            kw["disas_format"] = common_format + "<src, soff>, " + dst_fmt
+
+            fields = ext_word + [
+                c(4, opcode),
+                o(4, "src"), # src is any
+                c(1, ad),
+                o(1, "bw"), # B/W
+                c(2, 1), # As == 01b, indexed/symbolic/absolute
+                o(4, "dst"),
+                o(16, "soff")
+            ] + dst_offset
+
+            kw["priority"] = 1
+
+            @i(name + "_idx" + dst_suffix, *fields, **kw)
+            @wraps(semantics)
+            @flat_list
+            def src_idx_sem(f, s, ad = ad, ext = ext):
+                src = f["src"]
+                soff = f["soff"]
+                src_val = tcg("src_val")
+                tcg_mem_size = MemOp("size")
+
+                bits = []
+                yield gen_define_size_bits(f, s, ext, bits, msb_used,
+                    mask_used or changes_dst, # because `mask` used
+                    carry_used
+                )
+
+                # tcg_mem_size is required because of src indexed mode
+                yield gen_set_mem_size(f, s, True, ext, tcg_mem_size)
+                yield gen_get_operand_idx_code(f, s, ext, src, soff, src_val,
+                    tcg_mem_size
+                )
+
+                if (reads_dst or changes_dst) and ad:
+                    mem_addr = tcg("mem_addr")
+                    yield Call(
+                        "get_dst_mem_addr",
+                        mem_addr,
+                        f["ctx"],
+                        f["dst"],
+                        f["doff"],
+                        6 if ext else 4
+                    )
+                else:
+                    mem_addr = None
+
+                if reads_dst:
+                    dst_val = tcg("dst_val")
+                    yield gen_get_dst_code(f, s, ext, ad, dst_val,
+                        tcg_mem_size, mem_addr, 6 if ext else 4
+                    )
+                else:
+                    dst_val = None
+
+                res = tcg("res")
+                yield semantics(f, s, src_val, dst_val, res, *bits)
+
+                if changes_dst:
+                    yield OpCombAssign(res, bits[1], "&") # mask
+                    yield gen_set_dst_code(f, s, ad, res, tcg_mem_size,
+                        mem_addr
+                    )
+
+            # src: (indirect) register (autoincrement)
+            kw["disas_format"] = common_format + "<src, as>, " + dst_fmt
+
+            if ext:
+                if not ad:
+                    # Register Mode Extension Word
+                    # Note, now used not only for Register/Register mode, but
+                    # for (Indirect) Register (Autoincrement)/Register mode.
+                    ext_word = [
+                        c(7, 0b0001100),
+                        o(1, "zc"),
+                        o(1, "rep"),
+                        o(1, "al"),
+                        c(2, 0b00),
+                        o(4, "reg_or_n") # depends on rep
+                    ]
+
+                    kw["disas_format"] = "<rep, reg_or_n>" + kw["disas_format"]
+                # else: ext_word is same as previously
+
+            fields = ext_word + [
+                c(4, opcode),
+                o(4, "src"), # src is not PC
+                c(1, ad),
+                o(1, "bw"), # B/W
+                o(2, "as"), # (As == 00b) or (As == 10b) or (As == 11b and src != 0)
+                o(4, "dst")
+            ] + dst_offset
+
+            kw["priority"] = 0
+
+            @i(name + "_reg" + dst_suffix, *fields, **kw)
+            @wraps(semantics)
+            @flat_list
+            def src_reg_sem(f, s, ad = ad, ext = ext):
+                _as = f["as"]
+                src = f["src"]
+                src_val = tcg("src_val")
+                tcg_mem_size = MemOp("size")
+                mem_addr = None
+
+                # TODO: repetition mode (ext)
+                # TODO: Zero carry (ext)
+
+                bits = []
+                yield gen_define_size_bits(f, s, ext, bits, msb_used,
+                    mask_used or changes_dst, # because `mask` used
+                    carry_used
+                )
+
+                if ad:
+                    yield gen_set_mem_size(f, s, True, ext, tcg_mem_size)
+                    if reads_dst or changes_dst:
+                        mem_addr = tcg("mem_addr")
+                        yield Call(
+                            "get_dst_mem_addr",
+                            mem_addr,
+                            f["ctx"],
+                            f["dst"],
+                            f["doff"],
+                            4 if ext else 2
+                        )
+                else:
+                    yield BranchIf(OpLE(2, _as))(
+                        gen_set_mem_size(f, s, True, ext, tcg_mem_size)
+                    )
+
+                yield gen_get_oper_reg_code(f, s, ext, _as, src, src_val,
+                    tcg_mem_size, 4 if ext else 2, ad, False
+                )
+                if reads_dst:
+                    dst_val = tcg("dst_val")
+                    yield gen_get_dst_code(f, s, ext, ad, dst_val,
+                        tcg_mem_size, mem_addr, 4 if ext else 2
+                    )
+                else:
+                    dst_val = None
+
+                res = tcg("res")
+                yield semantics(f, s, src_val, dst_val, res, *bits)
+
+                if changes_dst:
+                    yield OpCombAssign(res, bits[1], "&") # mask
+                    yield gen_set_dst_code(f, s, ad, res, tcg_mem_size,
+                        mem_addr
+                    )
+
+
+def append_FII(opcode, base_name, has_ext, semantics, changes_dst, sub_sp,
+    save_pc, msb_used, mask_used, carry_used,
+    **kw
+):
+    "Single-Operand Instruction, Format II"
+
+    # There is no explicit confirmation found in the ISA manual but this looks
+    # like Ad of format 2 instructions has same semantics as As of format 1.
+
+    for ext in [False] + ([True] if (has_ext and with_ext) else []):
+        if ext:
+            name = base_name + "x"
+            # ext_word is defined depending on instruction variant
+            fmt_bwa = ".<bw, al>"
+        else:
+            name = base_name
+            ext_word = []
+            fmt_bwa = ".<bw>"
+
+        NAME = name.upper()
+
+        common_format = NAME + fmt_bwa + "\\t "
+
+        # dst: immediate
+        if ext:
+            ext_word = [
+                c(9, 0b000110000),
+                o(1, "al"),
+                c(2, 0),
+                o(4, "doff", 1)
+            ]
+
+        fields = ext_word + [
+            c(9, opcode),
+            o(1, "bw"), # B/W
+            c(2, 3), # Ad == 11b, immediate as Rdst == 0
+            c(4, 0), # Rdst is PC
+            o(16, "doff")
+        ]
+
+        kw["disas_format"] = common_format + "#<doff>"
+
+        kw["priority"] = 0
+
+        @i(name + "_imm", *fields, **kw)
+        @wraps(semantics)
+        @flat_list
+        def dst_imm_sem(f, s, ext = ext):
+            res = tcg("res")
+
+            bits = []
+            yield gen_define_size_bits(f, s, ext, bits,
+                msb_used or (sub_sp and ext), # because `gen_sub_sp` uses `msb`
+                mask_used, carry_used
+            )
+
+            if sub_sp:
+                yield gen_sub_sp(f, s, ext, *bits)
+
+            if save_pc:
+                yield gen_save_pc(f, s, 6 if ext else 4)
+
+            dst_val = tcg("dst_val")
+            yield OpAssign(dst_val, f["doff"])
+
+            yield semantics(f, s, dst_val, res, 6 if ext else 4, ext, *bits)
+
+        # dst: dst==3 => CG2
+        # if ext: is ext_word same as previously? There is no doff
+
+        fields = ext_word + [
+            c(9, opcode),
+            o(1, "bw"), # B/W
+            o(2, "ad"),
+            c(4, 3) # Rdst is R3 (CG2)
+        ]
+
+        kw["disas_format"] = common_format + "#<ad>"
+
+        kw["priority"] = 1
+
+        @i(name + "_cg2", *fields, **kw)
+        @wraps(semantics)
+        @flat_list
+        def dst_cg2_sem(f, s, ext = ext):
+            dst_val = tcg("dst_val")
+
+            bits = []
+            yield gen_define_size_bits(f, s, ext, bits,
+                msb_used or (sub_sp and ext), # because `gen_sub_sp` uses `msb`
+                True, # `mask_used` is ignored because the `gen_set_cg2` uses
+                # `mask`
+                carry_used
+            )
+
+            if sub_sp:
+                yield gen_sub_sp(f, s, ext, *bits)
+
+            if save_pc:
+                yield gen_save_pc(f, s, 4 if ext else 2)
+
+            yield gen_set_cg2(f, s, dst_val, f["ad"], *bits)
+
+            res = tcg("res")
+            yield semantics(f, s, dst_val, res, 4 if ext else 2, ext, *bits)
+
+            # it can't change dst
+
+        # dst: indexed/symbolic/absolute
+        # if ext: ext_word is same as previously
+
+        fields = ext_word + [
+            c(9, opcode),
+            o(1, "bw"), # B/W
+            c(2, 1), # Ad == 01b, indexed/symbolic/absolute
+            o(4, "dst"), # Rdst
+            o(16, "doff")
+        ]
+
+        kw["disas_format"] = common_format + "<dst, doff>"
+
+        kw["priority"] = 0
+
+        @i(name + "_ind", *fields, **kw)
+        @wraps(semantics)
+        @flat_list
+        def dst_idx_sem(f, s, ext = ext):
+            dst = f["dst"]
+            doff = f["doff"]
+            dst_val = tcg("dst_val")
+            tcg_mem_size = MemOp("size")
+            mem_addr = tcg("mem_addr")
+
+            bits = []
+            yield gen_define_size_bits(f, s, ext, bits,
+                msb_used or (sub_sp and ext), # because `gen_sub_sp` uses `msb`
+                mask_used or changes_dst, # because `mask` used
+                carry_used
+            )
+
+            yield gen_set_mem_size(f, s, True, ext, tcg_mem_size)
+
+            if sub_sp:
+                yield gen_sub_sp(f, s, ext, *bits)
+
+            if save_pc:
+                yield gen_save_pc(f, s, 6 if ext else 4)
+
+            yield gen_get_operand_idx_code(f, s, ext, dst, doff, dst_val,
+                tcg_mem_size,
+                oper_mem_addr = mem_addr
+            )
+
+            res = tcg("res")
+            yield semantics(f, s, dst_val, res, 6 if ext else 4, ext, *bits)
+
+            if changes_dst:
+                yield OpCombAssign(res, bits[1], "&") # mask
+                yield gen_set_dst_code(f, s, True, res, tcg_mem_size, mem_addr)
+
+        # dst: (indirect) register (autoincrement)
+        disas_format = common_format + "<dst, ad>"
+
+        if ext:
+            # Register Mode Extension Word
+            # Note, now used not only for Register mode, but for
+            # (Indirect) Register (Autoincrement) mode.
+            ext_word = [
+                c(7, 0b0001100),
+                o(1, "zc"),
+                o(1, "rep"),
+                o(1, "al"),
+                c(2, 0b00),
+                o(4, "reg_or_n") # depends on rep
+            ]
+
+            disas_format = "<rep, reg_or_n>" + disas_format
+
+        fields = ext_word + [
+            c(9, opcode),
+            o(1, "bw"), # B/W
+            o(2, "ad"), # (Ad == 00b) or (Ad == 10b) or (Ad == 11b and dst != 0)
+            o(4, "dst") # Rdst
+        ]
+
+        kw["disas_format"] = disas_format
+        kw["priority"] = 0
+
+        def dst_reg_sem_iteration(f, s, ext, bits, tcg_mem_size):
+            ad = f["ad"]
+            dst = f["dst"]
+            dst_val = tcg("dst_val")
+            mem_addr = tcg("mem_addr")
+
+            # XXX: add `gen_sub_sp` for properly PUSH generation
+
+            if save_pc:
+                yield gen_save_pc(f, s, 4 if ext else 2)
+
+            yield gen_get_oper_reg_code(f, s, ext, ad, dst, dst_val,
+                tcg_mem_size, 4 if ext else 2, # XXX: correct for X?
+                0, # XXX: fix value
+                sub_sp,
+                oper_mem_addr = mem_addr
+            )
+
+            res = tcg("res")
+            yield semantics(f, s, dst_val, res, 4 if ext else 2, ext, *bits)
+
+            # Note: place here registers incrementation to solve problem with
+            # @SP+ usage
+            if sub_sp:
+                yield BranchIf(
+                    OpLogAnd(
+                        OpLogAnd(
+                            OpEq(ad, 3),
+                            OpNEq(dst, 0)
+                        ),
+                        OpNEq(dst, 2)
+                    )
+                )(
+                    gen_autoincrement(f, s, dst, s["regs"][dst - 1], ext)
+                )
+
+            if changes_dst:
+                yield OpCombAssign(res, bits[1], "&") # mask
+                yield BranchIf(ad)(
+                    gen_set_dst_code(f, s, True, res, tcg_mem_size, mem_addr),
+                    BranchElse()(
+                        gen_set_dst_code(f, s, False, res, tcg_mem_size,
+                            mem_addr
+                        )
+                    )
+                )
+
+        @i(name + "_reg", *fields, **kw)
+        @wraps(semantics)
+        @flat_list
+        def dst_reg_sem(f, s, ext = ext):
+            ad = f["ad"]
+            tcg_mem_size = MemOp("size")
+
+            bits = []
+            yield gen_define_size_bits(f, s, ext, bits,
+                msb_used or (sub_sp and ext), # because `gen_sub_sp` uses `msb`
+                mask_used or changes_dst, # because `mask` used
+                carry_used
+            )
+
+            yield BranchIf(ad)(
+                gen_set_mem_size(f, s, True, ext, tcg_mem_size)
+            )
+
+            if sub_sp:
+                yield gen_sub_sp(f, s, ext, *bits)
+
+            if ext:
+                # TODO: Zero carry (ext)
+
+                reg_or_n = f["reg_or_n"]
+                reps = tcg("reps")
+                pc = OpSDeref(f["ctx"], "pc")
+
+                yield BranchIf(f["rep"])(
+                    BranchIf(reg_or_n)(
+                        Comment("repetition count is in Rn[3:0] (not PC)"),
+                        OpAssign(reps, s["regs"][reg_or_n - 1]),
+                        BranchElse()(
+                            Comment("repetition count is in PC[3:0]"),
+                            OpAssign(reps, pc)
+                        )
+                    ),
+                    OpCombAssign(reps, CINT("0x0000F"), "&"),
+                    BranchElse()(
+                        Comment("repetition count is immediate"),
+                        OpAssign(reps, reg_or_n)
+                    )
+                )
+                yield Comment("repetition count is kept one less")
+                yield OpInc(reps)
+
+                yield LoopWhile(OpDec(reps))(
+                    dst_reg_sem_iteration(f, s, ext, bits, tcg_mem_size)
+                )
+            else:
+                yield dst_reg_sem_iteration(f, s, ext, bits, tcg_mem_size)
+
+
+def append_J(opcode_and_cond, name, semantics, **kw):
+    "Conditional Jump"
+
+    @i(name,
+        c(6, opcode_and_cond),
+        # c(3, opcode),
+        # o(3, "cond"), # Condition
+        # o(1, "s"), # S
+        # o(9, "offset") # 10-Bit Signed PC Offset (s is 10-th bit)
+        o(10, "offset"), # 10-Bit Signed PC Offset
+        disas_format = name.upper() + "\\t <offset>",
+        **kw
+    )
+    @wraps(semantics)
+    @flat_list
+    def j_sem(f, s):
+        offset = f["offset"]
+        yield semantics(f, s, offset)
+        yield is_branch(f, s)
+
+
+def append_A(opcode, name, semantics,
+    changes_dst = True,
+    reads_dst = True,
+    **kw
+):
+    "(Extended) Address Instruction"
+
+    msb, mask, carry = CINT("0x80000"), CINT("0xFFFFF"), CINT("100000")
+
+    name += "a"
+
+    @i(name + "_imm",
+        c(4, 0),
+        o(4, "imm", 1),
+        c(2, 0b10),
+        c(2, opcode),
+        o(4, "dst"),
+        o(16, "imm"),
+        disas_format = name.upper() + "\\t #<imm>, <dst>",
+        **kw
+    )
+    @flat_list
+    def imm_and_reg_sem(f, s):
+        src_val = tcg("src_val")
+
+        yield OpAssign(src_val, f["imm"])
+
+        if reads_dst:
+            dst_val = tcg("dst_val")
+            dst = f["dst"]
+            yield BranchIf(dst)(
+                OpAssign(dst_val, s["regs"][dst - 1]),
+                BranchElse()(
+                    OpAssign(dst_val, s["pc"])
+                )
+            )
+        else:
+            dst_val = None
+
+        res = tcg("res")
+        yield semantics(f, s, src_val, dst_val, res, msb, mask, carry)
+
+        if changes_dst:
+            yield gen_set_dst_reg_code(f, s, res)
+
+    @i(name + "_reg",
+        c(4, 0),
+        o(4, "src"),
+        c(2, 0b11),
+        c(2, opcode),
+        o(4, "dst"),
+        disas_format = name.upper() + "\\t <src>, <dst>",
+        **kw
+    )
+    @flat_list
+    def reg_and_reg_sem(f, s):
+        src = f["src"]
+        src_val = tcg("src_val")
+
+        yield BranchIf(src)(
+            OpAssign(src_val, s["regs"][src - 1]),
+            BranchElse()(
+                OpAssign(src_val, s["pc"])
+            )
+        )
+
+        if reads_dst:
+            dst_val = tcg("dst_val")
+            dst = f["dst"]
+            yield BranchIf(src)(
+                OpAssign(dst_val, s["regs"][dst - 1]),
+                BranchElse()(
+                    OpAssign(dst_val, s["pc"])
+                )
+            )
+        else:
+            dst_val = None
+
+        res = tcg("res")
+        yield semantics(f, s, src_val, dst_val, res, msb, mask, carry)
+
+        if changes_dst:
+            yield gen_set_dst_reg_code(f, s, res)
+
+
+def append_R(opcode, name, semantics, **kw):
+    "Extended Rotate Instructions"
+
+    @i(name,
+        c(4, 0),
+        o(2, "imm"),
+        c(2, opcode),
+        c(3, 0b010),
+        o(1, "aw"),
+        o(4, "dst"),
+        disas_format = name.upper() + ".<aw>\\t #<imm>, <dst>",
+        **kw
+    )
+    @wraps(semantics)
+    @flat_list
+    def semantics_wrapper(f, s):
+        dst = f["dst"]
+        pc = s["pc"]
+        dst_val = tcg("dst_val")
+
+        yield BranchIf(dst)(
+            OpAssign(dst_val, s["regs"][dst - 1]),
+            BranchElse()(
+                OpAssign(dst_val, pc)
+            )
+        )
+
+        res = tcg("res")
+        imm = f["imm"]
+
+        yield semantics(f, s, dst_val, imm, res)
+
+        yield BranchIf(dst)(
+            OpAssign(s["regs"][dst - 1], res),
+            BranchElse()(
+                OpAssign(pc, res),
+                is_branch(f, s)
+            )
+        )
+
+
+# And some specific MOVAs
+def append_mova(opcode, *operands, **kw):
+    kw["disas_format"] = "MOVA\\t" + kw.pop("disas_suffix")
+
+    read_src = kw.pop("read_src")
+    write_dst = kw.pop("write_dst")
+
+    @i("mova_%x" % opcode,
+        c(4, 0),
+        operands[0],
+        c(1, 0),
+        c(3, opcode),
+        *operands[1:],
+        **kw
+    )
+    @flat_list
+    def semantics(f, s):
+        val = tcg("val")
+        yield read_src(f, s, val)
+        yield write_dst(f, s, val)
+
+
+def append_calla(opcode, *operands, **kw):
+    kw["disas_format"] = "CALLA\\t" + kw.pop("disas_suffix")
+
+    fields = (c(8, 0b00010011), c(4, opcode)) + operands
+    i_bitsize = 0
+    for f in fields:
+        i_bitsize += f.bitsize
+    instruction_size = i_bitsize // 8
+
+    read_src = kw.pop("read_src")
+
+    @i("calla_%x" % opcode, *fields, **kw)
+    @flat_list
+    def semantics(f, s):
+        target_address = tcg("target_address")
+
+        yield read_src(f, s, target_address)
+
+        ret_pc = uint32_t("ret_pc")
+        yield OpAssign(ret_pc, OpSDeref(f["ctx"], "pc") + instruction_size)
+
+        ret_pc_low = tcg("ret_pc_low")
+        yield OpAssign(ret_pc_low, ret_pc & CINT("0xFFFF"))
+
+        ret_pc_high = tcg("ret_pc_high")
+        yield OpAssign(ret_pc_high, ret_pc >> 16)
+
+        sp = SP(f, s)
+        flags = MO_UW | MO_TE
+
+        # TODO: can it be done with MO_UL? using single tcg_gen_qemu_st_tl call
+        # According to operation note in the docs, it's made in two memory
+        # writes.
+        yield OpAssign(sp, sp - 2)
+        yield Call("tcg_gen_qemu_st_tl", ret_pc_high, sp, 0, flags)
+        yield OpAssign(sp, sp - 2)
+        yield Call("tcg_gen_qemu_st_tl", ret_pc_low, sp, 0, flags)
+
+        yield is_branch(f, s)
+        # set PC
+        yield OpAssign(s["pc"], target_address)
+
+
+# semantics sub-generators used in functions above
+
+
+def gen_define_size_bits(f, s, ext, bits, msb_used, mask_used, carry_used):
+    bits[:] = msb, mask, carry = int_("msb"), int_("mask"), int_("carry")
+
+    carry_used = carry_used or mask_used
+
+    if msb_used or carry_used:
+        bw = f["bw"]
+
+        bits_b = []
+        bits_w = []
+        bits_a = []
+        if msb_used:
+            bits_b.append(OpAssign(msb, CINT("0x80")))
+            bits_w.append(OpAssign(msb, CINT("0x8000")))
+            bits_a.append(OpAssign(msb, CINT("0x80000")))
+        if carry_used:
+            bits_b.append(OpAssign(carry, CINT("0x100")))
+            bits_w.append(OpAssign(carry, CINT("0x10000")))
+            bits_a.append(OpAssign(carry, CINT("0x100000")))
+
+        bw_size = BranchIf(bw)(
+            *bits_b
+        )
+        bw_size(
+            BranchElse()(
+                *bits_w
+            )
+        )
+
+        if ext:
+            al_size = BranchIf(bw)(
+                Comment("address size mode"),
+                *bits_a
+            )
+            al_size(
+                BranchElse()(
+                    Comment("reserved")
+                )
+            )
+
+            yield BranchIf(f["al"])(
+                bw_size,
+                BranchElse()(
+                    al_size
+                )
+            )
+        else:
+            yield bw_size
+
+    if mask_used:
+        yield OpAssign(mask, carry - 1)
+
+
+def gen_sub_sp(f, s, ext, msb, mask, carry):
+    sp = SP(f, s)
+
+    if ext:
+        yield BranchIf(OpLogOr(OpEq(msb, "0x80"), OpEq(msb, "0x8000")))(
+            OpAssign(sp, sp - 2),
+            BranchElse()(
+                OpAssign(sp, sp - 4)
+            )
+        )
+    else:
+        yield OpAssign(sp, sp - 2)
+
+
+def gen_save_pc(f, s, instruction_size):
+    sp = SP(f, s)
+    ret_pc = tcg("ret_pc")
+
+    yield OpAssign(ret_pc, OpSDeref(f["ctx"], "pc") + instruction_size)
+    yield Call("tcg_gen_qemu_st_tl", ret_pc, sp, 0, MO_UW | MO_TE)
+
+
+def gen_set_mem_size(f, s, ad, ext, tcg_mem_size):
+    if not ad:
+        return
+
+    bw = f["bw"]
+
+    bw_size = BranchIf(bw)(
+        OpAssign(tcg_mem_size, MO_UB),
+        BranchElse()(
+            OpAssign(tcg_mem_size, MO_UW)
+        )
+    )
+
+    if ext:
+        yield BranchIf(f["al"])(
+            bw_size,
+            BranchElse()(
+                BranchIf(bw)(
+                    Comment("address size mode"),
+                    OpAssign(tcg_mem_size, MO_UL),
+                    BranchElse()(
+                        Comment("reserved")
+                    )
+                )
+            )
+        )
+    else:
+        yield bw_size
+
+
+def gen_truncate_val(f, s, val, ext):
+    bw = f["bw"]
+
+    bw_branch = BranchIf(bw)(
+        Comment("byte mode"),
+        OpAssign(val, val & CINT("0xFF")),
+        BranchElse()(
+            Comment("word mode"),
+            OpAssign(val, val & CINT("0xFFFF"))
+        )
+    )
+
+    if ext:
+        yield BranchIf(f["al"])(
+            bw_branch,
+            BranchElse()(
+                BranchIf(bw)(
+                    Comment("address size mode"),
+                    OpAssign(val, val & CINT("0xFFFFF")),
+                    BranchElse()(
+                        Comment("reserved")
+                    )
+                )
+            )
+        )
+    else:
+        yield bw_branch
+
+
+def gen_autoincrement(f, s, operand, reg_expr, ext):
+    bw = f["bw"]
+
+    # Note: SP always increments by 2
+    bw_branch = BranchIf(OpLogAnd(bw, OpNEq(operand, 1)))(
+        Comment("byte mode"),
+        OpCombAssign(reg_expr, 1, "+"),
+        BranchElse()(
+            Comment("word mode"),
+            OpCombAssign(reg_expr, 2, "+")
+        )
+    )
+
+    if ext:
+        yield BranchIf(f["al"])(
+            bw_branch,
+            BranchElse()(
+                BranchIf(bw)(
+                    Comment("address size mode"),
+                    OpCombAssign(reg_expr, 4, "+"),
+                    BranchElse()(
+                        Comment("reserved")
+                    )
+                )
+            )
+        )
+    else:
+        yield bw_branch
+
+
+def gen_set_cg2(f, s, val, mode, msb, mask, carry):
+    return BranchSwitch(mode) (
+        SwitchCase(3)(
+            OpAssign(val, mask)
+        ),
+        SwitchCaseDefault()(
+            OpAssign(val, mode)
+        )
+    )
+
+
+def gen_get_operand_idx_code(f, s, ext, operand, op_off, val, tcg_mem_size,
+    oper_mem_addr = None
+):
+    pc = OpSDeref(f["ctx"], "pc")
+    regs = s["regs"]
+    if oper_mem_addr is None:
+        oper_mem_addr = tcg("oper_mem_addr")
+
+    yield BranchSwitch(operand)(
+        SwitchCase(0)(
+            Comment("PC - symbolic mode"),
+            OpAssign(oper_mem_addr, pc + (4 if ext else 2) + op_off),
+            *gen_indexed_addr_wrapping(
+                OpAdd(pc, 4 if ext else 2, parenthesis = True),
+                oper_mem_addr, ext
+            )
+        ),
+        SwitchCase(2)(
+            Comment("SR - absolute mode"),
+            OpAssign(oper_mem_addr, op_off)
+        ),
+        SwitchCase(3)(
+            Comment("CG2 is handled in another place"),
+            Call("assert", 0)
+        ),
+        SwitchCaseDefault()(
+            Comment("indexed mode"),
+            OpAssign(oper_mem_addr, regs[operand - 1] + op_off),
+            *gen_indexed_addr_wrapping(regs[operand - 1], oper_mem_addr, ext)
+        )
+    )
+
+    yield OpCombAssign(oper_mem_addr, CINT("0xFFFFF" if ext else "0x0FFFF"),
+        "&"
+    )
+
+    yield Call("tcg_gen_qemu_ld_tl", val, oper_mem_addr, 0,
+        tcg_mem_size | MO_TE
+    )
+
+    yield gen_truncate_val(f, s, val, ext)
+
+
+def gen_get_oper_reg_code(f, s, ext, mode, operand, oper_val, tcg_mem_size,
+    pc_offset, ad, deferred_increment,
+    oper_mem_addr = None
+):
+    pc = OpSDeref(f["ctx"], "pc")
+    regs = s["regs"]
+    if oper_mem_addr is None:
+        oper_mem_addr = tcg("oper_mem_addr")
+
+    if deferred_increment:
+        autoincrement = Comment(
+            "Post increment for Indirect Register Autoincrement mode"
+        )
+    else:
+        autoincrement = BranchIf(OpEq(mode, 3))(
+            gen_autoincrement(f, s, operand, regs[operand - 1], ext)
+        )
+
+    yield BranchIf(OpLogAnd(OpEq(operand, 2), OpEq(mode, 2)))(
+        Comment("CG1 R2, As == 0b10"),
+        OpAssign(oper_val, 4),
+        BranchElse(OpLogAnd(OpEq(operand, 2), OpEq(mode, 3)))(
+            Comment("CG1 R2, As == 0b11"),
+            OpAssign(oper_val, 8)
+        ),
+        BranchElse()(
+            BranchSwitch(mode)(
+                SwitchCase(0)(
+                    Comment("Register mode"),
+                    BranchIf(operand)(
+                        OpAssign(oper_val, regs[operand - 1]),
+                        BranchElse()(
+                            # Note: PC points to the next instruction in
+                            # Register mode
+                            OpAssign(oper_val, pc + (pc_offset + 2 * ad))
+                        )
+                    )
+                ),
+                Comment(
+                    "Indexed/Symbolic/Absolute/Immediate modes are"
+                    " handled not here"
+                ),
+                SwitchCaseDefault()(
+                    Comment("Indirect Register (Autoincrement) mode"),
+                    BranchIf(operand)(
+                        OpAssign(oper_mem_addr, regs[operand - 1]),
+                        autoincrement,
+                        BranchElse()(
+                            OpAssign(oper_mem_addr, pc + pc_offset)
+                        )
+                    ),
+                    Call("tcg_gen_qemu_ld_tl", oper_val, oper_mem_addr, 0,
+                        tcg_mem_size | MO_TE
+                    )
+                )
+            ),
+            gen_truncate_val(f, s, oper_val, ext)
+        )
+    )
+
+
+def gen_get_dst_mem_addr_func_body(f, s, ext):
+    mem_addr = f["mem_addr"]
+    pc = OpSDeref(f["ctx"], "pc")
+    regs = s["regs"]
+    dst = f["dst"]
+    doff = f["doff"]
+    pc_offset = f["pc_offset"]
+
+    yield BranchSwitch(dst)(
+        SwitchCase(0)(
+            Comment("PC - symbolic mode"),
+            OpAssign(mem_addr, pc + pc_offset + doff),
+            *gen_indexed_addr_wrapping(
+                OpAdd(pc, pc_offset, parenthesis = True),
+                mem_addr, ext
+            )
+        ),
+        SwitchCase(2)(
+            Comment("SR - absolute mode"),
+            OpAssign(mem_addr, doff)
+        ),
+        SwitchCaseDefault()(
+            Comment("indexed mode"),
+            OpAssign(mem_addr, regs[dst - 1] + doff),
+            *gen_indexed_addr_wrapping(regs[dst - 1], mem_addr, ext)
+        )
+    )
+
+    yield OpCombAssign(mem_addr, CINT("0xFFFFF" if ext else "0x0FFFF"), "&")
+
+
+def gen_indexed_addr_wrapping(reg_val, addr, ext):
+    if not ext:
+        return
+
+    # XXX: Which value of PC used? Old or new?
+    # Indexed/Symbolic mode of MSP430 instruction in lower 64KiB
+    yield BranchIf(OpLogNot(reg_val & CINT("0xF0000")))(
+        OpCombAssign(addr, CINT("0x0FFFF"), "&")
+    )
+
+
+def gen_get_dst_code(f, s, ext, ad, dst_val, tcg_mem_size, mem_addr,
+    pc_offset
+):
+    if ad:
+        yield Call("tcg_gen_qemu_ld_tl", dst_val, mem_addr, 0,
+            tcg_mem_size | MO_TE
+        )
+    else:
+        pc = OpSDeref(f["ctx"], "pc")
+        regs = s["regs"]
+        dst = f["dst"]
+
+        yield BranchIf(dst)(
+            OpAssign(dst_val, regs[dst - 1]),
+            BranchElse()(
+                OpAssign(dst_val, pc + pc_offset)
+            )
+        )
+
+    yield gen_truncate_val(f, s, dst_val, ext)
+
+
+def gen_set_dst_code(f, s, ad, res, tcg_mem_size, mem_addr):
+    if ad: # indexed/symbolic/absolute mode
+        yield Call("tcg_gen_qemu_st_tl", res, mem_addr, 0,
+            tcg_mem_size | MO_TE
+        )
+    else: # register mode
+        yield gen_set_dst_reg_code(f, s, res)
+
+
+def gen_set_dst_reg_code(f, s, res):
+    regs = s["regs"]
+    dst = f["dst"]
+    # PC and SP are word aligned
+    yield BranchIf(OpLess(dst, 2))(
+        OpCombAssign(res, CINT("0xFFFFE"), "&")
+    )
+
+    yield BranchIf(dst)(
+        OpAssign(regs[dst - 1], res),
+        BranchIf(OpEq(dst, 2))(
+            gen_helper_check_sr_machine_bits(f, s)
+        ),
+        BranchElse()(
+            OpAssign(s["pc"], res),
+            is_branch(f, s)
+        )
+    )
+
+
+def SP(f, s):
+    "PC is not in regs, so 0-th reg is SP (R1)"
+    return s["regs"][0]
+
+
+def SR(f, s):
+    "1-th is SR (R2)"
+    return s["regs"][1]
+
+
+def set_sr_flag_if(f, s, flag, cond):
+    sr = SR(f, s)
+    return BranchIf(cond)(
+        OpAssign(sr, sr | MCall(flag)),
+        BranchElse()(
+            reset_sr_flag(f, s, flag)
+        )
+    )
+
+
+def set_sr_flag(f, s, flag):
+    sr = SR(f, s)
+    return OpAssign(sr, sr | MCall(flag))
+
+
+def reset_sr_flag(f, s, flag):
+    sr = SR(f, s)
+    return OpAssign(sr, sr & ~MCall(flag))
+
+
+def set_neg(f, s, res, msb):
+    return set_sr_flag_if(f, s, "SR_N", res & msb)
+
+
+def set_zero(f, s, res, mask):
+    return set_sr_flag_if(f, s, "SR_Z", OpLogNot(res & mask))
+
+
+def set_carry(f, s, res, carry):
+    return set_sr_flag_if(f, s, "SR_C", res & carry)
+
+
+def set_overflow(f, s, src, dst, res, msb, inv_sign):
+    if inv_sign:
+        # If `sub`straction is done by addition (~src + 1), the src's
+        # sign is opposite.
+        same_sign = (src ^ dst) & msb
+    else:
+        same_sign = OpLogNot((src ^ dst) & msb)
+
+    diff_sign = (dst ^ res) & msb
+    return set_sr_flag_if(f, s, "SR_V", OpLogAnd(same_sign, diff_sign))
+
+
+def gen_set_flags(f, s, src, dst, res, msb, mask, carry):
+    yield set_neg(f, s, res, msb)
+    yield set_zero(f, s, res, mask)
+    yield set_carry(f, s, res, carry)
+
+
+def is_branch(f, s):
+    # ctx->bstate = BS_BRANCH;
+    return OpAssign(OpSDeref(f["ctx"], "bstate"), MCall("BS_BRANCH"))
+
+
+def gen_call_autoinc_sp(f, s):
+    sp = SP(f, s)
+
+    dst_val = tcg("dst_val")
+    mem_addr = tcg("mem_addr")
+    ret_pc = tcg("ret_pc")
+
+    flags = MO_UW | MO_TE
+
+    yield OpAssign(ret_pc, OpSDeref(f["ctx"], "pc") + 2)
+    yield Call("tcg_gen_qemu_st_tl", ret_pc, sp, 0, flags)
+
+    yield OpAssign(mem_addr, sp - 2)
+    yield Call("tcg_gen_qemu_ld_tl", dst_val, mem_addr, 0, flags)
+
+    yield is_branch(f, s)
+
+    # set PC
+    yield OpAssign(s["pc"], dst_val)
+
+
+def gen_reti_430(f, s):
+    sp = SP(f, s)
+    sr = SR(f, s)
+    PC = s["pc"]
+    flags = MO_UW | MO_TE
+
+    yield Call("tcg_gen_qemu_ld_tl", sr, sp, 0, flags)
+    yield OpCombAssign(sp, 2, "+")
+
+    yield Call("tcg_gen_qemu_ld_tl", PC, sp, 0, flags)
+    yield OpCombAssign(sp, 2, "+")
+
+    yield is_branch(f, s)
+
+
+def gen_reti_430x(f, s):
+    sp = SP(f, s)
+    sr = SR(f, s)
+    PC = s["pc"]
+    flags = MO_UW | MO_TE
+
+    pc_19_16_and_sr = tcg("pc_19_16_and_sr")
+
+    yield Call("tcg_gen_qemu_ld_tl", pc_19_16_and_sr, sp, 0, flags)
+    yield OpCombAssign(sp, 2, "+")
+
+    sr_mask = CINT("0x0FFF")
+    yield OpAssign(sr, pc_19_16_and_sr & sr_mask)
+
+    yield Call("tcg_gen_qemu_ld_tl", PC, sp, 0, flags)
+    yield OpCombAssign(sp, 2, "+")
+
+    pc_mask = CINT("0xF000")
+    yield OpCombAssign(PC, pc_19_16_and_sr & pc_mask, "|")
+
+    yield is_branch(f, s)
+
+
+# read/write semantics for `append_mova` and `append_calla`
+
+
+def write_dst_reg(f, s, dst_val):
+    dst = f["dst"]
+    yield BranchIf(dst)(
+        OpAssign(s["regs"][dst - 1], dst_val),
+        BranchElse()(
+            OpAssign(s["pc"], dst_val),
+            is_branch(f, s)
+        )
+    )
+
+
+def read_src_indirect(f, s, src_val):
+    src = f["src"]
+
+    src_mem_addr = tcg("src_mem_addr")
+
+    yield BranchSwitch(src)(
+        SwitchCase(2)(
+            Comment("CG1, There is no As but let it be 0b10 (indirect)"),
+            OpAssign(src_val, CINT("0x00004"))
+        ),
+        SwitchCase(3)(
+            Comment("CG2, There is no As but let it be 0b10 (indirect)"),
+            OpAssign(src_val, CINT("0x00002"))
+        ),
+        SwitchCaseDefault()(
+            BranchIf(src)(
+                OpAssign(src_mem_addr,
+                    s["regs"][src - 1]
+                ),
+                BranchElse()(
+                    Comment("Symbolic mode"),
+                    OpAssign(src_mem_addr, s["pc"])
+                )
+            ),
+            Call("tcg_gen_qemu_ld_tl", src_val, src_mem_addr, 0,
+                MO_UL | MO_TE
+            ),
+            OpCombAssign(src_val, CINT("0xFFFFF"), "&")
+        )
+    )
+
+
+def read_src_autoincrement(f, s, src_val):
+    src = f["src"]
+
+    src_mem_addr = tcg("src_mem_addr")
+
+    yield BranchSwitch(src)(
+        SwitchCase(0)(
+            Comment("There is another MOVA opcode for immediate mode"),
+            Comment("TODO: gen_helper_illegal")
+        ),
+        SwitchCase(2)(
+            Comment("CG1, There is no As but let it be 0b11 (autoincrement)"),
+            OpAssign(src_val, CINT("0x00008"))
+        ),
+        SwitchCase(3)(
+            Comment("CG2, There is no As but let it be 0b11 (autoincrement)"),
+            OpAssign(src_val, CINT("0xFFFFF"))
+        ),
+        SwitchCaseDefault()(
+            OpAssign(src_mem_addr, s["regs"][src - 1]),
+            OpCombAssign(s["regs"][src - 1], 4, "+"),
+            Call("tcg_gen_qemu_ld_tl", src_val, src_mem_addr, 0,
+                MO_UL | MO_TE
+            ),
+            OpCombAssign(src_val, CINT("0xFFFFF"), "&")
+        )
+    )
+
+
+def read_src_absolute(f, s, src_val):
+    src_mem_addr = tcg("src_mem_addr")
+
+    yield OpAssign(src_mem_addr, f["imm"])
+
+    yield Call("tcg_gen_qemu_ld_tl", src_val, src_mem_addr, 0, MO_UL | MO_TE)
+
+    yield OpCombAssign(src_val, CINT("0xFFFFF"), "&")
+
+
+def read_src_indexed(f, s, src_val):
+    src = f["src"]
+    soff = f["soff"]
+
+    src_mem_addr = tcg("src_mem_addr")
+
+    yield BranchSwitch(src)(
+        SwitchCase(0)(
+            Comment("Symbolic mode"),
+            OpAssign(src_mem_addr, s["pc"] + soff)
+        ),
+        SwitchCase(2)(
+            Comment("There is another MOVA opcode for absolute mode, but..."),
+            OpAssign(src_mem_addr, soff)
+        ),
+        SwitchCaseDefault()(
+            OpAssign(src_mem_addr, s["regs"][src - 1] + soff)
+        )
+    )
+
+    yield Call("tcg_gen_qemu_ld_tl", src_val, src_mem_addr, 0, MO_UL | MO_TE)
+
+    yield OpCombAssign(src_val, CINT("0xFFFFF"), "&")
+
+
+def read_src_reg(f, s, src_val):
+    src = f["src"]
+    yield BranchIf(src)(
+        OpAssign(src_val, s["regs"][src - 1]),
+        BranchElse()(
+            OpAssign(src_val, s["pc"])
+        )
+    )
+
+
+def write_dst_absolute(f, s, dst_val):
+    dst_mem_addr = tcg("dst_mem_addr")
+    yield OpAssign(dst_mem_addr, f["imm"])
+
+    yield Call("tcg_gen_qemu_st_tl", dst_val, dst_mem_addr, 0, MO_UL | MO_TE)
+
+
+def write_dst_indexed(f, s, dst_val):
+    dst = f["dst"]
+    doff = f["doff"]
+
+    dst_mem_addr = tcg("dst_mem_addr")
+
+    yield BranchSwitch(dst)(
+        SwitchCase(0)(
+            Comment("Symbolic mode"),
+            OpAssign(dst_mem_addr, s["pc"] + doff)
+        ),
+        SwitchCase(2)(
+            Comment("There is another MOVA opcode for absolute mode, but..."),
+            OpAssign(dst_mem_addr, doff)
+        ),
+        # 3 CG2? There are no As mode bits, remember?
+        SwitchCaseDefault()(
+            OpAssign(dst_mem_addr, s["regs"][dst - 1] + doff)
+        )
+    )
+
+    yield Call("tcg_gen_qemu_st_tl", dst_val, dst_mem_addr, 0, MO_UL | MO_TE)
+
+
+# read/write semantics for `append_calla`
+
+
+def read_src_symbolic(f, s, src_val):
+    soff = f["soff"]
+    src_mem_addr = tcg("src_mem_addr")
+    yield OpAssign(src_mem_addr, s["pc"] + soff)
+
+    yield Call("tcg_gen_qemu_ld_tl", src_val, src_mem_addr, 0, MO_UL | MO_TE)
+
+    yield OpCombAssign(src_val, CINT("0xFFFFF"), "&")
+
+
+def read_src_immediate(f, s, src_val):
+    yield OpAssign(src_val, f["imm"])
+
+
+# jump semantics generation helpers
+
+
+def jump(f, s, offset):
+    ctx_pc = OpSDeref(f["ctx"], "pc")
+
+    target_offset = (
+        OpAdd(ctx_pc, Call("extend_offset", offset) + 2, parenthesis = True) &
+        CINT("0xFFFFF")
+    )
+
+    return OpAssign(s["pc"], target_offset)
+
+
+def cond_jump(f, s, cond, offset):
+    ctx_pc = OpSDeref(f["ctx"], "pc")
+
+    return BranchIf(cond)(
+        jump(f, s, offset),
+        BranchElse()(
+            OpAssign(s["pc"], ctx_pc + 2)
+        )
+    )
+
+
+# helper calls
+
+
+def gen_helper_check_sr_machine_bits(f, s):
+    return Call("do_gen_helper_check_sr_machine_bits")
+
+
+# common semantics
+
+
+def ADD(f, s, src, dst, res, msb, mask, carry):
+    "src + dst -> dst; NZCV; see INC, INCD, RLA;"
+
+    yield OpAssign(res, src + dst)
+
+    yield gen_set_flags(f, s, src, dst, res, msb, mask, carry)
+    yield set_overflow(f, s, src, dst, res, msb, False)
+
+
+def CMP(f, s, src, dst, res, msb, mask, carry):
+    "~src + 1 + dst; NZCV;"
+
+    yield OpAssign(res, (~src & mask) + 1)
+    yield OpCombAssign(res, dst, "+")
+
+    yield gen_set_flags(f, s, src, dst, res, msb, mask, carry)
+    yield set_overflow(f, s, src, dst, res, msb, True)
+
+
+def MOV(f, s, src, dst, res, *bits):
+    "src -> dst; see BR, CLR, NOP, POP;"
+
+    yield OpAssign(res, src)
+
+
+def SUB(f, s, src, dst, res, msb, mask, carry):
+    "~src + 1 + dst -> dst; NZCV; see DEC, DECD;"
+
+    yield OpAssign(res, (~src & mask) + 1)
+    yield OpCombAssign(res, dst, "+")
+
+    yield gen_set_flags(f, s, src, dst, res, msb, mask, carry)
+    yield set_overflow(f, s, src, dst, res, msb, True)
+
+
+def append_common_instructions():
+
+    # ADC -> ADDC #0, dst
+
+    FI(5)(ADD)
+
+    @FI(6)
+    def ADDC(f, s, src, dst, res, msb, mask, carry):
+        "src + dst + C -> dst; NZCV; see ADC, RLC;"
+
+        # Looks like Carry bit is not accounted during oVerflow bit evaluation.
+        yield OpAssign(res, src + dst)
+        yield BranchIf(SR(f, s) & MCall("SR_C"))(
+            OpInc(res)
+        )
+        yield gen_set_flags(f, s, src, dst, res, msb, mask, carry)
+        yield set_overflow(f, s, src, dst, res, msb, False)
+
+    @FI(0xF, carry_used = False)
+    def AND(f, s, src, dst, res, msb, mask, carry):
+        "src & dst -> dst; NZC; 0 -> V;"
+
+        yield OpAssign(res, src & dst)
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+
+        # C: Set if result is not zero, reset otherwise (C = .not. Z)
+        yield set_sr_flag_if(f, s, "SR_C", res & mask)
+
+        yield reset_sr_flag(f, s, "SR_V")
+
+    @FI(0xC, msb_used = False, mask_used = False, carry_used = False)
+    def BIC(f, s, src, dst, res, *bits):
+        "(~src) & dst -> dst; see CLRC, CLRN, CLRZ, DINT;"
+
+        yield OpAssign(res, ~src & dst)
+
+    @FI(0xD, msb_used = False, mask_used = False, carry_used = False)
+    def BIS(f, s, src, dst, res, *bits):
+        "src | dst -> dst; see EINT, SETC, SETN, SETZ;"
+
+        yield OpAssign(res, src | dst)
+
+    @FI(0xB, changes_dst = False, carry_used = False)
+    def BIT(f, s, src, dst, res, msb, mask, carry):
+        "src & dst; NZC; 0 -> V;"
+
+        yield OpAssign(res, src & dst)
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+
+        yield set_sr_flag_if(f, s, "SR_C", res & mask)
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # BR, BRANCH -> MOV dst, PC
+
+    @FII(((0x10 + 2) << 1) | 1,
+        changes_dst = False,
+        has_ext = False,
+        sub_sp = True,
+        save_pc = True,
+        msb_used = False,
+        mask_used = False,
+        carry_used = False
+    )
+    def CALL(f, s, dst, res, instruction_size, ext, *bits):
+        "dst -> tmp; SP - 2 -> SP; PC -> @@SP; tmp & ~(0xF << 16) -> PC;"
+
+        # Call is made within lower 64 K
+        mask = CINT((1 << 16) - 1, base = 16)
+        yield OpCombAssign(dst, mask, "&")
+
+        yield is_branch(f, s)
+
+        # set PC
+        yield OpAssign(s["pc"], dst)
+
+    # Note: extract "CALL @SP+" into separate case
+    i("call_autoinc_sp", c(9, 0b000100101), o(1, "bw"), c(6, 0b110001),
+        comment = "PC -> @@SP; @@(SP - 2) -> PC;",
+        disas_format = "CALL.<bw>\\t @r1+",
+        semantics = flat_list(gen_call_autoinc_sp)
+    )
+
+    # CLR -> MOV #0, dst
+
+    # CLRC -> BIC #1, SR
+
+    # CLRN -> BIC #4, SR
+
+    # CLRZ -> BIC #2, SR
+
+    FI(9, changes_dst = False)(CMP)
+
+    # DADC -> DADD #0, dst
+
+    @FI(0xA, carry_used = False)
+    def DADD(f, s, src, dst, res, msb, mask, carry):
+        "src + dst + C -> dst (decimally); Z; specific NC; see DADC;"
+
+        # BCD arithmetics
+        carry_outs = tcg("carry_outs")
+        actual_carry_outs = tcg("actual_carry_outs")
+
+        # Operands are at max 20 bit
+        force_carry = OpAdd(src + dst, CINT("0x66666"), parenthesis = True)
+        carry_ins = (src ^ dst) ^ force_carry
+
+        yield OpAssign(carry_outs, (carry_ins >> 1) & CINT("0x88888"))
+
+        yield OpAssign(actual_carry_outs, carry_outs - (carry_outs >> 2))
+
+        yield OpAssign(res, src + dst + actual_carry_outs)
+
+        force_carry = OpAdd(res + 1, CINT("0x66666"), parenthesis = True)
+        carry_ins = (res ^ 1) ^ force_carry
+
+        yield BranchIf(SR(f, s) & MCall("SR_C"))(
+            OpAssign(carry_outs, (carry_ins >> 1) & CINT("0x88888")),
+            OpAssign(actual_carry_outs, carry_outs - (carry_outs >> 2)),
+            OpCombAssign(res, 1 + actual_carry_outs, "+")
+        )
+
+        yield OpCombAssign(res, mask, "&")
+
+        # flags
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+
+        max_val = mask & CINT("0x99999")
+
+        yield set_sr_flag_if(f, s, "SR_C", OpGreater(res, max_val))
+
+    # DEC -> SUB #1, dst
+
+    # DECD -> SUB #2, dst
+
+    # DINT -> BIC #8, SR
+
+    # EINT -> BIS #8, SR
+
+    # INC -> ADD #1, dst
+
+    # INCD -> ADD #2, dst
+
+    # INV -> XOR #0FFFFh, dst
+
+    @J(0x2C >> 2)
+    def JC(f, s, offset):
+        "if C: PC + 2 * offset -> PC;"
+
+        yield cond_jump(f, s, SR(f, s) & MCall("SR_C"), offset)
+
+    @J(0x24 >> 2)
+    def JZ(f, s, offset):
+        "if Z: PC + 2 * offset -> PC;"
+
+        yield cond_jump(f, s, SR(f, s) & MCall("SR_Z"), offset)
+
+    @J(0x34 >> 2)
+    def JGE(f, s, offset):
+        "if !(N ^ V): PC + 2 * offset -> PC;"
+
+        # V is 8th bit and N is second.
+        V_at_N = SR(f, s) >> 6
+
+        yield cond_jump(f, s, OpLogNot((SR(f, s) ^ V_at_N) & MCall("SR_N")),
+            offset
+        )
+
+    @J(0x38 >> 2)
+    def JL(f, s, offset):
+        "if (N ^ V): PC + 2 * offset -> PC;"
+
+        V_at_N = SR(f, s) >> 6
+
+        yield cond_jump(f, s, (SR(f, s) ^ V_at_N) & MCall("SR_N"), offset)
+
+    @J(0x3C >> 2)
+    def JMP(f, s, offset):
+        "PC + 2 * offset -> PC;"
+
+        yield jump(f, s, offset)
+
+    @J(0x30 >> 2)
+    def JN(f, s, offset):
+        "if N: PC + 2 * offset -> PC;"
+
+        yield cond_jump(f, s, SR(f, s) & MCall("SR_N"), offset)
+
+    @J(0x28 >> 2)
+    def JNC(f, s, offset):
+        "if !C: PC + 2 * offset -> PC;"
+
+        yield cond_jump(f, s, OpLogNot(SR(f, s) & MCall("SR_C")), offset)
+
+    @J(0x20 >> 2)
+    def JNE(f, s, offset):
+        "if !Z: PC + 2 * offset -> PC;"
+
+        yield cond_jump(f, s, OpLogNot(SR(f, s) & MCall("SR_Z")), offset)
+
+    FI(4,
+        reads_dst = False,
+        msb_used = False,
+        mask_used = False,
+        carry_used = False
+    )(MOV)
+
+    # NOP -> MOV #0, R3
+
+    # POP -> MOV @SP+, dst
+
+    @FII(((0x10 + 2) << 1) | 0,
+        changes_dst = False,
+        sub_sp = True,
+        mask_used = False,
+        carry_used = False
+    )
+    def PUSH(f, s, dst, res, instruction_size, ext, msb, mask, carry):
+        "SP - 2 -> SP; dst -> @@SP;"
+
+        sp = SP(f, s)
+
+        if ext:
+            yield BranchIf(OpEq(msb, "0x80"))(
+                Call("tcg_gen_qemu_st_tl", dst, sp, 0, MO_UB | MO_TE),
+                BranchElse(OpEq(msb, "0x8000"))(
+                    Call("tcg_gen_qemu_st_tl", dst, sp, 0, MO_UW | MO_TE)
+                ),
+                BranchElse()(
+                    Call("tcg_gen_qemu_st_tl", dst, sp, 0, MO_UL | MO_TE)
+                )
+            )
+        else:
+            yield BranchIf(OpEq(msb, "0x80"))(
+                Call("tcg_gen_qemu_st_tl", dst, sp, 0, MO_UB | MO_TE),
+                BranchElse()(
+                    Call("tcg_gen_qemu_st_tl", dst, sp, 0, MO_UW | MO_TE)
+                )
+            )
+
+    # RET -> MOV @SP+, PC
+
+    if with_ext:
+        i("reti", c(16, 0x1300),
+            comment = ("@@SP -> PC[19:16]|SR[11:0]; SP += 2; @@SP ->" +
+                " PC[15:0]; SP += 2;"
+            ),
+            disas_format = "RETI",
+            semantics = flat_list(gen_reti_430x)
+        )
+    else:
+        i("reti", c(16, 0x1300),
+            comment = "@@SP -> SR; SP += 2; @@SP -> PC; SP += 2;",
+            disas_format = "RETI",
+            semantics = flat_list(gen_reti_430)
+        )
+
+    # RLA -> ADD dst, dst
+
+    # RLC -> ADDC dst, dst
+
+    @FII(((0x10 + 1) << 1) | 0, carry_used = False)
+    def RRA(f, s, dst, res, instruction_size, ext, msb, mask, carry):
+        "dst[i] -> dst[i-1]; dst[MSB-1] -> dst[MSB]; i>MSB, 0 -> dst[i];"
+
+        yield OpAssign(res, dst >> 1)
+
+        yield OpCombAssign(res, dst & msb, "|")
+
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst & 1)
+        yield reset_sr_flag(f, s, "SR_V")
+
+    @FII(((0x10 + 0) << 1) | 0, carry_used = False)
+    def RRC(f, s, dst, res, instruction_size, ext, msb, mask, carry):
+        "dst[LSB] -> C; dst[i] -> dst[i-1]; C -> dst[MSB];"
+
+        yield OpAssign(res, dst >> 1)
+
+        yield BranchIf(SR(f, s) & MCall("SR_C"))(
+            OpCombAssign(res, msb, "|")
+        )
+
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst & 1)
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # SBC -> SUBC #0, dst
+
+    # SETC -> BIS #1, SR
+
+    # SETN -> BIS #4, SR
+
+    # SETZ -> BIS #2, SR
+
+    FI(8)(SUB)
+
+    @FI(7)
+    def SUBC(f, s, src, dst, res, msb, mask, carry):
+        "~src + C + dst -> dst; NZCV; see SBC;"
+
+        yield OpAssign(res, (~src & mask) + dst)
+
+        # Looks like Carry bit is not accounted during oVerflow bit evaluation.
+        yield BranchIf(SR(f, s) & MCall("SR_C"))(
+            OpInc(res)
+        )
+
+        yield gen_set_flags(f, s, src, dst, res, msb, mask, carry)
+        yield set_overflow(f, s, src, dst, res, msb, True)
+
+    @FII(((0x10 + 0) << 1) | 1, msb_used = False, carry_used = False)
+    def SWPB(f, s, dst, res, instruction_size, ext, msb, mask, carry):
+        "dst[0:7]->t; dst[8:15]->dst[0:7]; t->dst[8:15]; 0->dst[19:16];"
+
+        yield OpAssign(res, dst >> 8)
+        yield OpCombAssign(res, CINT("0xFF"), "&")
+        yield OpCombAssign(res, dst << 8, "|")
+        yield OpCombAssign(res, CINT("0xFFFF"), "&")
+
+        yield BranchIf(OpEq(mask, CINT("0xFFFFF")))(
+            Comment("address size (extended-only)"),
+            OpCombAssign(res, dst & CINT("0xF0000"), "|")
+        )
+
+    @FII(((0x10 + 1) << 1) | 1,
+        msb_used = False,
+        mask_used = False,
+        carry_used = False
+    )
+    def SXT(f, s, dst, res, instruction_size, ext, *bits):
+        "dst[7]->dst[MSB:8] (different for mem and reg); NZCl 0 -> V;"
+
+        yield BranchIf(dst & CINT("0x80"))(
+            OpAssign(res, dst | CINT("0xFFF00")),
+            BranchElse()(
+                OpAssign(res, dst & CINT("0x000FF"))
+            )
+        )
+
+        yield set_neg(f, s, res, CINT("0x80000"))
+        yield set_zero(f, s, res, CINT("0xFFFFF"))
+
+        # C: Set if result is not zero, reset otherwise (C = .not. Z)
+        yield set_sr_flag_if(f, s, "SR_C", res & CINT("0xFFFFF"))
+
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # TST -> CMP #0, dst
+
+    @FI(0xE, carry_used = False)
+    def XOR(f, s, src, dst, res, msb, mask, carry):
+        "src ^ dst -> dst; NZCV; see INV;"
+
+        yield OpAssign(res, src ^ dst)
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+
+        # C: Set if result is not zero, reset otherwise (C = .not. Z)
+        yield set_sr_flag_if(f, s, "SR_C", res & mask)
+
+        # V: Set if both operands are negative before execution,
+        #    reset otherwise
+        yield set_sr_flag_if(f, s, "SR_V", OpLogAnd(src & msb, dst & msb))
+
+
+def gen_msp430_instructions():
+    global with_ext
+    with_ext = False
+    del instructions[:]
+
+    append_common_instructions()
+
+    try:
+        return list(instructions)
+    finally:
+        del instructions[:]
+
+
+def gen_msp430x_instructions():
+    global with_ext
+    with_ext = True
+    del instructions[:]
+
+    # `append_common_instructions` also creates extended instructions when
+    # `with_ext == True`:
+    # ADCX (ADDCX), ADDX, ADDCX, ANDX, BICX, BISX, BITX, CLRX (MOVX), CMPX,
+    # DADCX (DADDX), DADDX, DECX (SUBX), DECDX (SUBX), INCX (ADDX),
+    # INCDX (ADDX), INVX (XORX), MOVX, ...
+    append_common_instructions()
+
+    @i("popm",
+        c(7, 0b0001011),
+        o(1, "aw"),
+        o(4, "n_minus_1"),
+        o(4, "dst"),
+        disas_format = "POPM.<aw>\\t #<n_minus_1>, <dst, n_minus_1>"
+    )
+    @flat_list
+    def popm(f, s):
+        "Restore n CPU registers (20/16-bit data) from the stack"
+
+        reg_n = int_("reg_n")
+        last_reg = int_("last_reg")
+        sp = SP(f, s)
+        regs = s["regs"]
+        reg_val = tcg("reg_val")
+
+        yield OpAssign(reg_n, f["dst"])
+        yield OpAssign(last_reg, reg_n + f["n_minus_1"])
+
+        yield LoopFor(None, OpLE(reg_n, last_reg), OpInc(reg_n))(
+            BranchIf(f["aw"])(
+                Call("tcg_gen_qemu_ld_tl", reg_val, sp, 0, MO_UW | MO_TE),
+                OpCombAssign(sp, 2, "+"),
+                OpCombAssign(reg_val, "0x0FFFF", "&"),
+
+                BranchElse()(
+                    Call("tcg_gen_qemu_ld_tl", reg_val, sp, 0, MO_UL | MO_TE),
+                    OpCombAssign(sp, 4, "+"),
+                    OpCombAssign(reg_val, "0xFFFFF", "&")
+                )
+            ),
+            BranchIf(reg_n)(
+                OpAssign(regs[reg_n - 1], reg_val),
+                BranchElse()(
+                    OpAssign(s["pc"], reg_val),
+                    is_branch(f, s)
+                )
+            )
+        )
+
+    @i("pushm",
+        c(7, 0b0001010),
+        o(1, "aw"),
+        o(4, "n_minus_1"),
+        o(4, "dst"),
+        disas_format = "PUSHM.<aw>\\t #<n_minus_1>, <dst>"
+    )
+    @flat_list
+    def pushm(f, s):
+        "Save n CPU registers (20/16-bit data) on the stack"
+
+        reg_n = int_("reg_n")
+        last_reg = int_("last_reg")
+        sp = SP(f, s)
+        regs = s["regs"]
+        reg_val = tcg("reg_val")
+
+        yield OpAssign(reg_n, f["dst"])
+        yield OpAssign(last_reg, reg_n - f["n_minus_1"])
+
+        yield LoopFor(None, OpLE(last_reg, reg_n), OpDec(reg_n))(
+            BranchIf(reg_n)(
+                OpAssign(reg_val, regs[reg_n - 1]),
+                BranchElse()(
+                    OpAssign(reg_val, s["pc"])
+                )
+            ),
+            BranchIf(f["aw"])(
+                OpCombAssign(sp, 2, "-"),
+                Call("tcg_gen_qemu_st_tl", reg_val, sp, 0, MO_UW | MO_TE),
+
+                BranchElse()(
+                    OpCombAssign(sp, 4, "-"),
+                    OpCombAssign(reg_val, "0xFFFFF", "&"),
+                    Call("tcg_gen_qemu_ld_tl", reg_val, sp, 0, MO_UL | MO_TE)
+                )
+            )
+        )
+
+    # by `append_common_instructions`:
+    # ..., POPX (MOVX), PUSHX, ...
+
+    @R(0b10)
+    def RLAM(f, s, dst_val, imm, res):
+        "C <- MSB <- ... <- LSB <- 0; NZC; V is undefined; aw == 0 -> .A;"
+
+        n = uint32_t("n")
+        yield OpAssign(n, imm + 1)
+
+        mask, msb = uint32_t("mask"), uint32_t("msb")
+
+        yield OpAssign(res, dst_val << n)
+
+        yield BranchIf(f["aw"])(
+            Comment("Word size"),
+            OpAssign(mask, CINT("0xFFFF")),
+            OpAssign(msb, CINT("0x8000")),
+
+            BranchElse()(
+                Comment("Address size"),
+                OpAssign(mask, CINT("0xFFFFF")),
+                OpAssign(msb, CINT("0x80000"))
+            )
+        )
+
+        yield OpCombAssign(res, mask, "&")
+
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst_val & (msb >> imm))
+
+    # by `append_common_instructions`:
+    # ..., RLAX (ADDX), RLCX (ADDCX), ...
+
+    @R(0b01)
+    def RRAM(f, s, dst_val, imm, res):
+        "MSB -> MSB -> ... -> LSB -> C; NZC; 0 -> V; aw == 0 -> .A;"
+
+        n = uint32_t("n")
+        yield OpAssign(n, imm + 1)
+
+        mask = uint32_t("mask")
+
+        yield BranchIf(f["aw"])(
+            Comment("Word size"),
+            OpAssign(mask, CINT("0xFFFF")),
+            OpAssign(res, (dst_val & CINT("0xFFFF")) >> n),
+            BranchIf(dst_val & CINT("0x8000"))(
+                OpCombAssign(res,
+                    (
+                        OpSub(1 << n, 1, parenthesis = True) <<
+                        OpSub(16, n, parenthesis = True)
+                    ),
+                    "|"
+                ),
+                set_sr_flag(f, s, "SR_N"),
+                BranchElse()(
+                    reset_sr_flag(f, s, "SR_N")
+                )
+            ),
+
+            BranchElse()(
+                Comment("Address size"),
+                OpAssign(mask, CINT("0xFFFFF")),
+                OpAssign(res, dst_val >> n),
+                BranchIf(dst_val & CINT("0x80000"))(
+                    OpCombAssign(res,
+                        (
+                            OpSub(1 << n, 1, parenthesis = True) <<
+                            OpSub(20, n, parenthesis = True)
+                        ),
+                        "|"
+                    ),
+                    set_sr_flag(f, s, "SR_N"),
+                    BranchElse()(
+                        reset_sr_flag(f, s, "SR_N")
+                    )
+                )
+            )
+        )
+
+        yield OpCombAssign(res, mask, "&")
+
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst_val & (1 << imm))
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # by `append_common_instructions`:
+    # ..., RRAX, ...
+
+    @R(0b00)
+    def RRCM(f, s, dst_val, imm, res):
+        "C -> MSB -> ... -> LSB -> C; NZCV; aw == 0 -> .A;"
+
+        n = uint32_t("n")
+        yield OpAssign(n, imm + 1)
+
+        mask, msb, carry = uint32_t("mask"), uint32_t("msb"), uint32_t("carry")
+
+        yield BranchIf(f["aw"])(
+            Comment("Word size"),
+            OpAssign(mask, CINT("0xFFFF")),
+            OpAssign(msb, CINT("0x8000")),
+            OpAssign(res, (dst_val & CINT("0xFFFF")) >> n),
+            BranchIf(SR(f, s) & MCall("SR_C"))(
+                OpAssign(carry, CINT("0x10000") >> n),
+                OpCombAssign(res, carry, "|")
+            ),
+            OpCombAssign(res, dst_val << OpSub(16, imm, parenthesis = True),
+                "|"
+            ),
+
+            BranchElse()(
+                Comment("Address size"),
+                OpAssign(mask, CINT("0xFFFFF")),
+                OpAssign(msb, CINT("0x80000")),
+                OpAssign(carry, CINT("0x100000")),
+                OpAssign(res, dst_val >> n),
+                BranchIf(SR(f, s) & MCall("SR_C"))(
+                    OpAssign(carry, CINT("0x100000") >> n),
+                    OpCombAssign(res, carry, "|")
+                ),
+                OpCombAssign(res,
+                    dst_val << OpSub(20, imm, parenthesis = True),
+                    "|"
+                )
+            )
+        )
+
+        yield OpCombAssign(res, mask, "&")
+
+        yield set_neg(f, s, res, msb)
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst_val & (1 << imm))
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # by `append_common_instructions`:
+    # ..., RRCX, ...
+
+    @R(0b11)
+    def RRUM(f, s, dst_val, imm, res):
+        "0 -> MAB -> ... -> LSB -> C; NZC; 0 -> V; aw == 0 -> .A;"
+
+        n = uint32_t("n")
+        yield OpAssign(n, imm + 1)
+
+        mask = uint32_t("mask")
+
+        yield OpAssign(res, dst_val >> n)
+
+        yield BranchIf(f["aw"])(
+            Comment("Word size"),
+            OpAssign(mask, CINT("0xFFFF")),
+
+            BranchElse()(
+                Comment("Address size"),
+                OpAssign(mask, CINT("0xFFFFF"))
+            )
+        )
+
+        yield OpCombAssign(res, mask, "&")
+
+        # Cannot be negative, because 0 is inserted into MSB
+        yield reset_sr_flag(f, s, "SR_N")
+        yield set_zero(f, s, res, mask)
+        yield set_sr_flag_if(f, s, "SR_C", dst_val & (1 << imm))
+        yield reset_sr_flag(f, s, "SR_V")
+
+    # TODO: RRUX (no opcode in the docs)
+
+    # by `append_common_instructions`:
+    # ..., SBCX (SUBCX), ..., SUBX, SUBCX, SWPBX, SXTX, TSTX (CMPX), XORX
+
+    # Address instructions
+
+    append_A(0b10, "add",
+        semantics = ADD,
+        comment = "(src/imm) + dst -> dst; NZCV;"
+    )
+
+    # BRA -> MOVA dst, PC
+
+    # CALLA
+    append_calla(0b0100, o(4, "src"),
+        disas_suffix = "<src>",
+        comment = "register",
+        read_src = read_src_reg
+    )
+
+    append_calla(0b0101, o(4, "src"), o(16, "soff"),
+        disas_suffix = "<soff>(<src>)",
+        comment = "indexed",
+        read_src = read_src_indexed
+    )
+
+    append_calla(0b0110, o(4, "src"),
+        disas_suffix = "@<src>",
+        comment = "indirect",
+        read_src = read_src_indirect
+    )
+
+    append_calla(0b0111, o(4, "src"),
+        disas_suffix = "@<src>+",
+        comment = "indirect autoincrement",
+        read_src = read_src_autoincrement
+    )
+
+    append_calla(0b1000, o(4, "imm", 1), o(16, "imm"),
+        disas_suffix = "&<imm>",
+        comment = "absolute",
+        read_src = read_src_absolute
+    )
+
+    append_calla(0b1001, o(4, "soff", 1), o(16, "soff"),
+        disas_suffix = "<soff>",
+        comment = "symbolic",
+        read_src = read_src_symbolic
+    )
+
+    append_calla(0b1011, o(4, "imm", 1), o(16, "imm"),
+        disas_suffix = "#<imm>",
+        comment = "immediate",
+        read_src = read_src_immediate
+    )
+
+    # CLRA -> MOVA #0, dst
+
+    append_A(0b01, "cmp",
+        semantics = CMP,
+        changes_dst = False,
+        comment = "~(src/imm) + 1 + dst; NZCV;"
+    )
+
+    # DECDA -> SUBA #2, dst
+
+    # INCDA -> ADDA #2, dst
+
+    # MOVA
+    append_A(0b00, "mov",
+        semantics = MOV,
+        comment = "(src/imm) -> dst;",
+        reads_dst = False
+    )
+
+    append_mova(0b000, o(4, "src"), o(4, "dst"),
+        comment = "indirect src, register dst",
+        disas_suffix = "@<src>, <dst>",
+        read_src = read_src_indirect,
+        write_dst = write_dst_reg
+    )
+
+    append_mova(0b001, o(4, "src"), o(4, "dst"),
+        comment = "indirect autoincrement src, register dst",
+        disas_suffix = "@<src>+, <dst>",
+        read_src = read_src_autoincrement,
+        write_dst = write_dst_reg
+    )
+
+    append_mova(0b010, o(4, "imm", 1), o(4, "dst"), o(16, "imm"),
+        comment = "absolute src, register dst",
+        disas_suffix = "&<imm>, <dst>",
+        read_src = read_src_absolute,
+        write_dst = write_dst_reg
+    )
+
+    append_mova(0b011, o(4, "src"), o(4, "dst"), o(16, "soff"),
+        comment = "indexed src, register dst",
+        disas_suffix = "<src, soff>, <dst>",
+        read_src = read_src_indexed,
+        write_dst = write_dst_reg
+    )
+
+    append_mova(0b110, o(4, "src"), o(4, "imm", 1), o(16, "imm"),
+        comment = "register src, absolute dst",
+        disas_suffix = "<src>, &<imm>",
+        read_src = read_src_reg,
+        write_dst = write_dst_absolute
+    )
+
+    append_mova(0b111, o(4, "src"), o(4, "dst"), o(16, "doff"),
+        comment = "register src, indexed dst",
+        disas_suffix = "<src>, <dst, doff>",
+        read_src = read_src_reg,
+        write_dst = write_dst_indexed
+    )
+
+    # RETA -> MOVA @SP+. PC
+
+    # TSTA -> CMPA #0, dst
+
+    append_A(0b11, "sub",
+        semantics = SUB,
+        comment = "~(src/imm) + 1 + dst -> dst; NZCV;"
+    )
+
+    try:
+        return list(instructions)
+    finally:
+        del instructions[:]
+
+
+# Byte, word or address size B/W/A
+# A/L  B/W
+#  0    0   reserved
+#  0    1   20 bit (.A)
+#  1    0   16 bit (.W)
+#  1    1    8 bit (.B)
+# See Non-Register Mode Extension Word description.
+# Let B/W have same encoding for non-extended instructions (without A/L bit).
+# This also different for SWPBX and SXTX instructions.
+# A/L  B/W
+#  0    0   .A
+#  0    1   N/A
+#  1    0   .W
+#  1    1   N/A
+
+
+# There are few functions automatizing instruction encoding definition.
+
+
+def reg_types(s, ext):
+    # CPU Status Register flags
+    Macro("SR_C", text = "(1 << 0)")
+    Macro("SR_Z", text = "(1 << 1)")
+    Macro("SR_N", text = "(1 << 2)")
+    Macro("SR_V", text = "(1 << 8)")
+
+    extend_offset = Function(
+        name = "extend_offset",
+        ret_type = uint32_t,
+        args = [ uint32_t("offset") ],
+        static = True,
+        inline = True
+    )
+
+    extend_offset.body = BodyTree()(
+        BranchIf(extend_offset["offset"] & OpLShift(1, 9))(
+            OpCombAssign(extend_offset["offset"], OpLShift(CINT("0x1FF"), 10),
+                "|"
+            )
+        ),
+        Return(extend_offset["offset"] << 1)
+    )
+
+    get_dst_mem_addr = Function(
+        name = "get_dst_mem_addr",
+        args = [
+            tcg("mem_addr"),
+            Pointer(Type["DisasContext"])("ctx"),
+            uint64_t("dst"),
+            uint64_t("doff"),
+            uint64_t("pc_offset"),
+        ],
+        ret_type = Type["void"],
+        static = True,
+        inline = True
+    )
+    get_dst_mem_addr.body = BodyTree()(
+       *gen_get_dst_mem_addr_func_body(get_dst_mem_addr, s, ext)
+    )
+    s.add_type(get_dst_mem_addr)
+
+    s.add_type(Function(
+        name = "do_gen_helper_check_sr_machine_bits",
+        static = True,
+        inline = True
+    ))
+
+
+def msp430_reg_types(source):
+    reg_types(source, False)
+
+
+def msp430x_reg_types(source):
+    reg_types(source, True)
+
+
+# Disas formatters
+
+
+def gen_get_reg_name(f, s):
+    """ get_reg used by several disas formatters. This way ensures that it
+always be defined.
+    """
+
+    try:
+        get_reg = Type["get_reg"]
+    except TypeNotRegistered:
+        reg = Type["unsigned"]("reg")
+
+        get_reg = Function(
+            name = "get_reg",
+            ret_type = Pointer(Type["const char"]),
+            args = [ reg ],
+            static = True,
+            inline = True
+        )
+
+        get_reg.body = BodyTree()(
+            BranchIf(reg)(
+                Return(s["regs"][reg - 1]),
+                BranchElse()(
+                    Return("pc")
+                )
+            )
+        )
+
+    return get_reg
+
+
+def format_size(func, __):
+    bw = func[0]
+    bw.name = "bw"
+
+    yield BranchIf(bw)(
+        Return("B"),
+        BranchElse()(
+            Return("W")
+        )
+    )
+
+
+def format_size_ex(func, *a):
+    bw, al = func[0], func[1]
+    bw.name = "bw"
+    al.name = "al"
+
+    ret = BranchIf(al)(
+        *format_size(func, *a)
+    )
+    ret(BranchElse()(
+        BranchIf(bw)(
+            Return("A"),
+            BranchElse()(
+                Return("[reserved]")
+            )
+        )
+    ))
+    yield ret
+
+
+def format_size_rot(func, __):
+    aw = func[0]
+    aw.name = "aw"
+
+    yield BranchIf(aw)(
+        Return("W"),
+        BranchElse()(
+            Return("A")
+        )
+    )
+
+
+def format_reg(func, module):
+    reg = func[0]
+    reg.name = "reg"
+
+    yield Return(Call(gen_get_reg_name(func, module), reg))
+
+
+def print_indexed(func, module):
+
+    def fpr(fmt, *args):
+        fprintf = func[0]
+        stream = func[1]
+        offset = func[3]
+        offset.name = "offset"
+        return Call(fprintf, stream, fmt, offset, *args)
+
+    reg = func[2]
+    reg.name = "reg"
+
+    yield BranchSwitch(reg)(
+        SwitchCase(0)(
+            Comment("symbolic"),
+            fpr(
+                StrConcat(
+                    "0x%",
+                    MCall("PRIx64"),
+                    delim = "@s"
+                )
+            )
+        ),
+        SwitchCase(2)(
+            Comment("absolute"),
+            fpr(
+                StrConcat(
+                    "&0x%",
+                    MCall("PRIx64"),
+                    delim = "@s"
+                )
+            )
+        ),
+        SwitchCaseDefault()(
+            Comment("indexed"),
+            fpr(
+                StrConcat(
+                    "0x%",
+                    MCall("PRIx64"),
+                    "(%s)",
+                    delim = "@s"
+                ),
+                module["regs"][reg - 1]
+            )
+        )
+    )
+
+
+def print_src(func, module):
+
+    def fpr(fmt, *args):
+        fprintf = func[0]
+        stream = func[1]
+        return Call(fprintf, stream, fmt, *args)
+
+    reg = func[2]
+    as_ = func[3]
+
+    reg.name = "reg"
+    as_.name = "as"
+
+    reg_name = module["regs"][reg - 1]
+
+    yield BranchSwitch(as_)(
+        SwitchCase(0)(
+            BranchSwitch(reg)(
+                SwitchCase(0)(
+                    fpr("pc")
+                ),
+                SwitchCase(3)(
+                    Comment("CG2"),
+                    fpr("#0")
+                ),
+                SwitchCaseDefault()(
+                    fpr("%s", reg_name)
+                )
+            )
+        ),
+        SwitchCase(2)(
+            BranchSwitch(reg)(
+                SwitchCase(0)(
+                    fpr("@pc")
+                ),
+                SwitchCase(2)(
+                    Comment("CG1"),
+                    fpr("#4")
+                ),
+                SwitchCase(3)(
+                    Comment("CG2"),
+                    fpr("#2")
+                ),
+                SwitchCaseDefault()(
+                    fpr("@%s", reg_name)
+                )
+            )
+        ),
+        SwitchCase(3)(
+            BranchSwitch(reg)(
+                SwitchCase(0)(
+                    fpr("; error: immediate mode must not be handled here")
+                ),
+                SwitchCase(2)(
+                    Comment("CG1"),
+                    fpr("#8")
+                ),
+                SwitchCase(3)(
+                    Comment("CG2"),
+                    fpr("#-1")
+                ),
+                SwitchCaseDefault()(
+                    fpr("@%s+", reg_name)
+                )
+            )
+        ),
+        SwitchCaseDefault()(
+            fpr(
+                StrConcat(
+                    "; error: As == %",
+                    MCall("PRIu64"),
+                    " must not be handled here",
+                    delim = "@s"
+                ),
+                as_
+            )
+        )
+    )
+
+
+def format_cg2(func, __):
+    mode = func[0]
+    mode.name = "mode"
+
+    yield BranchIf(OpEq(mode, 3))(
+        Return(-1),
+        BranchElse()(
+            Return(mode)
+        )
+    )
+
+
+def format_jump_offset(func, __):
+    arg = func[0]
+    yield Comment("sxxxxxxxxx0")
+    yield BranchIf(arg & OpLShift(1, 9, parenthesis = True))(
+        Comment("Note that 2 is size of a jump instruction."),
+        # 2 - ((~(arg | ~0x3FFUL) + 1) << 1)
+        Return(
+            2 - (
+                OpAdd(
+                    ~(arg | OpNot(CINT("0x3FFUL"))),
+                    1,
+                    parenthesis = True
+                ) << 1
+            )
+        ),
+        BranchElse()(
+            Return(2 + (arg << 1))
+        )
+    )
+
+
+def print_rep(func, module):
+
+    def fpr(fmt, *args):
+        fprintf = func[0]
+        stream = func[1]
+        return Call(fprintf, stream, fmt, *args)
+
+    rep, reg_or_n = func.args[-2:]
+    rep.name = "rep"
+    reg_or_n.name = "reg_or_n"
+
+    yield BranchIf(rep)(
+        fpr("RPT %s { ", Call(gen_get_reg_name(func, module), reg_or_n)),
+        BranchElse()(
+            fpr("RPT #%u { ", OpCast("unsigned", reg_or_n) + 1)
+        )
+    )
+
+
+def inc_by_one(func, __):
+    yield Return(func[0] + 1)
+
+
+def format_reg_plus_n_minus_1(func, module):
+    reg, n_minus_1 = func.args
+    reg.name = "reg"
+    n_minus_1.name = "n_minus_1"
+
+    yield Return(Call(gen_get_reg_name(func, module), reg + n_minus_1))
+
+
+name_to_format = {
+    "bw": ("%s", flat_list(format_size)), # B or W
+    "src": ("%s", flat_list(format_reg)), # register name
+    "dst": ("%s", flat_list(format_reg)),
+    "imm": ("0x%x", None), # hexadecimal immediate
+    "soff": ("0x%x", None),
+    "doff": ("0x%x", None),
+    # X(Rn), X, &X depending on reg
+    "dst, doff": (None, flat_list(print_indexed)),
+    "src, soff": (None, flat_list(print_indexed)),
+    "src, as": (None, flat_list(print_src)), # Rn, @Rn or @Rn+ depending on As
+    "as": ("%d", flat_list(format_cg2)),
+    "ad": ("%d", flat_list(format_cg2)), # for FII instructions
+    "dst, ad": (None, flat_list(print_src)), # ad is 2-bit wide (as `As`) here
+    # the offset requires special handling
+    "offset": ("%d", flat_list(format_jump_offset)),
+}
+
+name_to_format_x = {
+    "bw, al": ("%s", flat_list(format_size_ex)), # B or W or A
+    "aw": ("%s", flat_list(format_size_rot)), # A or W
+    # repetition mode of extended instructions
+    "rep, reg_or_n": (None, flat_list(print_rep)),
+    "n_minus_1": ("%u", flat_list(inc_by_one)), # see pushm/popm
+    "dst, n_minus_1": ("%s", flat_list(format_reg_plus_n_minus_1)), # see popm
+}
+name_to_format_x.update(name_to_format)

--- a/examples/MSP430/msp430/msp430x2xx.py
+++ b/examples/MSP430/msp430/msp430x2xx.py
@@ -1,0 +1,1105 @@
+cpu = CPUNode(
+    qom_type = "msp430-cpu"
+)
+
+bus = SystemBusNode()
+
+bcm = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_BCM",
+    system_bus = bus,
+    mmio = [
+        0x53,
+        0x56
+    ],
+    var_base = "bcm"
+)
+
+dma = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_DMA",
+    system_bus = bus,
+    mmio = [
+        0x122,
+        0x1d0
+    ],
+    var_base = "dma"
+)
+
+ic = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_IC",
+    system_bus = bus,
+    mmio = [
+        0
+    ],
+    var_base = "ic"
+)
+
+ic.properties.extend([
+    QOMPropertyValue(QOMPropertyTypeLink, "cpu", cpu)
+])
+
+fmc = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_FMC",
+    system_bus = bus,
+    mmio = [
+        0x128,
+        0x1be,
+        0x1000,
+        0x8000
+    ],
+    var_base = "fmc"
+)
+
+fmc.properties.extend([
+    QOMPropertyValue(QOMPropertyTypeString, "blk", "pflash0")
+])
+
+io = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_IO",
+    system_bus = bus,
+    mmio = [
+        0x10
+    ],
+    var_base = "io"
+)
+
+svs = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_SVS",
+    system_bus = bus,
+    mmio = [
+        0x55
+    ],
+    var_base = "svs"
+)
+
+wdt = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_WDT",
+    system_bus = bus,
+    mmio = [
+        0x120
+    ],
+    var_base = "wdt"
+)
+
+# Use HWM from CPU simple board model definition
+hwm = SystemBusDeviceNode(
+    qom_type = "msp430_hwm",
+    system_bus = bus,
+    mmio = [
+        0x130
+    ],
+    var_base = "hwm"
+)
+
+hwm.properties.extend([
+    QOMPropertyValue(QOMPropertyTypeBoolean, "op-32-bit", False)
+])
+
+timer_a = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_TIMER_A",
+    system_bus = bus,
+    mmio = [
+        0x160,
+        0x12e
+    ],
+    var_base = "timer_a"
+)
+
+timer_b = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_TIMER_B",
+    system_bus = bus,
+    mmio = [
+        0x180,
+        0x11e
+    ],
+    var_base = "timer_b"
+)
+
+usi = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_USI",
+    system_bus = bus,
+    mmio = [
+        0x78
+    ],
+    var_base = "usi"
+)
+
+oa0 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_OA",
+    system_bus = bus,
+    mmio = [
+        0xc0
+    ],
+    var_base = "oa0"
+)
+
+oa1 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_OA",
+    system_bus = bus,
+    mmio = [
+        0xc2
+    ],
+    var_base = "oa1"
+)
+
+oa2 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_OA",
+    system_bus = bus,
+    mmio = [
+        0xc4
+    ],
+    var_base = "oa2"
+)
+
+comp_a = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_COMP_A",
+    system_bus = bus,
+    mmio = [
+        0x59
+    ],
+    var_base = "comp_a"
+)
+
+adc10 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_ADC10",
+    system_bus = bus,
+    mmio = [
+        0x48,
+        0x1b0
+    ],
+    var_base = "adc10"
+)
+
+adc12 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_ADC12",
+    system_bus = bus,
+    mmio = [
+        0x1a0,
+        0x140,
+        0x80
+    ],
+    var_base = "adc12"
+)
+
+dac12_0 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_DAC12",
+    system_bus = bus,
+    mmio = [
+        0x1c0,
+        0x1c8
+    ],
+    var_base = "dac12_0"
+)
+
+dac12_1 = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_DAC12",
+    system_bus = bus,
+    mmio = [
+        0x1c2,
+        0x1ca
+    ],
+    var_base = "dac12_1"
+)
+
+sd16_a = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_SD16_A",
+    system_bus = bus,
+    mmio = [
+        0x100,
+        0xb0
+    ],
+    var_base = "sd16_a"
+)
+
+usci_a = SystemBusDeviceNode(
+    qom_type = "TYPE_MSP430_USCI_A",
+    system_bus = bus,
+    mmio = [
+        0x5d
+    ],
+    var_base = "usci_a"
+)
+
+usci_a.properties.extend([
+    QOMPropertyValue(QOMPropertyTypeString, "chr", "serial0")
+])
+
+irq_usci_a_rx_to_ic_8 = IRQLine(
+    src_dev = usci_a,
+    dst_dev = ic,
+    dst_irq_idx = 0x8,
+    src_irq_name = "SYSBUS_DEVICE_GPIO_IRQ",
+    var_base = "irq_usci_a_rx_to_ic_8"
+)
+
+irq_usci_a_swrst_to_ic_9 = IRQLine(
+    src_dev = usci_a,
+    dst_dev = ic,
+    src_irq_idx = 0x1,
+    dst_irq_idx = 0x9,
+    src_irq_name = "SYSBUS_DEVICE_GPIO_IRQ",
+    var_base = "irq_usci_a_swrst_to_ic_9"
+)
+
+irq_wdt_0_to_ic_0 = IRQLine(
+    src_dev = wdt,
+    dst_dev = ic,
+    src_irq_name = "SYSBUS_DEVICE_GPIO_IRQ",
+    var_base = "irq_wdt_0_to_ic_0"
+)
+
+mem = MemorySASNode(
+    name = CSTR('System address space')
+)
+
+ram = MemoryRAMNode(
+    name = CSTR('RAM'),
+    size = CINT(0x200, 16, 3),
+    var_base = "ram"
+)
+mem.add_child(
+    child = ram,
+    offset = CINT(0x200, 16, 3),
+    priority = CINT(1, 10, 0)
+)
+
+msp430x2xx = MachineDescription(
+    name = "msp430x2xx",
+    directory = "msp430"
+)
+msp430x2xx.add_node(bus, with_id = 0)
+msp430x2xx.add_node(cpu, with_id = 1)
+msp430x2xx.add_node(mem, with_id = 2)
+msp430x2xx.add_node(ram, with_id = 3)
+msp430x2xx.add_node(bcm, with_id = 4)
+msp430x2xx.add_node(dma, with_id = 5)
+msp430x2xx.add_node(ic, with_id = 6)
+msp430x2xx.add_node(fmc, with_id = 7)
+msp430x2xx.add_node(io, with_id = 8)
+msp430x2xx.add_node(svs, with_id = 9)
+msp430x2xx.add_node(wdt, with_id = 10)
+msp430x2xx.add_node(hwm, with_id = 11)
+msp430x2xx.add_node(timer_a, with_id = 12)
+msp430x2xx.add_node(timer_b, with_id = 13)
+msp430x2xx.add_node(usi, with_id = 14)
+msp430x2xx.add_node(oa0, with_id = 15)
+msp430x2xx.add_node(oa1, with_id = 16)
+msp430x2xx.add_node(oa2, with_id = 17)
+msp430x2xx.add_node(comp_a, with_id = 18)
+msp430x2xx.add_node(adc10, with_id = 19)
+msp430x2xx.add_node(adc12, with_id = 20)
+msp430x2xx.add_node(dac12_0, with_id = 21)
+msp430x2xx.add_node(dac12_1, with_id = 22)
+msp430x2xx.add_node(sd16_a, with_id = 23)
+msp430x2xx.add_node(usci_a, with_id = 24)
+msp430x2xx.add_node(irq_usci_a_rx_to_ic_8, with_id = 25)
+msp430x2xx.add_node(irq_usci_a_swrst_to_ic_9, with_id = 26)
+msp430x2xx.add_node(irq_wdt_0_to_ic_0, with_id = 27)
+
+msp430_bcm = SysBusDeviceDescription(
+    name = "MSP430 BCM+",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'BCSCTL3', reset = CINT(0b00000101, 2, 8), full_name = 'Basic clock system control 3', wmask = CINT(0b11111100, 2, 8))
+        ],
+        0x1: [
+            Register(1, name = 'DCOCTL', reset = CINT(0b01100000, 2, 8), full_name = 'DCO control register'),
+            Register(1, name = 'BCSCTL1', reset = CINT(0b10000111, 2, 8), full_name = 'Basic clock system control 1'),
+            Register(1, name = 'BCSCTL2', full_name = 'Basic clock system control 2')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_dma = SysBusDeviceDescription(
+    name = "MSP430 DMA",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'DMACTL0', full_name = 'DMA Control Register 0'),
+            Register(2, name = 'DMACTL1', full_name = 'DMA Control Register 1', wmask = CINT(0x0007, 16, 4)),
+            Register(2, name = 'DMAIV', full_name = 'DMA Interrupt Vector Register', wmask = CINT(0b0000000000000000, 2, 16))
+        ],
+        0x1: [
+            Register(2, name = 'DMA0CTL', full_name = 'DMA channel 0 control'),
+            Register(4, name = 'DMA0SA', reset = None, full_name = 'DMA channel 0 source address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(4, name = 'DMA0DA', reset = None, full_name = 'DMA channel 0 destination address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(2, name = 'DMA0SZ', reset = None, full_name = 'DMA channel 0 transfer size'),
+            Register(2, name = 'DMA1CTL', full_name = 'DMA channel 1 control'),
+            Register(4, name = 'DMA1SA', reset = None, full_name = 'DMA channel 1 source address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(4, name = 'DMA1DA', reset = None, full_name = 'DMA channel 1 destination address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(2, name = 'DMA1SZ', reset = None, full_name = 'DMA channel 1 transfer size'),
+            Register(2, name = 'DMA2CTL', full_name = 'DMA channel 2 control'),
+            Register(4, name = 'DMA2SA', reset = None, full_name = 'DMA channel 2 source address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(4, name = 'DMA2DA', reset = None, full_name = 'DMA channel 2 destination address', wmask = CINT(0x000FFFFF, 16, 8)),
+            Register(2, name = 'DMA2SZ', reset = None, full_name = 'DMA channel 2 transfer size')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_ic = SysBusDeviceDescription(
+    name = "MSP430 IC",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0x20,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'IE1'),
+            Register(1, name = 'IE2'),
+            Register(1, name = 'IFG1'),
+            Register(1, name = 'IFG2')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_fmc = SysBusDeviceDescription(
+    name = "MSP430 FMC",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x4,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'FCTL1', reset = CINT(0x9600, 16, 4), full_name = 'Flash memory control register 1', wmask = CINT(0x00DE, 16, 4)),
+            Register(2, name = 'FCTL2', reset = CINT(0x9642, 16, 4), full_name = 'Flash memory control register 2', wmask = CINT(0x00FF, 16, 4)),
+            Register(2, name = 'FCTL3', reset = CINT(0x9658, 16, 4), full_name = 'Flash memory control register 3', wmask = CINT(0x00F7, 16, 4))
+        ],
+        0x1: [
+            Register(2, name = 'FCTL4', full_name = 'Flash memory control register 4', wmask = CINT(0x0030, 16, 4))
+        ],
+        0x2: MemoryROMNode(
+            name = CSTR('Information Memory'),
+            size = CINT(512, 10, 0),
+            var_base = "info"
+        ),
+        0x3: MemoryROMNode(
+            name = CSTR('Main Memory'),
+            size = CINT(32768, 10, 0)
+        )
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0x1
+)
+
+# Port 8 is disabled because it overlaps with ADC10:
+# P8SEL2 and ADC10DTC0 at 0x48
+msp430_io = SysBusDeviceDescription(
+    name = "MSP430 IO",
+    directory = "msp430",
+    out_irq_num = 0x2,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'P3REN', full_name = 'P3 Resistor Enable'),
+            Register(1, name = 'P4REN', full_name = 'P4 Resistor Enable'),
+            Register(1, name = 'P5REN', full_name = 'P5 Resistor Enable'),
+            Register(1, name = 'P6REN', full_name = 'P6 Resistor Enable'),
+            Register(1, name = 'P7REN', full_name = 'P7 Resistor Enable'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'P3IN', access = 'r', full_name = 'P3 Input'),
+            Register(1, name = 'P3OUT', reset = None, full_name = 'P3 Output'),
+            Register(1, name = 'P3DIR', full_name = 'P3 Direction'),
+            Register(1, name = 'P3SEL', full_name = 'P3 Port Select'),
+            Register(1, name = 'P4IN', access = 'r', full_name = 'P4 Input'),
+            Register(1, name = 'P4OUT', reset = None, full_name = 'P4 Output'),
+            Register(1, name = 'P4DIR', full_name = 'P4 Direction'),
+            Register(1, name = 'P4SEL', full_name = 'P4 Port Select'),
+            Register(1, name = 'P1IN', access = 'r', full_name = 'P1 Input'),
+            Register(1, name = 'P1OUT', reset = None, full_name = 'P1 Output'),
+            Register(1, name = 'P1DIR', full_name = 'P1 Direction'),
+            Register(1, name = 'P1IFG', full_name = 'P1 Interrupt Flag'),
+            Register(1, name = 'P1IES', reset = None, full_name = 'P1 Interrupt Edge Select'),
+            Register(1, name = 'P1IE', full_name = 'P1 Interrupt Enable'),
+            Register(1, name = 'P1SEL', full_name = 'P1 Port Select'),
+            Register(1, name = 'P1REN', full_name = 'P1 Resistor Enable'),
+            Register(1, name = 'P2IN', access = 'r', full_name = 'P2 Input'),
+            Register(1, name = 'P2OUT', reset = None, full_name = 'P2 Output'),
+            Register(1, name = 'P2DIR', full_name = 'P2 Direction'),
+            Register(1, name = 'P2IFG', full_name = 'P2 Interrupt Flag'),
+            Register(1, name = 'P2IES', reset = None, full_name = 'P2 Interrupt Edge Select'),
+            Register(1, name = 'P2IE', full_name = 'P2 Interrupt Enable'),
+            Register(1, name = 'P2SEL', reset = CINT(0xC0, 16, 2), full_name = 'P2 Port Select'),
+            Register(1, name = 'P2REN', full_name = 'P2 Resistor Enable'),
+            Register(1, name = 'P5IN', access = 'r', full_name = 'P5 Input'),
+            Register(1, name = 'P5OUT', reset = None, full_name = 'P5 Output'),
+            Register(1, name = 'P5DIR', full_name = 'P5 Direction'),
+            Register(1, name = 'P5SEL', full_name = 'P5 Port Select'),
+            Register(1, name = 'P6IN', access = 'r', full_name = 'P6 Input'),
+            Register(1, name = 'P6OUT', reset = None, full_name = 'P6 Output'),
+            Register(1, name = 'P6DIR', full_name = 'P6 Direction'),
+            Register(1, name = 'P6SEL', full_name = 'P6 Port Select'),
+            Register(1, name = 'P7IN', access = 'r', full_name = 'P7 Input'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'P7OUT', reset = None, full_name = 'P7 Output'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'P7DIR', full_name = 'P7 Direction'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'P7SEL', full_name = 'P7 Port Select'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'gap'),
+            Register(1, name = 'P1SEL2', full_name = 'P1 Port Select 2'),
+            Register(1, name = 'P2SEL2', full_name = 'P2 Port Select 2'),
+            Register(1, name = 'P3SEL2', full_name = 'P3 Port Select 2'),
+            Register(1, name = 'P4SEL2', full_name = 'P4 Port Select 2'),
+            Register(1, name = 'P5SEL2', full_name = 'P5 Port Select 2'),
+            Register(1, name = 'P6SEL2', full_name = 'P6 Port Select 2'),
+            Register(1, name = 'P7SEL2', full_name = 'P7 Port Select 2')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_svs = SysBusDeviceDescription(
+    name = "MSP430 SVS",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'SVSCTL', full_name = 'SVS Control Register')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_wdt = SysBusDeviceDescription(
+    name = "MSP430 WDT+",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'WDTCTL', reset = CINT(0x6900, 16, 4), full_name = 'Watchdog timer+ control register', wmask = CINT(0x00FF, 16, 4))
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0x1,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_timer_a = SysBusDeviceDescription(
+    name = "MSP430 Timer A",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'TACTL', full_name = 'Timer_A control'),
+            Register(2, name = 'TACCTL0', full_name = 'Timer_A capture/compare control 0', wmask = CINT(0b1111100111110111, 2, 16)),
+            Register(2, name = 'TACCTL1', full_name = 'Timer_A capture/compare control 1', wmask = CINT(0b1111100111110111, 2, 16)),
+            Register(2, name = 'TACCTL2', full_name = 'Timer_A capture/compare control 2', wmask = CINT(0b1111100111110111, 2, 16)),
+            Register(8),
+            Register(2, name = 'TAR', full_name = 'Timer_A counter'),
+            Register(2, name = 'TACCR0', full_name = 'Timer_A capture/compare 0'),
+            Register(2, name = 'TACCR1', full_name = 'Timer_A capture/compare 1'),
+            Register(2, name = 'TACCR2', full_name = 'Timer_A capture/compare 2')
+        ],
+        0x1: [
+            Register(2, name = 'TAIV', access = 'r', full_name = 'Timer_A interrupt vector')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0x1,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_timer_b = SysBusDeviceDescription(
+    name = "MSP430 Timer B",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'TBCTL', full_name = 'Timer_B control'),
+            Register(2, name = 'TBCCTL0', full_name = 'Timer_B capture/compare control 0', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL1', full_name = 'Timer_B capture/compare control 1', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL2', full_name = 'Timer_B capture/compare control 2', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL3', full_name = 'Timer_B capture/compare control 3', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL4', full_name = 'Timer_B capture/compare control 4', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL5', full_name = 'Timer_B capture/compare control 5', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBCCTL6', full_name = 'Timer_B capture/compare control 6', wmask = CINT(0b1111110111110111, 2, 16)),
+            Register(2, name = 'TBR', full_name = 'Timer_B counter'),
+            Register(2, name = 'TBCCR0', full_name = 'Timer_B capture/compare 0'),
+            Register(2, name = 'TBCCR1', full_name = 'Timer_B capture/compare 1'),
+            Register(2, name = 'TBCCR2', full_name = 'Timer_B capture/compare 2'),
+            Register(2, name = 'TBCCR3', full_name = 'Timer_B capture/compare 3'),
+            Register(2, name = 'TBCCR4', full_name = 'Timer_B capture/compare 4'),
+            Register(2, name = 'TBCCR5', full_name = 'Timer_B capture/compare 5'),
+            Register(2, name = 'TBCCR6', full_name = 'Timer_B capture/compare 6')
+        ],
+        0x1: [
+            Register(2, name = 'TBIV', access = 'r', full_name = 'Timer_B interrupt vector')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0x1,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_usi = SysBusDeviceDescription(
+    name = "MSP430 USI",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'USICTL0', reset = CINT(0x01, 16, 2), full_name = 'USI control register 0'),
+            Register(1, name = 'USICTL1', reset = CINT(0x01, 16, 2), full_name = 'USI control register 1'),
+            Register(1, name = 'USICKCTL', full_name = 'USI clock control'),
+            Register(1, name = 'USICNT', full_name = 'USI bit counter'),
+            Register(1, name = 'USISRL', reset = None, full_name = 'USI low byte shift register'),
+            Register(1, name = 'USISRH', reset = None, full_name = 'USI high byte shift register')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_oa = SysBusDeviceDescription(
+    name = "MSP430 OA",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'OAxCTL0', full_name = 'OAx control register 0'),
+            Register(1, name = 'OAxCTL1', full_name = 'OAx control register 1')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_comp_a = SysBusDeviceDescription(
+    name = "MSP430 Comp A+",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'CACTL1', full_name = 'Comparator_A+ control register 1'),
+            Register(1, name = 'CACTL2', full_name = 'Comparator_A+ control register 2', wmask = CINT(0b11111110, 2, 8)),
+            Register(1, name = 'CAPD', full_name = 'Comparator_A+ port disable')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_adc10 = SysBusDeviceDescription(
+    name = "MSP430 ADC10",
+    directory = "msp430",
+    out_irq_num = 0,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'ADC10DTC0', full_name = 'ADC10 data transfer control register 0', wmask = CINT(0b00001101, 2, 8)),
+            Register(1, name = 'ADC10DTC1', full_name = 'ADC10 data transfer control register 1'),
+            Register(1, name = 'ADC10AE0', full_name = 'ADC10 input enable register 0'),
+            Register(1, name = 'ADC10AE1', full_name = 'ADC10 input enable register 1')
+        ],
+        0x1: [
+            Register(2, name = 'ADC10CTL0', full_name = 'ADC10 control register 0'),
+            Register(2, name = 'ADC10CTL1', full_name = 'ADC10 control register 1', wmask = CINT(0xFFFE, 16, 4)),
+            Register(2, name = 'ADC10MEM', access = 'r', reset = None, full_name = 'ADC10 memory'),
+            Register(6),
+            Register(2, name = 'ADC10SA', reset = CINT(0x0200, 16, 4), full_name = 'ADC10 data transfer start address', wmask = CINT(0xFFFE, 16, 4))
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0x1,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_adc12 = SysBusDeviceDescription(
+    name = "MSP430 ADC12",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x3,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'ADC12CTL0', full_name = 'ADC12 control register 0'),
+            Register(2, name = 'ADC12CTL1', full_name = 'ADC12 control register 1'),
+            Register(2, name = 'ADC12IFG', full_name = 'ADC12 interrupt flag register'),
+            Register(2, name = 'ADC12IE', full_name = 'ADC12 interrupt enable register'),
+            Register(2, name = 'ADC12IV', access = 'r', full_name = 'ADC12 interrupt vector word')
+        ],
+        0x1: MemoryROMNode(
+            name = CSTR('ADC12 memory'),
+            size = CINT(32, 10, 0)
+        ),
+        0x2: MemoryROMNode(
+            name = CSTR('ADC12 memory control'),
+            size = CINT(16, 10, 0),
+            var_base = "ctl"
+        )
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_dac12 = SysBusDeviceDescription(
+    name = "MSP430 DAC12",
+    directory = "msp430",
+    out_irq_num = 0x1,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'DAC12_xCTL', full_name = 'DAC12_x control')
+        ],
+        0x1: [
+            Register(2, name = 'DAC12_xDAT', full_name = 'DAC12_x data', wmask = CINT(0x0FFF, 16, 4))
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_sd16_a = SysBusDeviceDescription(
+    name = "MSP430 SD16_A",
+    directory = "msp430",
+    out_irq_num = 0x2,
+    in_irq_num = 0,
+    mmio_num = 0x2,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(2, name = 'SD16CTL', full_name = 'SD16_A control', wmask = CINT(0x0FFE, 16, 4)),
+            Register(2, name = 'SD16CCTL0', full_name = 'SD16_A channel 0 control', wmask = CINT(0x7FFE, 16, 4)),
+            Register(14),
+            Register(2, name = 'SD16IV', access = 'r', full_name = 'SD16_A interrupt vector'),
+            Register(2, name = 'SD16MEM0', access = 'r', full_name = 'SD16_A conversion memory')
+        ],
+        0x1: [
+            Register(1, name = 'SD16INCTL0', full_name = 'SD16_A input control'),
+            Register(6),
+            Register(1, name = 'SD16AE', full_name = 'SD16_A analog enable')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0,
+    block_num = 0
+)
+
+msp430_usci_a = SysBusDeviceDescription(
+    name = "MSP430 USCI_A",
+    directory = "msp430",
+    out_irq_num = 0x2,
+    in_irq_num = 0,
+    mmio_num = 0x1,
+    pio_num = 0,
+    mmio = {
+        0: [
+            Register(1, name = 'UCAxABCTL', full_name = 'USCI_Ax Auto baud control register'),
+            Register(1, name = 'UCAxIRTCTL', full_name = 'USCI_Ax IrDA transmit control register'),
+            Register(1, name = 'UCAxIRRCTL', full_name = 'USCI_Ax IrDA receive control register'),
+            Register(1, name = 'UCAxCTL0', full_name = 'USCI_Ax control register 0'),
+            Register(1, name = 'UCAxCTL1', reset = CINT(0x01, 16, 2), full_name = 'USCI_Ax control register 1'),
+            Register(1, name = 'UCAxBR0', full_name = 'USCI_Ax Baud rate control register 0'),
+            Register(1, name = 'UCAxBR1', full_name = 'USCI_Ax Baud rate control register 1'),
+            Register(1, name = 'UCAxMCTL', full_name = 'USCI_Ax modulation control register'),
+            Register(1, name = 'UCAxSTAT', full_name = 'USCI_Ax status register'),
+            Register(1, name = 'UCAxRXBUF', access = 'r', full_name = 'USCI_Ax receive buffer register'),
+            Register(1, name = 'UCAxTXBUF', full_name = 'USCI_Ax transmit buffer register')
+        ]
+    },
+    pio = None,
+    nic_num = 0,
+    timer_num = 0,
+    char_num = 0x1,
+    block_num = 0
+)
+
+msp430_adc10_l0 = GUILayout(
+    desc_name = "MSP430 ADC10",
+    opaque = {},
+    shown = False
+)
+msp430_adc10_l0.lid = 0
+
+msp430_adc12_l0 = GUILayout(
+    desc_name = "MSP430 ADC12",
+    opaque = {},
+    shown = False
+)
+msp430_adc12_l0.lid = 0
+
+msp430_bcm_l0 = GUILayout(
+    desc_name = "MSP430 BCM+",
+    opaque = {},
+    shown = False
+)
+msp430_bcm_l0.lid = 0
+
+msp430_comp_a_l0 = GUILayout(
+    desc_name = "MSP430 Comp A+",
+    opaque = {},
+    shown = False
+)
+msp430_comp_a_l0.lid = 0
+
+msp430_dac12_l0 = GUILayout(
+    desc_name = "MSP430 DAC12",
+    opaque = {},
+    shown = False
+)
+msp430_dac12_l0.lid = 0
+
+msp430_dma_l0 = GUILayout(
+    desc_name = "MSP430 DMA",
+    opaque = {},
+    shown = False
+)
+msp430_dma_l0.lid = 0
+
+msp430_fmc_l0 = GUILayout(
+    desc_name = "MSP430 FMC",
+    opaque = {},
+    shown = False
+)
+msp430_fmc_l0.lid = 0
+
+msp430_ic_l0 = GUILayout(
+    desc_name = "MSP430 IC",
+    opaque = {},
+    shown = False
+)
+msp430_ic_l0.lid = 0
+
+msp430_io_l0 = GUILayout(
+    desc_name = "MSP430 IO",
+    opaque = {},
+    shown = False
+)
+msp430_io_l0.lid = 0
+
+msp430_oa_l0 = GUILayout(
+    desc_name = "MSP430 OA",
+    opaque = {},
+    shown = False
+)
+msp430_oa_l0.lid = 0
+
+msp430_sd16_a_l0 = GUILayout(
+    desc_name = "MSP430 SD16_A",
+    opaque = {},
+    shown = False
+)
+msp430_sd16_a_l0.lid = 0
+
+msp430_svs_l0 = GUILayout(
+    desc_name = "MSP430 SVS",
+    opaque = {},
+    shown = False
+)
+msp430_svs_l0.lid = 0
+
+msp430_timer_a_l0 = GUILayout(
+    desc_name = "MSP430 Timer A",
+    opaque = {},
+    shown = False
+)
+msp430_timer_a_l0.lid = 0
+
+msp430_timer_b_l0 = GUILayout(
+    desc_name = "MSP430 Timer B",
+    opaque = {},
+    shown = False
+)
+msp430_timer_b_l0.lid = 0
+
+msp430_usci_a_l0 = GUILayout(
+    desc_name = "MSP430 USCI_A",
+    opaque = {},
+    shown = False
+)
+msp430_usci_a_l0.lid = 0
+
+msp430_usi_l0 = GUILayout(
+    desc_name = "MSP430 USI",
+    opaque = {},
+    shown = False
+)
+msp430_usi_l0.lid = 0
+
+msp430_wdt_l0 = GUILayout(
+    desc_name = "MSP430 WDT+",
+    opaque = {},
+    shown = False
+)
+msp430_wdt_l0.lid = 0
+
+obj = MachineWidgetLayout(
+    mdwl = {
+        -1: {
+            "IRQ lines points": {
+                0x19: [
+                    (
+                        31.0,
+                        452.0
+                    ),
+                    (
+                        37.0,
+                        200.0
+                    )
+                ],
+                0x1a: [
+                    (
+                        42.0,
+                        440.0
+                    ),
+                    (
+                        47.0,
+                        212.0
+                    )
+                ],
+                0x1b: []
+            },
+            "mesh step": 0x14,
+            "physical layout": False,
+            "show mesh": False
+        },
+        0: (
+            368.0,
+            136.0
+        ),
+        0x1: (
+            340.0,
+            40.0
+        ),
+        0x4: (
+            420.0,
+            180.0
+        ),
+        0x5: (
+            560.0,
+            200.0
+        ),
+        0x6: (
+            100.0,
+            180.0
+        ),
+        0x7: (
+            420.0,
+            220.0
+        ),
+        0x8: (
+            560.0,
+            240.0
+        ),
+        0x9: (
+            260.0,
+            200.0
+        ),
+        0xa: (
+            100.0,
+            240.0
+        ),
+        0xb: (
+            260.0,
+            260.0
+        ),
+        0xc: (
+            100.0,
+            280.0
+        ),
+        0xd: (
+            240.0,
+            300.0
+        ),
+        0xe: (
+            420.0,
+            260.0
+        ),
+        0xf: (
+            560.0,
+            280.0
+        ),
+        0x10: (
+            560.0,
+            320.0
+        ),
+        0x11: (
+            560.0,
+            360.0
+        ),
+        0x12: (
+            420.0,
+            300.0
+        ),
+        0x13: (
+            100.0,
+            320.0
+        ),
+        0x14: (
+            100.0,
+            360.0
+        ),
+        0x15: (
+            420.0,
+            400.0
+        ),
+        0x16: (
+            420.0,
+            440.0
+        ),
+        0x17: (
+            100.0,
+            400.0
+        ),
+        0x18: (
+            100.0,
+            440.0
+        )
+    },
+    mtwl = {
+        -1: {
+            "columns width": {
+                "#0": 0xa0,
+                "id": 0x51,
+                "offset": 0x62,
+                "size": 0x98,
+                "type": 0x141
+            }
+        },
+        0x2: True
+    },
+    use_tabs = True
+)
+
+msp430x2xx_l0 = GUILayout(
+    desc_name = "msp430x2xx",
+    opaque = obj,
+    shown = True
+)
+msp430x2xx_l0.lid = 0
+
+project = GUIProject(
+    layouts = [
+        msp430_adc10_l0,
+        msp430_adc12_l0,
+        msp430_bcm_l0,
+        msp430_comp_a_l0,
+        msp430_dac12_l0,
+        msp430_dma_l0,
+        msp430_fmc_l0,
+        msp430_ic_l0,
+        msp430_io_l0,
+        msp430_oa_l0,
+        msp430_sd16_a_l0,
+        msp430_svs_l0,
+        msp430_timer_a_l0,
+        msp430_timer_b_l0,
+        msp430_usci_a_l0,
+        msp430_usi_l0,
+        msp430_wdt_l0,
+        msp430x2xx_l0
+    ],
+    target_version = "v5.1.0",
+    descriptions = [
+        msp430x2xx,
+        msp430_bcm,
+        msp430_dma,
+        msp430_ic,
+        msp430_fmc,
+        msp430_io,
+        msp430_svs,
+        msp430_wdt,
+        msp430_timer_a,
+        msp430_timer_b,
+        msp430_usi,
+        msp430_oa,
+        msp430_comp_a,
+        msp430_adc10,
+        msp430_adc12,
+        msp430_dac12,
+        msp430_sd16_a,
+        msp430_usci_a
+    ]
+)
+

--- a/examples/MSP430/msp430/tests/.gitignore
+++ b/examples/MSP430/msp430/tests/.gitignore
@@ -1,0 +1,9 @@
+# Python caches for test scripts.
+*.pyc
+# Those files are produced by test suite.
+*.o
+*.elf
+*.elf.txt
+*.hex
+*.disas
+*.log

--- a/examples/MSP430/msp430/tests/addc_sr.py
+++ b/examples/MSP430/msp430/tests/addc_sr.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class ADDC_SR_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/addc_sr.s
+++ b/examples/MSP430/msp430/tests/addc_sr.s
@@ -1,0 +1,15 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #-2, r4
+setc
+addc r2, r4
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/addcb.py
+++ b/examples/MSP430/msp430/tests/addcb.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class ADDC_B_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/addcb.s
+++ b/examples/MSP430/msp430/tests/addcb.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov.b #-2, r4
+mov.b #1, r5
+setc
+addc.b r4, r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_absolute.py
+++ b/examples/MSP430/msp430/tests/call_absolute.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class CALL_Abs_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_absolute.s
+++ b/examples/MSP430/msp430/tests/call_absolute.s
@@ -1,0 +1,19 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+call &addr_br
+addr_br:
+.word br_1
+mov #0, r4
+mov #0, r5
+br_1:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_imm.py
+++ b/examples/MSP430/msp430/tests/call_imm.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class CALL_Imm_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_imm.s
+++ b/examples/MSP430/msp430/tests/call_imm.s
@@ -1,0 +1,17 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+call #br_1
+mov #0, r4
+mov #0, r5
+br_1:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_indexed_sp.py
+++ b/examples/MSP430/msp430/tests/call_indexed_sp.py
@@ -1,0 +1,17 @@
+from tools import *
+
+
+class CALL_Idx_SP_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_indexed_sp.s
+++ b/examples/MSP430/msp430/tests/call_indexed_sp.s
@@ -1,0 +1,33 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0
+push #0
+push #0
+pop r15
+pop r15
+pop r15
+push #mov_1
+push #mov_2
+push #br_2
+br_1:
+add #2, r1
+
+.word 0x1291 ;call 0(r1)
+.word 0x0000
+
+mov_1:
+mov #0, r4
+mov_2:
+mov #0, r5
+br_2:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_indirect_autoincrement_sp.py
+++ b/examples/MSP430/msp430/tests/call_indirect_autoincrement_sp.py
@@ -1,0 +1,17 @@
+from tools import *
+
+
+class CALL_Auto_Inc_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(0, 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack(-2, 4)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_indirect_autoincrement_sp.s
+++ b/examples/MSP430/msp430/tests/call_indirect_autoincrement_sp.s
@@ -1,0 +1,30 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0
+push #0
+push #0
+pop r15
+pop r15
+pop r15
+push #mov_1
+push #mov_2
+push #br_2
+br_1:
+add #2, r1
+call @r1+
+mov_1:
+mov #0, r4
+mov_2:
+mov #0, r5
+br_2:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_indirect_sp.py
+++ b/examples/MSP430/msp430/tests/call_indirect_sp.py
@@ -1,0 +1,17 @@
+from tools import *
+
+
+class CALL_Indirect_SP(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_indirect_sp.s
+++ b/examples/MSP430/msp430/tests/call_indirect_sp.s
@@ -1,0 +1,30 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0
+push #0
+push #0
+pop r15
+pop r15
+pop r15
+push #mov_1
+push #mov_2
+push #br_2
+br_1:
+add #2, r1
+call @r1
+mov_1:
+mov #0, r4
+mov_2:
+mov #0, r5
+br_2:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_sp.py
+++ b/examples/MSP430/msp430/tests/call_sp.py
@@ -1,0 +1,17 @@
+from tools import *
+
+
+class CALL_SP_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(-2, 8)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack(0, 10)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_sp.s
+++ b/examples/MSP430/msp430/tests/call_sp.s
@@ -1,0 +1,34 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+.p2alignw 11, 0x4303
+
+.rept 121
+nop
+.endr
+
+mov #0, r12
+
+push #br_2
+push #0x4030 ;br
+
+push #0x4304 ;mov #0, r4
+push #0x4305 ;mov #0, r5
+push #0x4306 ;mov #0, r6
+
+add #2, r1 ;sp on "mov #0, r5"
+br_1:
+call r1
+mov #0, r7
+mov #0, r8
+br_2:
+mov #0, r9
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/call_symbolic.py
+++ b/examples/MSP430/msp430/tests/call_symbolic.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class CALL_Sym_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/call_symbolic.s
+++ b/examples/MSP430/msp430/tests/call_symbolic.s
@@ -1,0 +1,18 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+call 2(r0)
+.word br_1
+mov #0, r4
+mov #0, r5
+br_1:
+mov #0, r6
+ret
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/daddb.py
+++ b/examples/MSP430/msp430/tests/daddb.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class DADD_B_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/daddb.s
+++ b/examples/MSP430/msp430/tests/daddb.s
@@ -1,0 +1,15 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov.b #0x98, r5
+setc
+dadd.b #0, r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/diff-all.sh
+++ b/examples/MSP430/msp430/tests/diff-all.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+for f in $(ls | grep qemu.log | sed -e s/[.]qemu[.]log//);
+do
+    if [ "" != "$(diff $f.qemu.log $f.hw.log)" ];
+    then
+        echo "$f differs"
+        diff -U 10 $f.qemu.log $f.hw.log > $f.diff;
+    fi;
+done
+

--- a/examples/MSP430/msp430/tests/main.c
+++ b/examples/MSP430/msp430/tests/main.c
@@ -1,0 +1,8 @@
+void test();
+
+int main(void)
+{
+	test();
+	return 0;
+}
+

--- a/examples/MSP430/msp430/tests/mov_absolute.py
+++ b/examples/MSP430/msp430/tests/mov_absolute.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class MOV_Abs_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/mov_absolute.s
+++ b/examples/MSP430/msp430/tests/mov_absolute.s
@@ -1,0 +1,14 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #0x300, r1
+mov #0xfeed, &0x300
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/mov_pc.py
+++ b/examples/MSP430/msp430/tests/mov_pc.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class MOV_PC_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/mov_pc.s
+++ b/examples/MSP430/msp430/tests/mov_pc.s
@@ -1,0 +1,14 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov r0, r4
+mov @r0, r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/mov_symbolic.py
+++ b/examples/MSP430/msp430/tests/mov_symbolic.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class MOV_Sym_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/mov_symbolic.s
+++ b/examples/MSP430/msp430/tests/mov_symbolic.s
@@ -1,0 +1,13 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov 0, r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/mov_symbolic_2.py
+++ b/examples/MSP430/msp430/tests/mov_symbolic_2.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class MOV_Sym_2_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/mov_symbolic_2.s
+++ b/examples/MSP430/msp430/tests/mov_symbolic_2.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+.p2alignw 11, 0x4303
+
+mov #0x300, r1
+mov #0xfeed, 0x32f8(r0)
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_absolute.py
+++ b/examples/MSP430/msp430/tests/push_absolute.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_Abs_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 4)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_absolute.s
+++ b/examples/MSP430/msp430/tests/push_absolute.s
@@ -1,0 +1,15 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #0x300, r1
+push #0x1234
+push &0x2fe
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_indexed.py
+++ b/examples/MSP430/msp430/tests/push_indexed.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_Idx_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_indexed.s
+++ b/examples/MSP430/msp430/tests/push_indexed.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0xfeed
+push #0x1234
+push 2(r1)
+mov 2(r1), r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_indexed_2.py
+++ b/examples/MSP430/msp430/tests/push_indexed_2.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_Idx_2_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_indexed_2.s
+++ b/examples/MSP430/msp430/tests/push_indexed_2.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0x1234
+push #0xfeed
+mov r1, r5
+push 2(r5)
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_indirect_autoincrement_sp.py
+++ b/examples/MSP430/msp430/tests/push_indirect_autoincrement_sp.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_Auto_Inc_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(-2, 2)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_indirect_autoincrement_sp.s
+++ b/examples/MSP430/msp430/tests/push_indirect_autoincrement_sp.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0x1234
+push #0xfeed
+pop r5
+push @r1+
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_indirect_sp.py
+++ b/examples/MSP430/msp430/tests/push_indirect_sp.py
@@ -1,0 +1,12 @@
+from tools import *
+
+
+class PUSH_Indirect_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 4)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True
+

--- a/examples/MSP430/msp430/tests/push_indirect_sp.s
+++ b/examples/MSP430/msp430/tests/push_indirect_sp.s
@@ -1,0 +1,16 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0x1234
+push #0xfeed
+pop r5
+push @r1
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_pc.py
+++ b/examples/MSP430/msp430/tests/push_pc.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_PC_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 6)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_pc.s
+++ b/examples/MSP430/msp430/tests/push_pc.s
@@ -1,0 +1,19 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push @r0
+
+.word 0x1210 ;push 0(r0)
+.word 0
+
+push r0
+subc 2(r1), 0(r1)
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/push_sp.py
+++ b/examples/MSP430/msp430/tests/push_sp.py
@@ -1,0 +1,14 @@
+from tools import *
+
+
+class PUSH_SP_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(-2, 6)
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack(-2, 6)
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_sp.s
+++ b/examples/MSP430/msp430/tests/push_sp.s
@@ -1,0 +1,32 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #0x240, r4
+mov #0x260, r5
+call #zerorange
+
+mov r1, r5
+decd r5 ; don't zero ret addr
+mov r1, r4
+sub #20, r4
+call #zerorange
+
+sub #10, r1
+
+push r1
+br_1:
+pop r1
+push.w #0x250
+pop r1
+br_2:
+mov r5, r1
+
+.include "tools/pop_regs.s"
+
+ret
+
+.include "tools/zerorange.s"

--- a/examples/MSP430/msp430/tests/push_symbolic.py
+++ b/examples/MSP430/msp430/tests/push_symbolic.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_Sym_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/push_symbolic.s
+++ b/examples/MSP430/msp430/tests/push_symbolic.s
@@ -1,0 +1,13 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push 2(r0)
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/pushb_cg.py
+++ b/examples/MSP430/msp430/tests/pushb_cg.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class PUSH_B_CG_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(end_offset = 12)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/pushb_cg.s
+++ b/examples/MSP430/msp430/tests/pushb_cg.s
@@ -1,0 +1,25 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0
+push #0
+push #0
+push #0
+push #0
+push #0
+add #12, r1
+push.b #-1
+push.b #0
+push.b #1
+push.b #2
+push.b #4
+push.b #8
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/readme.md
+++ b/examples/MSP430/msp430/tests/readme.md
@@ -1,0 +1,3 @@
+# Tests for MSP430 in assembly
+
+Use with "misc/msp430_test.py"  of QDT (branch `msp430_hw_test`).

--- a/examples/MSP430/msp430/tests/rra_sr.py
+++ b/examples/MSP430/msp430/tests/rra_sr.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class RRA_SR_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/rra_sr.s
+++ b/examples/MSP430/msp430/tests/rra_sr.s
@@ -1,0 +1,15 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+setn
+setc
+rra r2
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/rrab.py
+++ b/examples/MSP430/msp430/tests/rrab.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class RRA_B_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/rrab.s
+++ b/examples/MSP430/msp430/tests/rrab.s
@@ -1,0 +1,14 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #-2, r5
+rra.b r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/rrcb_indirect.py
+++ b/examples/MSP430/msp430/tests/rrcb_indirect.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class RRC_B_Indirect_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/rrcb_indirect.s
+++ b/examples/MSP430/msp430/tests/rrcb_indirect.s
@@ -1,0 +1,15 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push #0x1234
+mov r1, r5
+rrc.b @r5
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/subcb_pc.py
+++ b/examples/MSP430/msp430/tests/subcb_pc.py
@@ -1,0 +1,16 @@
+from tools import *
+
+
+class SUBC_B_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+
+    def on_br2(self):
+        "br_2"
+        self.dump_stack()
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/subcb_pc.s
+++ b/examples/MSP430/msp430/tests/subcb_pc.s
@@ -1,0 +1,19 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+setc
+subc.b r0, r4
+br_1:
+push #4
+setc
+subc.b r0, 0(r1)
+br_2:
+pop r4
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/swap_irqs.py
+++ b/examples/MSP430/msp430/tests/swap_irqs.py
@@ -1,0 +1,11 @@
+from tools import *
+
+
+class Swap_IRQs_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        self.dump_stack(-2, 0)
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/swap_irqs.s
+++ b/examples/MSP430/msp430/tests/swap_irqs.s
@@ -1,0 +1,17 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+push r2
+bic #8, r2
+nop
+bis #8, r2
+pop r2
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/swpb_1.py
+++ b/examples/MSP430/msp430/tests/swpb_1.py
@@ -1,0 +1,10 @@
+from tools import *
+
+
+class SWPB_1_Test(MSP430Watcher):
+
+    def on_br1(self):
+        "br_1"
+        # registers will be printed by RSP in verbose mode
+        self.rsp.step_over_br()
+        self.rsp.exit = True

--- a/examples/MSP430/msp430/tests/swpb_1.s
+++ b/examples/MSP430/msp430/tests/swpb_1.s
@@ -1,0 +1,14 @@
+.global test
+
+test:
+
+.include "tools/push_regs.s"
+.include "tools/enum_regs.s"
+
+mov #0xBEEF, r10
+swpb r10
+br_1:
+
+.include "tools/pop_regs.s"
+
+ret

--- a/examples/MSP430/msp430/tests/tests_comparator.py
+++ b/examples/MSP430/msp430/tests/tests_comparator.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+
+from glob import (
+    glob
+)
+from os.path import (
+    abspath,
+    isdir,
+    join,
+    basename,
+    splitext
+)
+from difflib import (
+    unified_diff
+)
+from os import (
+    getcwd
+)
+
+def main():
+    directory = getcwd()
+    for f in glob(join(directory, "*.s")):
+        test = splitext(basename(f))[0]
+
+        with open(join(directory, test + ".hw.log"), "r") as f:
+            hw_log = f.readlines()
+
+        with open(join(directory, test + ".qemu.log"), "r") as f:
+            qemu_log = f.readlines()
+
+        if hw_log == qemu_log:
+            print("TEST %s OK" % test)
+        else:
+            print("TEST %s DIFFER:" % test)
+            print("".join(unified_diff(hw_log, qemu_log)))
+
+main()

--- a/examples/MSP430/msp430/tests/tools/__init__.py
+++ b/examples/MSP430/msp430/tests/tools/__init__.py
@@ -1,0 +1,26 @@
+__all__ = [
+    "MSP430Watcher",
+]
+
+from debug import (
+    RSPWatcher,
+)
+from pyrsp.utils import (
+    hexdump,
+)
+
+
+class MSP430Watcher(RSPWatcher):
+    "Generic class for all MSP430 asm level tests"
+
+    def __init__(self, rsp, elf_file_name):
+        rsp.verbose = True
+
+        super(MSP430Watcher, self).__init__(rsp, elf_file_name)
+
+    def dump_stack(self, start_offset = 0, end_offset = 2):
+        stack_addr = int(self.rsp.r1, base = 16)
+        print("stack_addr 0x%x" % stack_addr)
+        start_addr = stack_addr + start_offset
+        stack_data = self.rsp[start_addr : (stack_addr + end_offset)]
+        print("stack data:\n" + hexdump(stack_data, start_addr))

--- a/examples/MSP430/msp430/tests/tools/enum_regs.s
+++ b/examples/MSP430/msp430/tests/tools/enum_regs.s
@@ -1,0 +1,12 @@
+mov #4, r4
+mov #5, r5
+mov #6, r6
+mov #7, r7
+mov #8, r8
+mov #9, r9
+mov #10, r10
+mov #11, r11
+mov #12, r12
+mov #13, r13
+mov #14, r14
+mov #15, r15

--- a/examples/MSP430/msp430/tests/tools/pop_regs.s
+++ b/examples/MSP430/msp430/tests/tools/pop_regs.s
@@ -1,0 +1,12 @@
+pop r15
+pop r14
+pop r13
+pop r12
+pop r11
+pop r10
+pop r9
+pop r8
+pop r7
+pop r6
+pop r5
+pop r4

--- a/examples/MSP430/msp430/tests/tools/push_regs.s
+++ b/examples/MSP430/msp430/tests/tools/push_regs.s
@@ -1,0 +1,12 @@
+push r4
+push r5
+push r6
+push r7
+push r8
+push r9
+push r10
+push r11
+push r12
+push r13
+push r14
+push r15

--- a/examples/MSP430/msp430/tests/tools/zerorange.s
+++ b/examples/MSP430/msp430/tests/tools/zerorange.s
@@ -1,0 +1,13 @@
+; r4 - start, r5 - end
+zerorange:
+bic #1, r4 ; align
+
+_zerorange_loop:
+cmp r5, r4
+jhs _zeromem_ret
+mov.w #0, @r4
+incd r4
+jmp _zerorange_loop
+
+_zeromem_ret:
+ret

--- a/examples/MSP430/patches/MSP430-CPU-reset-interrupts-GDB-RSP-access.patch
+++ b/examples/MSP430/patches/MSP430-CPU-reset-interrupts-GDB-RSP-access.patch
@@ -1,0 +1,459 @@
+From 43e83836bb8da547541fac75a9ba51a4e8a8f2c8 Mon Sep 17 00:00:00 2001
+From: Efimov Vasily <real@ispras.ru>
+Date: Fri, 8 Oct 2021 18:06:18 +0300
+Subject: [PATCH] MSP430 CPU: reset, interrupts, GDB RSP access
+
+Signed-off-by: Efimov Vasily <real@ispras.ru>
+---
+ target/msp430/cpu.c           |  18 +++-
+ target/msp430/cpu.h           | 105 +++++++++++++++++++-
+ target/msp430/helper.c        | 179 +++++++++++++++++++++++++++++++++-
+ target/msp430/helper.h        |   1 +
+ target/msp430/machine.c       |   6 ++
+ target/msp430/translate.inc.c |  10 +-
+ 6 files changed, 306 insertions(+), 13 deletions(-)
+
+diff --git a/target/msp430/cpu.c b/target/msp430/cpu.c
+index dc030204f0..fc5ae944bc 100644
+--- a/target/msp430/cpu.c
++++ b/target/msp430/cpu.c
+@@ -42,12 +42,16 @@ static int msp430_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
+     MSP430CPU *cpu = MSP430_CPU(cs);
+     CPUMSP430State *env = &cpu->env;
+ 
++    /* PC & SP are word aligned. */
+     switch (n) {
+-    case 0:
+-        env->pc = lduw_p(mem_buf);
++    case 0: /* PC */
++        env->pc = lduw_p(mem_buf) & 0xFFFE;
+         return 2;
+-    case 1 ... 15:
+-        env->regs[n - 1] = lduw_p(mem_buf);
++    case 1: /* SP */
++        env->regs[0] = lduw_p(mem_buf) & 0xFFFE;
++        return 2;
++    case 2 ... 15:
++        env->regs[n - 1] = lduw_p(mem_buf) & 0xFFFF;
+         return 2;
+     default:
+         return 0;
+@@ -84,7 +88,8 @@ static void msp430_cpu_reset(DeviceState *dev)
+ 
+     cc->parent_reset(dev);
+     memset(env, 0, offsetof(CPUMSP430State, end_reset_fields));
+-    env->pc = 0;
++
++    cs->exception_index = EXCP_RESET;
+ }
+ 
+ static void msp430_cpu_set_pc(CPUState *cs, vaddr value)
+@@ -95,6 +100,8 @@ static void msp430_cpu_set_pc(CPUState *cs, vaddr value)
+ }
+ 
+ static Property msp430_cpu_properties[] = {
++    DEFINE_PROP_UINT32("single-source-interrupts", MSP430CPU,
++                       single_source_interrupts, 0xFFFFFFFF),
+     DEFINE_PROP_END_OF_LIST()
+ };
+ 
+@@ -110,6 +117,7 @@ static void msp430_cpu_class_init(ObjectClass *oc, void *data)
+     device_class_set_parent_reset(dc, msp430_cpu_reset, &mcc->parent_reset);
+     cc->has_work = msp430_cpu_has_work;
+     cc->do_interrupt = msp430_cpu_do_interrupt;
++    cc->cpu_exec_interrupt = msp430_cpu_exec_interrupt;
+     cc->set_pc = msp430_cpu_set_pc;
+     cc->dump_state = msp430_cpu_dump_state;
+     cc->disas_set_info = msp430_cpu_disas_set_info;
+diff --git a/target/msp430/cpu.h b/target/msp430/cpu.h
+index 6ef5a516bb..cd53c7bd1e 100644
+--- a/target/msp430/cpu.h
++++ b/target/msp430/cpu.h
+@@ -5,17 +5,61 @@
+ #include "migration/vmstate.h"
+ #include "exec/cpu-defs.h"
+ 
++/* Status Register (SR, R2) flags */
++#define SR(env) (env->regs[1])
++#define SR_C            0x0001
++#define SR_Z            0x0002
++#define SR_N            0x0004
++#define SR_GIE          0x0008
++#define SR_CPUOFF       0x0010
++#define SR_OSCOFF       0x0020
++#define SR_SCG0         0x0040
++#define SR_SCG1         0x0080
++#define SR_V            0x0100
++
++/* ifg/ie (interrupt flag/interrupt enable) fields are an implementation
++ * tricks. ifg contains 1 for all currently active IRQs. 1 in ie enables the
++ * interrupt.
++ *
++ * Bit shift corresponds to interrupt vector/priority (less
++ * shift - greater priority). There is one-one correspondence between
++ * vector address word offset in ROM and vector priority.
++ *
++ * Some of ifg/ie bits corresponds to bits of IFG1, IFG2 and IE1, IE2
++ * registers.
++ * The IC (interrupt controller, an implementation trick too) manages the
++ * mapping between IFG(1,2)/IE(1,2) and ifg/ie.
++ * Some interrupt flags and enable bits are located in registers of
++ * corresponding devices. ifg only mirrors them, ie should not mask such
++ * interrupts because IC must not provide write access to corresponding bits.
++ * */
++
+ typedef struct CPUMSP430State {
+     uint32_t pc;
+     uint32_t regs[15];
++
++    uint32_t ie;
++
++    uint8_t ie1;
++    uint8_t ie2;
++
+     /* Fields up to this point are cleared by a CPU reset */
+     struct {} end_reset_fields;
++
++    uint32_t ifg;
++
++    uint8_t ifg1;
++    uint8_t ifg2;
+ } CPUMSP430State;
+ 
+ typedef struct MSP430CPU {
+     CPUState parent_obj;
+     CPUNegativeOffsetState neg;
+     CPUMSP430State env;
++
++    /* It's board dependent. Some devices (e.g. Timer_A) has one IRQ to CPU
++     * which is sources by multiple reasons. */
++    uint32_t single_source_interrupts;
+ } MSP430CPU;
+ 
+ typedef MSP430CPU ArchCPU;
+@@ -38,7 +82,10 @@ typedef struct MSP430CPUClass {
+ } MSP430CPUClass;
+ 
+ enum {
+-    EXCP_ILLEGAL = 1
++    /* Exceptions from 0 to 31 are interrupts. */
++    EXCP_RESET = 0,
++
++    EXCP_ILLEGAL = 32
+ };
+ 
+ extern const VMStateDescription vmstate_msp430_cpu;
+@@ -55,6 +102,7 @@ static inline int cpu_mmu_index(CPUMSP430State *env, bool ifetch)
+     return 0;
+ }
+ 
++bool msp430_cpu_exec_interrupt(CPUState *cs, int interrupt_request);
+ void msp430_cpu_do_interrupt(CPUState *cs);
+ void msp430_cpu_dump_state(CPUState *cs, FILE *f, int flags);
+ hwaddr msp430_cpu_get_phys_page_debug(CPUState *cs, vaddr addr);
+@@ -62,4 +110,59 @@ bool msp430_cpu_tlb_fill(CPUState *cs, vaddr address, int size,
+                          MMUAccessType access_type, int mmu_idx, bool probe,
+                          uintptr_t retaddr);
+ void msp430_tcg_init(void);
++
++/* Interrupts for MSP430G2x53 and MSP430G2x13.
++ * References:
++ *  - Table 5. SLAS735J
++ *  - SLAU144J
++ *
++ *
++ * CPU's ifg/ie bits:
++ *
++ * 0: - Reset (non maskable)
++ * 1: - Non-maskable
++ * ...
++ * 8: USCI_A0/USCI_B0 receive, USCI_B0 I2C status. V: 0FFEEh. P: 23.
++ *    IE2:0 (UCA0RXIE), IFG2:0 (UCA0RXIFG)
++ * 9: USCI_A0/USCI_B0 transmit, USCI_B0 I2C receive/transmit. V: 0FFECh. P: 24
++ *    IE2:1 (UCA0TXIE), IFG2:1 (UCA0TXIFG)
++ * ...
++ *
++ * --
++ * V: - vector address
++ * P: - priority
++ */
++
++/* IE1, Interrupt Enable Register 1
++ * */
++#define WDTIE           0x01
++#define OFIE            0x02
++#define NMIIE           0x10
++#define ACCVIE          0x20
++
++/* IE2, Interrupt Enable Register 2
++ * */
++#define UCA0RXIE        0x01
++#define UCA0TXIE        0x02
++#define UCB0RXIE        0x04
++#define UCB0TXIE        0x08
++
++/* IFG1, Interrupt Flag Register 1
++ * */
++#define WDTIFG          WDTIE
++#define OFIFG           OFIE
++#define PORIFG          0x04
++#define RSTIFG          0x08
++#define NMIIFG          NMIIE
++
++/* IFG2, Interrupt Flag Register 2
++ * */
++#define UCA0RXIFG       UCA0RXIE
++#define UCA0TXIFG       UCA0TXIE
++#define UCB0RXIFG       UCB0RXIE
++#define UCB0TXIFG       UCB0TXIE
++
++void msp430_cpu_update_ie(MSP430CPU *cpu);
++void msp430_cpu_update_ifg(MSP430CPU *cpu);
++
+ #endif /* INCLUDE_CPU_H */
+diff --git a/target/msp430/helper.c b/target/msp430/helper.c
+index eca28e20f2..622f33f2ff 100644
+--- a/target/msp430/helper.c
++++ b/target/msp430/helper.c
+@@ -24,7 +24,184 @@ void helper_illegal(CPUMSP430State *env)
+     raise_exception(env, EXCP_ILLEGAL);
+ }
+ 
+-void msp430_cpu_do_interrupt(CPUState *cs) {}
++static unsigned interrupt_ready(CPUMSP430State *env)
++{
++    uint32_t enabled_and_active = env->ie & env->ifg;
++    /* Use 0 as false because reset vector is not covered by
++     * ifg/ie pair. */
++    unsigned vector = 0;
++
++    /* SPAU144J p. 31: (Non)-maskable NMI interrupts are not masked by the
++     * general interrupt enable bit (GIE), but are enabled by individual
++     * interrupt enable bits (NMIIE, ACCVIE, OFIE). */
++    if (enabled_and_active & 2) {
++        vector = 1;
++    } else if ((SR(env) & SR_GIE)) {
++        if (enabled_and_active) {
++            /* less bit shift - greater interrupt priority */
++            vector = ctz32(enabled_and_active);
++        }
++    }
++
++    return vector;
++}
++
++/* Called when SR is used as dst register. It checks interrupt and board
++ * related flags. ALU's flags have no interest for the helper. */
++void helper_check_sr_machine_bits(CPUMSP430State *env)
++{
++    if (interrupt_ready(env)) {
++        CPUState *cpu = env_cpu(env);
++        cpu->interrupt_request |= CPU_INTERRUPT_HARD;
++        cpu_exit(env_cpu(env));
++    }
++}
++
++void msp430_cpu_update_ie(MSP430CPU *cpu)
++{
++    CPUMSP430State *env = &cpu->env;
++
++    uint32_t value = 0;
++
++    if (env->ie1 & (OFIE | NMIIE | ACCVIE)) {
++        value |= 1 << 1;
++    }
++    if (env->ie1 & WDTIE) {
++        value |= 1 << 5;
++    }
++    value |= (env->ie2 & (UCA0RXIE | UCA0TXIE | UCB0RXIE | UCB0TXIE)) << 8;
++
++    env->ie = value;
++
++    if (env->ie & env->ifg) {
++        cpu_interrupt(CPU(cpu), CPU_INTERRUPT_HARD);
++    }
++}
++
++void msp430_cpu_update_ifg(MSP430CPU *cpu)
++{
++    CPUMSP430State *env = &cpu->env;
++
++    uint32_t value = 0;
++
++    /* Note, ACCVIFG is in FCTL3. */
++    if (env->ifg1 & (OFIFG | NMIIFG)) {
++        value |= 1 << 1;
++    }
++    if (env->ifg1 & WDTIFG) {
++        value |= 1 << 5;
++    }
++    value |=
++        (env->ifg2 & (UCA0RXIFG | UCA0TXIFG | UCB0RXIFG | UCB0TXIFG)) << 8;
++
++    env->ifg = value;
++
++    if (env->ie & env->ifg) {
++        cpu_interrupt(CPU(cpu), CPU_INTERRUPT_HARD);
++    }
++}
++
++bool msp430_cpu_exec_interrupt(CPUState *cs, int interrupt_request)
++{
++    bool ret = false;
++
++    if (interrupt_request & CPU_INTERRUPT_HARD) {
++        MSP430CPU *cpu = MSP430_CPU(cs);
++        CPUMSP430State *env = &cpu->env;
++
++        unsigned vector = interrupt_ready(env);
++
++        if (vector) {
++            cs->exception_index = vector;
++            ret = true;
++        }
++
++        /* cs->interrupt_request is reset during msp430_cpu_do_interrupt */
++    }
++
++    if (ret) {
++        msp430_cpu_do_interrupt(cs);
++        /* cs->exception_index will be reset by common cpu_handle_interrupt. */
++    }
++
++    return ret;
++}
++
++void msp430_cpu_do_interrupt(CPUState *cs)
++{
++    if (cs->exception_index < 0) {
++        /* No interrupt. */
++        return;
++    }
++    if (cs->exception_index == EXCP_ILLEGAL) {
++        /* TODO: Illegal instruction handling. Now it's just reset. */
++        cpu_interrupt(cs, CPU_INTERRUPT_RESET);
++        return;
++    }
++
++    if (31 < cs->exception_index) {
++        /* Not an interrupt. */
++        return;
++    }
++
++    MSP430CPU *cpu = MSP430_CPU(cs);
++    CPUMSP430State *env = &cpu->env;
++
++    hwaddr vector_address = 0xFFFE - (cs->exception_index << 1);
++
++    if (cs->exception_index == 0) {
++        /* reset */
++    } else {
++        /* other interrupts */
++
++        /* SLAU144J p. 31: When a NMI interrupt is accepted, all NMI interrupt
++         * enable bits are automatically reset.
++         * */
++        if (cs->exception_index == 1) {
++            env->ie &= ~2;
++            env->ie1 &= ~(OFIE | NMIIE | ACCVIE);
++        }
++
++        /* According to SLAU144J
++         *
++         * > 5. The interrupt request flag resets automatically on
++         * > single-source flags. Multiple source flags remain set
++         * > for servicing by software. */
++        switch (cs->exception_index) {
++        case 5: /* WDT */
++            env->ifg1 &= ~WDTIFG;
++            env->ifg &= ~(1 << 5);
++            break;
++        case 9: /* UCA0TXIE, USCI is always ready to transmit. */
++            break;
++        default:
++            if (cpu->single_source_interrupts & (1 << cs->exception_index)) {
++                env->ifg &= ~(1 << cs->exception_index);
++                if (cs->exception_index > 7) {
++                    env->ifg2 &= ~(1 << (cs->exception_index - 8));
++                } else {
++                    env->ifg1 &= ~(1 << cs->exception_index);
++                }
++            }
++            break;
++        }
++
++        if (interrupt_ready(env)) {
++            cs->interrupt_request |= CPU_INTERRUPT_HARD;
++        } else {
++            cs->interrupt_request &= ~CPU_INTERRUPT_HARD;
++        }
++
++        env->regs[0] -= 2;
++        cpu_stw_data(env, env->regs[0], env->pc);
++        env->regs[0] -= 2;
++        cpu_stw_data(env, env->regs[0], env->regs[1]);
++
++        env->regs[1] = 0;
++    }
++
++    env->pc = cpu_lduw_data(env, vector_address);
++}
+ 
+ hwaddr msp430_cpu_get_phys_page_debug(CPUState *cs, vaddr addr)
+ {
+diff --git a/target/msp430/helper.h b/target/msp430/helper.h
+index 0a10b1061b..caef603d08 100644
+--- a/target/msp430/helper.h
++++ b/target/msp430/helper.h
+@@ -1,2 +1,3 @@
+ DEF_HELPER_1(debug, void, env)
+ DEF_HELPER_1(illegal, void, env)
++DEF_HELPER_1(check_sr_machine_bits, void, env)
+diff --git a/target/msp430/machine.c b/target/msp430/machine.c
+index 6b5338a824..8144d8a4fa 100644
+--- a/target/msp430/machine.c
++++ b/target/msp430/machine.c
+@@ -11,6 +11,12 @@ const VMStateDescription vmstate_msp430_cpu = {
+     .fields = (VMStateField[]) {
+         VMSTATE_UINT32(pc, CPUMSP430State),
+         VMSTATE_UINT32_ARRAY(regs, CPUMSP430State, 15),
++        VMSTATE_UINT32(ie, CPUMSP430State),
++        VMSTATE_UINT32(ifg, CPUMSP430State),
++        VMSTATE_UINT8(ie1, CPUMSP430State),
++        VMSTATE_UINT8(ie2, CPUMSP430State),
++        VMSTATE_UINT8(ifg1, CPUMSP430State),
++        VMSTATE_UINT8(ifg2, CPUMSP430State),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+diff --git a/target/msp430/translate.inc.c b/target/msp430/translate.inc.c
+index 8a374ea17b..ee45ebd57f 100644
+--- a/target/msp430/translate.inc.c
++++ b/target/msp430/translate.inc.c
+@@ -5,11 +5,6 @@
+ #include "exec/exec-all.h"
+ #include "tcg/tcg-op.h"
+ 
+-#define SR_C (1 << 0)
+-#define SR_N (1 << 2)
+-#define SR_V (1 << 8)
+-#define SR_Z (1 << 1)
+-
+ typedef struct DisasContext {
+     TranslationBlock *tb;
+     uint64_t pc;
+@@ -161,7 +156,10 @@ static inline void add_cg2_idx_0(DisasContext *ctx, uint64_t bw, uint64_t as,
+     tcg_temp_free(src_val);
+ }
+ 
+-static inline void do_gen_helper_check_sr_machine_bits(void) {}
++static inline void do_gen_helper_check_sr_machine_bits(void)
++{
++    gen_helper_check_sr_machine_bits(cpu_env);
++}
+ 
+ static inline void add_cg2_reg_0(DisasContext *ctx, uint64_t bw, uint64_t as,
+                                  uint64_t dst)
+-- 
+2.33.1
+

--- a/examples/MSP430/patches/msp430-all-implement-HWM.patch
+++ b/examples/MSP430/patches/msp430-all-implement-HWM.patch
@@ -1,0 +1,752 @@
+From f2514487a925a9e83b194ba93b455bc426ef3886 Mon Sep 17 00:00:00 2001
+From: Efimov Vasily <real@ispras.ru>
+Date: Wed, 9 Dec 2020 14:04:55 +0300
+Subject: [PATCH] msp430-all: implement HWM
+
+Signed-off-by: Efimov Vasily <real@ispras.ru>
+---
+ hw/msp430-all/msp430_hwm.c         | 451 ++++++++++++++++++++++++-----
+ include/hw/msp430-all/msp430_hwm.h |  42 +--
+ 2 files changed, 404 insertions(+), 89 deletions(-)
+
+diff --git a/hw/msp430-all/msp430_hwm.c b/hw/msp430-all/msp430_hwm.c
+index 6bf903999a..ee764db07b 100644
+--- a/hw/msp430-all/msp430_hwm.c
++++ b/hw/msp430-all/msp430_hwm.c
+@@ -8,31 +8,300 @@
+ 
+ #define MSP430_HWM_MMIO TYPE_MSP430_HWM "_mmio"
+ #define MSP430_HWM_MMIO_SIZE 0x2E
++#define MSP430_HWM_MMIO_SIZE_16_BIT_OPER 0x10
++
++/* Multiplier mode */
++#define MPYMx_SHIFT 4
++#define MPYMx_MASK (3 << MPYMx_SHIFT)
++
++#define MPYM_SIGNED         (1 << MPYMx_SHIFT)
++#define MPYM_ACCUMULATE     (1 << (MPYMx_SHIFT + 1))
++
++#define MPYM_MPY  0 /* Multiply (unsigned) */
++#define MPYM_MPYS MPYM_SIGNED
++#define MPYM_MAC  MPYM_ACCUMULATE
++#define MPYM_MACS (MPYM_SIGNED | MPYM_ACCUMULATE)
++
++static inline void set_mode(MSP430HWMState *s, uint16_t mode)
++{
++    s->mpy32ctl0 &= ~MPYMx_MASK;
++    s->mpy32ctl0 |= mode;
++}
++
++static inline bool mode_is_signed(MSP430HWMState *s)
++{
++    return s->mpy32ctl0 & MPYM_SIGNED;
++}
++
++static inline bool mode_is_accumulate(MSP430HWMState *s)
++{
++    return s->mpy32ctl0 & MPYM_ACCUMULATE;
++}
++
++/* Carry of the multiplier. */
++#define MPYC 1
++
++static inline void set_mpyc(MSP430HWMState *s)
++{
++    s->mpy32ctl0 |= MPYC;
++}
++
++static inline void reset_mpyc(MSP430HWMState *s)
++{
++    s->mpy32ctl0 &= ~MPYC;
++}
++
++static inline void assign_mpyc(MSP430HWMState *s, bool set)
++{
++    if (set) {
++        set_mpyc(s);
++    } else {
++        reset_mpyc(s);
++    }
++}
++
++#define MPYOP1_32 (1 << 6)
++
++/* b32 == false -> 16 bit */
++static inline void set_op1_width(MSP430HWMState *s, bool b32)
++{
++    if (b32) {
++        s->mpy32ctl0 |= MPYOP1_32;
++    } else {
++        s->mpy32ctl0 &= ~MPYOP1_32;
++    }
++}
++
++static inline bool get_op1_width(MSP430HWMState *s)
++{
++    return s->mpy32ctl0 & MPYOP1_32;
++}
++
++#define MPYOP2_32 (1 << 7)
++
++/* b32 == false -> 16 bit */
++static inline void set_op2_width(MSP430HWMState *s, bool b32)
++{
++    if (b32) {
++        s->mpy32ctl0 |= MPYOP2_32;
++    } else {
++        s->mpy32ctl0 &= ~MPYOP2_32;
++    }
++}
++
++static inline bool get_op2_width(MSP430HWMState *s)
++{
++    return s->mpy32ctl0 & MPYOP2_32;
++}
++
++static inline void set_op1_lo(MSP430HWMState *s, uint16_t val)
++{
++    s->op1 = (s->op1 & 0xFFFF0000) | val;
++}
++
++static inline uint16_t get_op1_lo(MSP430HWMState *s)
++{
++    /* cast uint32_t to uint16_t truncates the value */
++    return s->op1;
++}
++
++static inline void set_op1_hi(MSP430HWMState *s, uint16_t val)
++{
++    s->op1 = (s->op1 & 0x0000FFFF) | (((uint32_t) val) << 16);
++}
++
++static inline uint16_t get_op1_hi(MSP430HWMState *s)
++{
++    return s->op1 >> 16;
++}
++
++static inline void set_op2_lo(MSP430HWMState *s, uint16_t val)
++{
++    s->op2 = (s->op2 & 0xFFFF0000) | val;
++}
++
++static inline void set_op2_hi(MSP430HWMState *s, uint16_t val)
++{
++    s->op2 = (s->op2 & 0x0000FFFF) | (((uint32_t) val) << 16);
++}
++
++static inline uint16_t get_op2_lo(MSP430HWMState *s)
++{
++    /* cast uint32_t to uint16_t truncates the value */
++    return s->op2;
++}
++
++static inline uint16_t get_op2_hi(MSP430HWMState *s)
++{
++    return s->op2 >> 16;
++}
++
++static inline void set_res_w0(MSP430HWMState *s, uint16_t val)
++{
++    s->res = (s->res & 0xFFFFFFFFFFFF0000) | val;
++}
++
++static inline void set_res_w1(MSP430HWMState *s, uint16_t val)
++{
++    s->res = (s->res & 0xFFFFFFFF0000FFFF) | (((uint64_t) val) << 16);
++}
++
++static inline void set_res_w2(MSP430HWMState *s, uint16_t val)
++{
++    s->res = (s->res & 0xFFFF0000FFFFFFFF) | (((uint64_t) val) << 32);
++}
++
++static inline void set_res_w3(MSP430HWMState *s, uint16_t val)
++{
++    s->res = (s->res & 0x0000FFFFFFFFFFFF) | (((uint64_t) val) << 48);
++}
++
++static inline uint16_t get_res_w0(MSP430HWMState *s)
++{
++    /* Cast uint64_t to uint16_t truncates bits [63:16] */
++    return s->res;
++}
++
++static inline uint16_t get_res_w1(MSP430HWMState *s)
++{
++    return s->res >> 16;
++}
++
++static inline uint16_t get_res_w2(MSP430HWMState *s)
++{
++    return s->res >> 32;
++}
++
++static inline uint16_t get_res_w3(MSP430HWMState *s)
++{
++    return s->res >> 48;
++}
++
++static void multiply_internal(MSP430HWMState *s)
++{
++    bool _signed = mode_is_signed(s);
++    bool accumulate = mode_is_accumulate(s);
++    bool op1_32 = get_op1_width(s);
++    bool op2_32 = get_op2_width(s);
++
++    uint64_t op1 = s->op1;
++    /* During the execution of the 16-bit operation, the content of the
++       high-word is ignored.*/
++    if (!op1_32) {
++        op1 &= 0x0000FFFF;
++    }
++
++    uint64_t op2 = s->op2;
++    if (!op2_32) {
++        op2 &= 0x0000FFFF;
++    }
++
++    /* for negative result identification in signed mode */
++    uint64_t msb;
++    if (op1_32 || op2_32) {
++        msb = 1ul << 63;
++    } else {
++        msb = 1ul << 31;
++    }
++
++    /* TODO: fractional mode */
++    /* TODO: saturation mode */
++
++    uint64_t res = op1 * op2;
++
++    bool carry;
++    if (accumulate) {
++        if (msb == 1 << 31) { /* 32-bit result */
++            res += s->res;
++            carry = res & (1ul << 32);
++        } else { /* 64-bit result */
++            carry = (s->res > UINT64_MAX - res);
++            res += s->res;
++        }
++    } else {
++        carry = false;
++    }
++    s->res = res;
++
++    if (_signed) {
++        bool neg = res & msb;
++        if (neg) {
++            s->sumext = 0xFFFF;
++        } else {
++            s->sumext = 0;
++        }
++        if (accumulate) {
++            assign_mpyc(s, carry);
++        } else {
++            assign_mpyc(s, neg);
++        }
++    } else {
++        if (accumulate) {
++            if (carry) {
++                s->sumext = 0;
++            } else {
++                s->sumext = 1;
++            }
++            assign_mpyc(s, carry);
++        } else {
++            s->sumext = 0;
++            reset_mpyc(s);
++        }
++    }
++}
++
++static void multiply(MSP430HWMState *s)
++{
++    switch ((MSP430HWMMultiplicationState)s->state) {
++    case MSP430HWM_IDLE:
++        break;
++    case MSP430HWM_OP2:
++        /* 16 bit OP1 */
++        multiply_internal(s);
++        break;
++    case MSP430HWM_OP2L:
++        /* high word of OP was not provided, last value will be used.
++           According to docs, it's undefined. */
++    case MSP430HWM_OP2H:
++        /* 32-bit OP2 */
++        multiply_internal(s);
++        break;
++    default:
++        assert(0 && "Unreachable state");
++    }
++
++    s->state = MSP430HWM_IDLE;
++}
+ 
+ static uint64_t msp430_hwm_mmio_read(void *opaque, hwaddr offset, unsigned size)
+ {
+     MSP430HWMState *s = MSP430_HWM(opaque);
+     uint64_t ret = 0;
+ 
++    /* There is no precise clock simulation in Qemu. So, behave as any
++       started multiplication is always finished before consequent read
++       access. I.e. guest is not have to use NOPs. */
++    multiply(s);
++
+     switch (offset) {
+     case 0x00 ... 0x01:
+         /* MPY, 16-bit operand one - multiply */
+-        ret = s->mpy;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x02 ... 0x03:
+         /* MPYS, 16-bit operand one - signed multiply */
+-        ret = s->mpys;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x04 ... 0x05:
+         /* MAC, 16-bit operand one - multiply accumulate */
+-        ret = s->mac;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x06 ... 0x07:
+         /* MACS, 16-bit operand one - signed multiply accumulate */
+-        ret = s->macs;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x08 ... 0x09:
+@@ -42,12 +311,12 @@ static uint64_t msp430_hwm_mmio_read(void *opaque, hwaddr offset, unsigned size)
+ 
+     case 0x0A ... 0x0B:
+         /* RESLO, 16x16-bit result low word */
+-        ret = s->reslo;
++        ret = get_res_w0(s);
+         break;
+ 
+     case 0x0C ... 0x0D:
+         /* RESHI, 16x16-bit result high word */
+-        ret = s->reshi;
++        ret = get_res_w1(s);
+         break;
+ 
+     case 0x0E ... 0x0F:
+@@ -57,72 +326,72 @@ static uint64_t msp430_hwm_mmio_read(void *opaque, hwaddr offset, unsigned size)
+ 
+     case 0x10 ... 0x11:
+         /* MPY32L, 32-bit operand 1 - multiply - low word */
+-        ret = s->mpy32l;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x12 ... 0x13:
+         /* MPY32H, 32-bit operand 1 - multiply - high word */
+-        ret = s->mpy32h;
++        ret = get_op1_hi(s);
+         break;
+ 
+     case 0x14 ... 0x15:
+         /* MPYS32L, 32-bit operand 1 - signed multiply - low word */
+-        ret = s->mpys32l;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x16 ... 0x17:
+         /* MPYS32H, 32-bit operand 1 - signed multiply - high word */
+-        ret = s->mpys32h;
++        ret = get_op1_hi(s);
+         break;
+ 
+     case 0x18 ... 0x19:
+         /* MAC32L, 32-bit operand 1 - multiply accumulate - low word */
+-        ret = s->mac32l;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x1A ... 0x1B:
+         /* MAC32H, 32-bit operand 1 - multiply accumulate - high word */
+-        ret = s->mac32h;
++        ret = get_op1_hi(s);
+         break;
+ 
+     case 0x1C ... 0x1D:
+         /* MACS32L, 32-bit operand 1 - signed multiply accumulate - low word */
+-        ret = s->macs32l;
++        ret = get_op1_lo(s);
+         break;
+ 
+     case 0x1E ... 0x1F:
+         /* MACS32H, 32-bit operand 1 - signed multiply accumulate - high word */
+-        ret = s->macs32h;
++        ret = get_op1_hi(s);
+         break;
+ 
+     case 0x20 ... 0x21:
+         /* OP2L, 32-bit operand 2 - low word */
+-        ret = s->op2l;
++        ret = get_op2_lo(s);
+         break;
+ 
+     case 0x22 ... 0x23:
+         /* OP2H, 32-bit operand 2 - high word */
+-        ret = s->op2h;
++        ret = get_op2_hi(s);
+         break;
+ 
+     case 0x24 ... 0x25:
+         /* RES0, 32x32-bit result 0 - least significant word */
+-        ret = s->res0;
++        ret = get_res_w0(s);
+         break;
+ 
+     case 0x26 ... 0x27:
+         /* RES1, 32x32-bit result 1 */
+-        ret = s->res1;
++        ret = get_res_w1(s);
+         break;
+ 
+     case 0x28 ... 0x29:
+         /* RES2, 32x32-bit result 2 */
+-        ret = s->res2;
++        ret = get_res_w2(s);
+         break;
+ 
+     case 0x2A ... 0x2B:
+         /* RES3, 32x32-bit result 3 - most significant word */
+-        ret = s->res3;
++        ret = get_res_w3(s);
+         break;
+ 
+     case 0x2C ... 0x2D:
+@@ -144,40 +413,70 @@ static void msp430_hwm_mmio_write(void *opaque, hwaddr offset, uint64_t value,
+ {
+     MSP430HWMState *s = MSP430_HWM(opaque);
+ 
++    /* Behave as MPYDLYWRTEN is set because there is no precise clock
++       simulation in Qemu. I.e. a started multiplication is always
++       finished before changing operands. */
++    /* OP2H is expected to be set after multiplication has been started. */
++    if (offset != 0x22 /* OP2H */ ) {
++        multiply(s);
++    }
++
+     switch (offset) {
+     case 0x00 ... 0x01:
+         /* MPY, 16-bit operand one - multiply */
+-        s->mpy = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MPY);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x02 ... 0x03:
+         /* MPYS, 16-bit operand one - signed multiply */
+-        s->mpys = value;
++        if ((size == 1) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MPYS);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x04 ... 0x05:
+         /* MAC, 16-bit operand one - multiply accumulate */
+-        s->mac = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MAC);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x06 ... 0x07:
+         /* MACS, 16-bit operand one - signed multiply accumulate */
+-        s->macs = value;
++        if ((size == 1) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MACS);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x08 ... 0x09:
+         /* OP2, 16-bit operand two */
+-        s->op2 = value;
++        if ((size == 1) && mode_is_signed(s) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op2_lo(s, value);
++        set_op2_width(s, false);
++        s->state = MSP430HWM_OP2;
+         break;
+ 
+     case 0x0A ... 0x0B:
+         /* RESLO, 16x16-bit result low word */
+-        s->reslo = value;
++        set_res_w0(s, value);
+         break;
+ 
+     case 0x0C ... 0x0D:
+         /* RESHI, 16x16-bit result high word */
+-        s->reshi = value;
++        set_res_w1(s, value);
+         break;
+ 
+     case 0x0E ... 0x0F:
+@@ -188,72 +487,102 @@ static void msp430_hwm_mmio_write(void *opaque, hwaddr offset, uint64_t value,
+ 
+     case 0x10 ... 0x11:
+         /* MPY32L, 32-bit operand 1 - multiply - low word */
+-        s->mpy32l = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MPY);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x12 ... 0x13:
+         /* MPY32H, 32-bit operand 1 - multiply - high word */
+-        s->mpy32h = value;
++        set_op1_hi(s, value);
++        set_op1_width(s, true);
+         break;
+ 
+     case 0x14 ... 0x15:
+         /* MPYS32L, 32-bit operand 1 - signed multiply - low word */
+-        s->mpys32l = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MPYS);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x16 ... 0x17:
+         /* MPYS32H, 32-bit operand 1 - signed multiply - high word */
+-        s->mpys32h = value;
++        if ((size == 1) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op1_hi(s, value);
++        set_op1_width(s, true);
+         break;
+ 
+     case 0x18 ... 0x19:
+         /* MAC32L, 32-bit operand 1 - multiply accumulate - low word */
+-        s->mac32l = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MAC);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x1A ... 0x1B:
+         /* MAC32H, 32-bit operand 1 - multiply accumulate - high word */
+-        s->mac32h = value;
++        set_op1_hi(s, value);
++        set_op1_width(s, true);
+         break;
+ 
+     case 0x1C ... 0x1D:
+         /* MACS32L, 32-bit operand 1 - signed multiply accumulate - low word */
+-        s->macs32l = value;
++        set_op1_lo(s, value);
++        set_mode(s, MPYM_MACS);
++        set_op1_width(s, false);
+         break;
+ 
+     case 0x1E ... 0x1F:
+         /* MACS32H, 32-bit operand 1 - signed multiply accumulate - high word */
+-        s->macs32h = value;
++        if ((size == 1) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op1_hi(s, value);
++        set_op1_width(s, true);
+         break;
+ 
+     case 0x20 ... 0x21:
+         /* OP2L, 32-bit operand 2 - low word */
+-        s->op2l = value;
++        set_op2_lo(s, value);
++        set_op2_width(s, true);
++        s->state = MSP430HWM_OP2L;
+         break;
+ 
+     case 0x22 ... 0x23:
+         /* OP2H, 32-bit operand 2 - high word */
+-        s->op2h = value;
++        if ((size == 1) && mode_is_signed(s) && (value & 0x80)) {
++            /* auto sign extension */
++            value |= 0xFF00;
++        }
++        set_op2_hi(s, value);
++        if (s->state == MSP430HWM_OP2L) {
++            s->state = MSP430HWM_OP2H;
++        }
++        multiply(s);
+         break;
+ 
+     case 0x24 ... 0x25:
+         /* RES0, 32x32-bit result 0 - least significant word */
+-        s->res0 = value;
++        set_res_w0(s, value);
+         break;
+ 
+     case 0x26 ... 0x27:
+         /* RES1, 32x32-bit result 1 */
+-        s->res1 = value;
++        set_res_w1(s, value);
+         break;
+ 
+     case 0x28 ... 0x29:
+         /* RES2, 32x32-bit result 2 */
+-        s->res2 = value;
++        set_res_w2(s, value);
+         break;
+ 
+     case 0x2A ... 0x2B:
+         /* RES3, 32x32-bit result 3 - most significant word */
+-        s->res3 = value;
++        set_res_w3(s, value);
+         break;
+ 
+     case 0x2C ... 0x2D:
+@@ -278,16 +607,17 @@ static const MemoryRegionOps msp430_hwm_mmio_ops = {
+ 
+ static void msp430_hwm_instance_init(Object *obj)
+ {
+-    MSP430HWMState *s = MSP430_HWM(obj);
+-
+-    memory_region_init_io(&s->mmio, obj, &msp430_hwm_mmio_ops, s,
+-                          MSP430_HWM_MMIO, MSP430_HWM_MMIO_SIZE);
+-    sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->mmio);
+ }
+ 
+ static void msp430_hwm_realize(DeviceState *dev, Error **errp)
+ {
+-    __attribute__((unused)) MSP430HWMState *s = MSP430_HWM(dev);
++    MSP430HWMState *s = MSP430_HWM(dev);
++
++    memory_region_init_io(&s->mmio, OBJECT(dev), &msp430_hwm_mmio_ops, s,
++                          MSP430_HWM_MMIO,
++                          s->op_32_bit ? MSP430_HWM_MMIO_SIZE
++                                       : MSP430_HWM_MMIO_SIZE_16_BIT_OPER);
++    sysbus_init_mmio(SYS_BUS_DEVICE(dev), &s->mmio);
+ }
+ 
+ static void msp430_hwm_reset(DeviceState *dev)
+@@ -295,6 +625,7 @@ static void msp430_hwm_reset(DeviceState *dev)
+     MSP430HWMState *s = MSP430_HWM(dev);
+ 
+     s->mpy32ctl0 = 0x0000;
++    s->state = MSP430HWM_IDLE;
+ }
+ 
+ static void msp430_hwm_unrealize(DeviceState *dev)
+@@ -303,6 +634,7 @@ static void msp430_hwm_unrealize(DeviceState *dev)
+ }
+ 
+ static Property msp430_hwm_properties[] = {
++    DEFINE_PROP_BOOL("op-32-bit", MSP430HWMState, op_32_bit, true),
+     DEFINE_PROP_END_OF_LIST()
+ };
+ 
+@@ -310,29 +642,12 @@ static const VMStateDescription vmstate_msp430_hwm = {
+     .name = "msp430_hwm",
+     .version_id = 1,
+     .fields = (VMStateField[]) {
+-        VMSTATE_UINT16(mpy, MSP430HWMState),
+-        VMSTATE_UINT16(mpys, MSP430HWMState),
+-        VMSTATE_UINT16(mac, MSP430HWMState),
+-        VMSTATE_UINT16(macs, MSP430HWMState),
+-        VMSTATE_UINT16(op2, MSP430HWMState),
+-        VMSTATE_UINT16(reslo, MSP430HWMState),
+-        VMSTATE_UINT16(reshi, MSP430HWMState),
++        VMSTATE_UINT32(op1, MSP430HWMState),
++        VMSTATE_UINT32(op2, MSP430HWMState),
++        VMSTATE_UINT64(res, MSP430HWMState),
+         VMSTATE_UINT16(sumext, MSP430HWMState),
+-        VMSTATE_UINT16(mpy32l, MSP430HWMState),
+-        VMSTATE_UINT16(mpy32h, MSP430HWMState),
+-        VMSTATE_UINT16(mpys32l, MSP430HWMState),
+-        VMSTATE_UINT16(mpys32h, MSP430HWMState),
+-        VMSTATE_UINT16(mac32l, MSP430HWMState),
+-        VMSTATE_UINT16(mac32h, MSP430HWMState),
+-        VMSTATE_UINT16(macs32l, MSP430HWMState),
+-        VMSTATE_UINT16(macs32h, MSP430HWMState),
+-        VMSTATE_UINT16(op2l, MSP430HWMState),
+-        VMSTATE_UINT16(op2h, MSP430HWMState),
+-        VMSTATE_UINT16(res0, MSP430HWMState),
+-        VMSTATE_UINT16(res1, MSP430HWMState),
+-        VMSTATE_UINT16(res2, MSP430HWMState),
+-        VMSTATE_UINT16(res3, MSP430HWMState),
+         VMSTATE_UINT16(mpy32ctl0, MSP430HWMState),
++        VMSTATE_UINT8(state, MSP430HWMState),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+diff --git a/include/hw/msp430-all/msp430_hwm.h b/include/hw/msp430-all/msp430_hwm.h
+index 803ba1fac3..7f763c491d 100644
+--- a/include/hw/msp430-all/msp430_hwm.h
++++ b/include/hw/msp430-all/msp430_hwm.h
+@@ -7,32 +7,32 @@
+ #define TYPE_MSP430_HWM "msp430_hwm"
+ #define MSP430_HWM(obj) OBJECT_CHECK(MSP430HWMState, (obj), TYPE_MSP430_HWM)
+ 
++/* Multiplication process state. */
++typedef enum {
++    /* No multiplication was made or last one was finished. */
++    MSP430HWM_IDLE = 0,
++
++    /* Started with 16-bit OP2. */
++    MSP430HWM_OP2,
++
++    /* Started with 32-bit OP2 but high OP2 word has not been written to OP2H
++       yet. */
++    MSP430HWM_OP2L,
++
++    /* Started with 32-bit OP2 and both OP2 words have been written. */
++    MSP430HWM_OP2H
++} MSP430HWMMultiplicationState;
++
+ typedef struct MSP430HWMState {
+     SysBusDevice parent_obj;
+     MemoryRegion mmio;
+-    uint16_t mpy;
+-    uint16_t mpys;
+-    uint16_t mac;
+-    uint16_t macs;
+-    uint16_t op2;
+-    uint16_t reslo;
+-    uint16_t reshi;
++    uint32_t op1;
++    uint32_t op2;
++    uint64_t res;
+     uint16_t sumext;
+-    uint16_t mpy32l;
+-    uint16_t mpy32h;
+-    uint16_t mpys32l;
+-    uint16_t mpys32h;
+-    uint16_t mac32l;
+-    uint16_t mac32h;
+-    uint16_t macs32l;
+-    uint16_t macs32h;
+-    uint16_t op2l;
+-    uint16_t op2h;
+-    uint16_t res0;
+-    uint16_t res1;
+-    uint16_t res2;
+-    uint16_t res3;
+     uint16_t mpy32ctl0;
++    uint8_t state;
++    bool op_32_bit;
+ } MSP430HWMState;
+ 
+ #endif /* INCLUDE_MSP430_HWM_H */
+-- 
+2.33.1
+

--- a/examples/MSP430/patches/msp430_test-description-kernel-loading.patch
+++ b/examples/MSP430/patches/msp430_test-description-kernel-loading.patch
@@ -1,0 +1,55 @@
+From b2a6ea736835f2893e9637396c75422555c02016 Mon Sep 17 00:00:00 2001
+From: Efimov Vasily <real@ispras.ru>
+Date: Wed, 9 Dec 2020 13:56:38 +0300
+Subject: [PATCH] msp430_test: description & kernel loading
+
+Signed-off-by: Efimov Vasily <real@ispras.ru>
+---
+ hw/msp430/msp430_test.c | 18 +++++++++++++++++-
+ 1 file changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/hw/msp430/msp430_test.c b/hw/msp430/msp430_test.c
+index 65fd05e9ce..0265aa530a 100644
+--- a/hw/msp430/msp430_test.c
++++ b/hw/msp430/msp430_test.c
+@@ -7,6 +7,7 @@
+ #include "hw/boards.h"
+ #include "hw/msp430-all/msp430_hwm.h"
+ #include "sysemu/reset.h"
++#include "hw/loader.h"
+ 
+ static void msp430_test_cpu_reset(void *opaque)
+ {
+@@ -40,13 +41,28 @@ static void init_msp430_test(MachineState *machine)
+     rom = g_new(MemoryRegion, 1);
+     memory_region_init_ram(rom, NULL, "ROM", 0xFC00, NULL);
+     memory_region_add_subregion_overlap(mem, 0x400, rom, 1);
++
++    if (machine->kernel_filename) {
++        /* load guest from an ELF produced by msp430-gcc */
++        load_elf(
++            machine->kernel_filename,
++            NULL, NULL, NULL, /* no address translation */
++            NULL, /* entry point is written into interrupt vector table */
++            NULL, NULL, /* bounds of loaded data is not interesting */
++            NULL, /* no pflags required */
++            0, /* little-endian */
++            105, /* Texas Instruments embedded microcontroller msp430 */
++            0, /* clearing LSB of symbol addresses is not required */
++            0 /* data bytes swapping is not required */
++        );
++    }
+ }
+ 
+ static void machine_msp430_test_class_init(ObjectClass *oc, void *opaque)
+ {
+     MachineClass *mc = MACHINE_CLASS(oc);
+ 
+-    mc->desc = "TODO: provide description for msp430-test";
++    mc->desc = "A test purpose machine with msp430x2xx-like memory layout";
+     mc->init = init_msp430_test;
+ }
+ 
+-- 
+2.33.1
+

--- a/examples/MSP430/patches/msp430x2xx-implement-some-devices-and-guest-loading.patch
+++ b/examples/MSP430/patches/msp430x2xx-implement-some-devices-and-guest-loading.patch
@@ -1,0 +1,909 @@
+From f070b78bf0c1a12301871826583a713423da1a7d Mon Sep 17 00:00:00 2001
+From: Efimov Vasily <real@ispras.ru>
+Date: Fri, 8 Oct 2021 18:14:24 +0300
+Subject: [PATCH] msp430x2xx: implement some devices and guest loading
+
+Signed-off-by: Efimov Vasily <real@ispras.ru>
+---
+ hw/Makefile.objs                  |   1 -
+ hw/msp430/msp430_bcm.c            | 212 +++++++++++++++++++++++++++++-
+ hw/msp430/msp430_ic.c             |  70 +++++++---
+ hw/msp430/msp430_usci_a.c         |  99 +++++++++++++-
+ hw/msp430/msp430_wdt.c            |  79 ++++++++++-
+ hw/msp430/msp430x2xx.c            |  38 +++++-
+ include/hw/msp430/msp430_bcm.h    |   5 +
+ include/hw/msp430/msp430_ic.h     |   5 +-
+ include/hw/msp430/msp430_usci_a.h |  14 +-
+ include/hw/msp430/msp430_wdt.h    |   1 +
+ 10 files changed, 483 insertions(+), 41 deletions(-)
+
+diff --git a/hw/Makefile.objs b/hw/Makefile.objs
+index ba9419cd77..690b71f156 100644
+--- a/hw/Makefile.objs
++++ b/hw/Makefile.objs
+@@ -41,7 +41,6 @@ devices-dirs-$(CONFIG_NUBUS) += nubus/
+ devices-dirs-y += semihosting/
+ devices-dirs-y += smbios/
+ devices-dirs-y += msp430-all/
+-devices-dirs-y += msp430/
+ endif
+ 
+ common-obj-y += $(devices-dirs-y)
+diff --git a/hw/msp430/msp430_bcm.c b/hw/msp430/msp430_bcm.c
+index 4c5ac36d14..1ed5e92c86 100644
+--- a/hw/msp430/msp430_bcm.c
++++ b/hw/msp430/msp430_bcm.c
+@@ -11,6 +11,166 @@
+ #define MSP430_BCM_MMIO_1 TYPE_MSP430_BCM "_mmio_1"
+ #define MSP430_BCM_MMIO_1_SIZE 0x3
+ 
++
++/* DCO Frequency estimation.
++ *
++ * About DCO frequency:
++ * - SLAS735J p. 14, p. 29
++ * - SLAU144J p. 279
++ * */
++
++/* The array is filled according to average between MIN & MAX or TYP values
++ * from table "DCO Frequency" at SLAS735J p. 14, p. 29.
++ * Values are for DCOx = 3
++ * */
++
++static const uint64_t rselx_freq[] = { /* Unit is Hz. */
++    (170000 + 70000) >> 1,
++    150000,
++    210000,
++    300000,
++    410000,
++    580000,
++    (1060000 + 540000) >> 1,
++    (1500000 + 800000) >> 1,
++    1600000,
++    2300000,
++    3400000,
++    4250000,
++    (7300000 + 4300000) >> 1,
++    7800000,
++    (13900000 + 8600000) >> 1,
++    (18500000 + 12000000) >> 1,
++};
++
++/* Scales for values in array rselx_freq. Reminder, values are for DCOx = 3.
++ * According to docs, f DCO(RSEL,DCO+1) / f DCO(RSEL,DCO) = 1.08 */
++
++/* A fixed point integer arithmetic is used. */
++#define ONE_SHIFT 20
++#define ONE (1 << ONE_SHIFT)
++
++static const uint64_t dcox_scale[] = {
++    ONE / 1.08 / 1.08 / 1.08,
++    ONE / 1.08 / 1.08,
++    ONE / 1.08,
++    ONE,
++    ONE * 1.08,
++    ONE * 1.08 * 1.08,
++    ONE * 1.08 * 1.08 * 1.08,
++    ONE * 1.08 * 1.08 * 1.08 * 1.08,
++};
++
++static inline uint64_t f_dco(uint8_t rselx, uint8_t dcox, uint8_t modx)
++{
++    uint64_t f_dco = (rselx_freq[rselx] * dcox_scale[dcox]) >> ONE_SHIFT;
++    uint64_t f_dco_1 = (rselx_freq[rselx] * dcox_scale[dcox + 1]) >> ONE_SHIFT;
++
++    return ((f_dco * f_dco_1) << 5 /* x32 */) /
++           (modx * f_dco + (32 - modx) * f_dco_1);
++}
++
++
++static inline void update_dco_freq(MSP430BCMState *s)
++{
++    s->dco_freq = f_dco(s->bcsctl1 & 0x0F, s->dcoctl >> 5, s->dcoctl & 0x1F);
++}
++
++/* According to 5.2.2, SLAU144J p. 276 */
++#define VLOCLK_FREQ 12000 /* Hz */
++
++/* Normally software must know which crystal is connected to XT2 and set
++ * XT2Sx accordingly. The model use XT2Sx value to assume XT2 frequency.  */
++static const uint64_t xt2_freq[] = {
++    1000000,
++    3000000,
++    8000000,
++    16000000
++};
++
++/* When XTS = 1 LFXT1 is avaluated as for XT2.
++ * The array below is for XTS = 0 */
++static const uint64_t lfxt1_freq_xts0[] = {
++    32768,
++    32768, /* It's reserved actually */
++    VLOCLK_FREQ,
++    16000000
++};
++
++#define lfxt1_freq_xts1 xt2_freq
++
++
++#define XT2OFF(s) (!!((s)->bcsctl1 & (1 << 7)))
++#define XTS(s) (!!((s)->bcsctl1 & (1 << 6)))
++#define LFXT1Sx(s) (((s)->bcsctl3 >> 4) & 3)
++#define XT2Sx(s) ((s)->bcsctl3 >> 6)
++
++static inline void update_mclk_freq(MSP430BCMState *s)
++{
++    /* dco_freq must be already updated. */
++    uint8_t selm = s->bcsctl2 >> 6;
++    uint8_t divm = (s->bcsctl2 >> 4) & 0x3;
++
++    switch (selm) {
++    case 0:
++    case 1:
++        s->mclk_freq = s->dco_freq;
++        break;
++    case 2:
++        /* Assume that XT2 is present and works. */
++        if (!XT2OFF(s)) {
++            s->mclk_freq = xt2_freq[XT2Sx(s)];
++            break;
++        } /* else fall through to case 3 */
++    case 3:
++        if (XTS(s)) {
++            s->mclk_freq = lfxt1_freq_xts1[LFXT1Sx(s)];
++        } else {
++            s->mclk_freq = lfxt1_freq_xts0[LFXT1Sx(s)];
++        }
++        break;
++    }
++
++    s->mclk_freq >>= divm;
++}
++
++static inline void update_smclk_freq(MSP430BCMState *s)
++{
++    /* dco_freq must be already updated. */
++    uint8_t sels = (s->bcsctl2 >> 3) & 1;
++    uint8_t divs = (s->bcsctl2 >> 1) & 0x3;
++
++    if (sels) {
++        /* Assume that XT2 is present and works. */
++
++        if (XT2OFF(s)) {
++            if (XTS(s)) {
++                s->smclk_freq = lfxt1_freq_xts1[LFXT1Sx(s)];
++            } else {
++                s->smclk_freq = lfxt1_freq_xts0[LFXT1Sx(s)];
++            }
++        } else {
++            s->smclk_freq = xt2_freq[XT2Sx(s)];
++        }
++    } else {
++        s->smclk_freq = s->dco_freq;
++    }
++
++    s->smclk_freq >>= divs;
++}
++
++static inline void update_aclk_freq(MSP430BCMState *s)
++{
++    uint8_t diva = (s->bcsctl1 >> 4) & 3;
++    if (XTS(s)) {
++        s->aclk_freq = lfxt1_freq_xts1[LFXT1Sx(s)];
++    } else {
++        s->aclk_freq = lfxt1_freq_xts0[LFXT1Sx(s)];
++    }
++    s->aclk_freq >>= diva;
++}
++
++
+ static uint64_t msp430_bcm_mmio_0_read(void *opaque, hwaddr offset,
+                                        unsigned size)
+ {
+@@ -41,6 +201,12 @@ static void msp430_bcm_mmio_0_write(void *opaque, hwaddr offset, uint64_t value,
+     case 0x0:
+         /* BCSCTL3, Basic clock system control 3 */
+         s->bcsctl3 = (value & 0b11111100) | (s->bcsctl3 & ~0b11111100);
++
++        /* XT2Sx configures XT2. LFXT1Sx configures LFXT1. ACLK, MCLK and
++         * SMCLK all can use XT2 or LFXT1. */
++        update_mclk_freq(s);
++        update_smclk_freq(s);
++        update_aclk_freq(s);
+         break;
+ 
+     default:
+@@ -98,16 +264,34 @@ static void msp430_bcm_mmio_1_write(void *opaque, hwaddr offset, uint64_t value,
+     case 0x0:
+         /* DCOCTL, DCO control register */
+         s->dcoctl = value;
++        /* Because of DCOx and MODx: */
++        update_dco_freq(s);
++        /* ACLK never uses DCO, MCLK and SMCLK can. */
++        update_mclk_freq(s);
++        update_smclk_freq(s);
+         break;
+ 
+     case 0x1:
+         /* BCSCTL1, Basic clock system control 1 */
+         s->bcsctl1 = value;
++        /* Because of RSELx: */
++        update_dco_freq(s);
++        /* MCLK and SMCLK can use DCO. */
++        update_mclk_freq(s);
++        update_smclk_freq(s);
++
++        /* Because of XTS and DIVAx: */
++        update_aclk_freq(s);
+         break;
+ 
+     case 0x2:
+         /* BCSCTL2, Basic clock system control 2 */
+         s->bcsctl2 = value;
++
++        /* Because of SELMx and DIVMx: */
++        update_mclk_freq(s);
++        /* Because of SELS and DIVSx: */
++        update_smclk_freq(s);
+         break;
+ 
+     default:
+@@ -140,19 +324,33 @@ static void msp430_bcm_instance_init(Object *obj)
+     sysbus_init_irq(SYS_BUS_DEVICE(obj), &s->out_irq);
+ }
+ 
++static void reset_clocks(MSP430BCMState *s)
++{
++    s->bcsctl3 = 0b00000101;
++    s->dcoctl = 0b01100000;
++    s->bcsctl1 = 0b10000111;
++    s->bcsctl2 = 0x00;
++
++    update_dco_freq(s);
++    update_mclk_freq(s);
++    update_smclk_freq(s);
++    update_aclk_freq(s);
++}
++
+ static void msp430_bcm_realize(DeviceState *dev, Error **errp)
+ {
+-    __attribute__((unused)) MSP430BCMState *s = MSP430_BCM(dev);
++    MSP430BCMState *s = MSP430_BCM(dev);
++
++    /* Reset functions of some devices relies on clock frequencies. However
++     * resets of those devices can be called before msp430_bcm_reset. */
++    reset_clocks(s);
+ }
+ 
+ static void msp430_bcm_reset(DeviceState *dev)
+ {
+     MSP430BCMState *s = MSP430_BCM(dev);
+ 
+-    s->bcsctl3 = 0b00000101;
+-    s->dcoctl = 0b01100000;
+-    s->bcsctl1 = 0b10000111;
+-    s->bcsctl2 = 0x00;
++    reset_clocks(s);
+ }
+ 
+ static void msp430_bcm_unrealize(DeviceState *dev)
+@@ -172,6 +370,10 @@ static const VMStateDescription vmstate_msp430_bcm = {
+         VMSTATE_UINT8(dcoctl, MSP430BCMState),
+         VMSTATE_UINT8(bcsctl1, MSP430BCMState),
+         VMSTATE_UINT8(bcsctl2, MSP430BCMState),
++        VMSTATE_UINT64(dco_freq, MSP430BCMState),
++        VMSTATE_UINT64(mclk_freq, MSP430BCMState),
++        VMSTATE_UINT64(aclk_freq, MSP430BCMState),
++        VMSTATE_UINT64(smclk_freq, MSP430BCMState),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+diff --git a/hw/msp430/msp430_ic.c b/hw/msp430/msp430_ic.c
+index d6497c2728..ac865a6a18 100644
+--- a/hw/msp430/msp430_ic.c
++++ b/hw/msp430/msp430_ic.c
+@@ -5,39 +5,73 @@
+ #include "hw/qdev-properties.h"
+ #include "hw/msp430/msp430_ic.h"
+ #include "migration/vmstate.h"
++#include "cpu.h"
+ 
+ #define MSP430_IC_MMIO TYPE_MSP430_IC "_mmio"
+ #define MSP430_IC_MMIO_SIZE 0x4
+ 
+ static void msp430_ic_irq_handler(void *opaque, int n, int level)
+ {
+-    __attribute__((unused)) MSP430ICState *s = MSP430_IC(opaque);
++    MSP430ICState *s = MSP430_IC(opaque);
++    MSP430CPU *cpu = MSP430_CPU(s->cpu);
++
++    if (n == 9) {
++        /* State of UCSWRST bit of UCA0CTL1 */
++        if (level) {
++            /* Note, UCA0RXIFG is reset (as general IRQ) because USCI lowers
++             * RX irq when UCSWRST is set. */
++            cpu->env.ifg2 &= ~UCA0TXIFG;
++            cpu->env.ie2 &= ~(UCA0TXIE|UCA0RXIE);
++        } else {
++            /* Always ready to transmit when it's not in software reset
++             * state. */
++            cpu->env.ifg2 |= UCA0TXIFG;
++        }
++    } else {
++        /* General code. */
++        if (level) {
++            if (n > 7) {
++                cpu->env.ifg2 |= 1 << (n - 8);
++            } else {
++                cpu->env.ifg1 |= 1 << n;
++            }
++        } else {
++            if (n > 7) {
++                cpu->env.ifg2 &= ~(1 << (n - 8));
++            } else {
++                cpu->env.ifg1 &= ~(1 << n);
++            }
++        }
++    }
++
++    msp430_cpu_update_ifg(cpu);
+ }
+ 
+ static uint64_t msp430_ic_mmio_read(void *opaque, hwaddr offset, unsigned size)
+ {
+     MSP430ICState *s = MSP430_IC(opaque);
++    MSP430CPU *cpu = MSP430_CPU(s->cpu);
+     uint64_t ret = 0;
+ 
+     switch (offset) {
+     case 0x0:
+         /* IE1 */
+-        ret = s->ie1;
++        ret = cpu->env.ie1;
+         break;
+ 
+     case 0x1:
+         /* IE2 */
+-        ret = s->ie2;
++        ret = cpu->env.ie2;
+         break;
+ 
+     case 0x2:
+         /* IFG1 */
+-        ret = s->ifg1;
++        ret = cpu->env.ifg1;
+         break;
+ 
+     case 0x3:
+         /* IFG2 */
+-        ret = s->ifg2;
++        ret = cpu->env.ifg2;
+         break;
+ 
+     default:
+@@ -53,26 +87,32 @@ static void msp430_ic_mmio_write(void *opaque, hwaddr offset, uint64_t value,
+                                  unsigned size)
+ {
+     MSP430ICState *s = MSP430_IC(opaque);
++    MSP430CPU *cpu = MSP430_CPU(s->cpu);
++
+ 
+     switch (offset) {
+     case 0x0:
+         /* IE1 */
+-        s->ie1 = value;
++        cpu->env.ie1 = value;
++        msp430_cpu_update_ie(MSP430_CPU(s->cpu));
+         break;
+ 
+     case 0x1:
+         /* IE2 */
+-        s->ie2 = value;
++        cpu->env.ie2 = value;
++        msp430_cpu_update_ie(MSP430_CPU(s->cpu));
+         break;
+ 
+     case 0x2:
+         /* IFG1 */
+-        s->ifg1 = value;
++        cpu->env.ifg1 = value;
++        msp430_cpu_update_ifg(MSP430_CPU(s->cpu));
+         break;
+ 
+     case 0x3:
+         /* IFG2 */
+-        s->ifg2 = value;
++        cpu->env.ifg2 = value;
++        msp430_cpu_update_ifg(MSP430_CPU(s->cpu));
+         break;
+ 
+     default:
+@@ -108,12 +148,7 @@ static void msp430_ic_realize(DeviceState *dev, Error **errp)
+ 
+ static void msp430_ic_reset(DeviceState *dev)
+ {
+-    MSP430ICState *s = MSP430_IC(dev);
+-
+-    s->ie1 = 0x00;
+-    s->ie2 = 0x00;
+-    s->ifg1 = 0x00;
+-    s->ifg2 = 0x00;
++    __attribute__((unused)) MSP430ICState *s = MSP430_IC(dev);
+ }
+ 
+ static void msp430_ic_unrealize(DeviceState *dev)
+@@ -122,6 +157,7 @@ static void msp430_ic_unrealize(DeviceState *dev)
+ }
+ 
+ static Property msp430_ic_properties[] = {
++    DEFINE_PROP_LINK("cpu", MSP430ICState, cpu, TYPE_MSP430_CPU, CPUState *),
+     DEFINE_PROP_END_OF_LIST()
+ };
+ 
+@@ -129,10 +165,6 @@ static const VMStateDescription vmstate_msp430_ic = {
+     .name = "msp430_ic",
+     .version_id = 1,
+     .fields = (VMStateField[]) {
+-        VMSTATE_UINT8(ie1, MSP430ICState),
+-        VMSTATE_UINT8(ie2, MSP430ICState),
+-        VMSTATE_UINT8(ifg1, MSP430ICState),
+-        VMSTATE_UINT8(ifg2, MSP430ICState),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+diff --git a/hw/msp430/msp430_usci_a.c b/hw/msp430/msp430_usci_a.c
+index c78ba31aad..33fa167643 100644
+--- a/hw/msp430/msp430_usci_a.c
++++ b/hw/msp430/msp430_usci_a.c
+@@ -9,16 +9,68 @@
+ #define MSP430_USCI_A_MMIO TYPE_MSP430_USCI_A "_mmio"
+ #define MSP430_USCI_A_MMIO_SIZE 0xB
+ 
++/* UCAxCTL0
++ * */
++#define UCMODEx_MASK        0x06
++#define UCMODEx_UART        0x00
++/* UART mode with automatic baud rate detection */
++#define UCMODEx_UART_ABR    0x06
++
++#define UCSYNC_BIT          0x01
++
++/* UCAxCTL1
++ * */
++/* Software reset enable */
++#define UCSWRST             0x01
++
++/* UCAxSTAT
++ * */
++/* Listen enable. UCAxTXD is internally fed back to the receiver. */
++#define UCLISTEN            0x80
++#define UCFE                0x40
++#define UCOE                0x20
++#define UCPE                0x10
++#define UCBRK               0x08
++#define UCRXERR             0x04
++
++/* UCAxABCTL
++ * */
++#define UCSTOE              0x08
++#define UCBTOE              0x04
++
++static inline bool msp430_usci_a_in_uart_mode(MSP430USCIAState *s)
++{
++    if (s->ucaxctl0 & UCSYNC_BIT) {
++        return false;
++    }
++    uint8_t mode = s->ucaxctl0 & UCMODEx_MASK;
++    return (mode == UCMODEx_UART) || (mode == UCMODEx_UART_ABR);
++}
++
+ static int msp430_usci_a_chr_can_read(void *opaque)
+ {
+-    __attribute__((unused)) MSP430USCIAState *s = MSP430_USCI_A(opaque);
++    MSP430USCIAState *s = MSP430_USCI_A(opaque);
+ 
+-    return 0;
++    if (!msp430_usci_a_in_uart_mode(s)) {
++        return 0;
++    }
++    if (s->ucaxctl1 & UCSWRST) {
++        return 0;
++    }
++    if (s->rx_ready) {
++        return 0;
++    }
++    return 1;
+ }
+ 
+ static void msp430_usci_a_chr_read(void *opaque, const uint8_t *buf, int size)
+ {
+-    __attribute__((unused)) MSP430USCIAState *s = MSP430_USCI_A(opaque);
++    MSP430USCIAState *s = MSP430_USCI_A(opaque);
++
++    s->rx_ready = true;
++    s->ucaxrxbuf = *buf;
++
++    qemu_irq_raise(s->out_irq_rx);
+ }
+ 
+ static void msp430_usci_a_chr_event(void *opaque, QEMUChrEvent event)
+@@ -88,6 +140,10 @@ static uint64_t msp430_usci_a_mmio_read(void *opaque, hwaddr offset,
+     case 0x9:
+         /* UCAxRXBUF, USCI_Ax receive buffer register */
+         ret = s->ucaxrxbuf;
++        if (s->rx_ready) {
++            s->rx_ready = false;
++            qemu_irq_lower(s->out_irq_rx);
++        }
+         break;
+ 
+     case 0xA:
+@@ -132,6 +188,24 @@ static void msp430_usci_a_mmio_write(void *opaque, hwaddr offset,
+ 
+     case 0x4:
+         /* UCAxCTL1, USCI_Ax control register 1 */
++
++        if ((value ^ s->ucaxctl1 ) & UCSWRST) {
++            if (value & UCSWRST) {
++                s->ucaxstat &= ~(UCRXERR | UCBRK | UCPE | UCOE | UCFE);
++                s->ucaxabctl &= ~(UCSTOE | UCBTOE);
++                qemu_irq_raise(s->out_irq_swrst);
++                qemu_irq_lower(s->out_irq_rx);
++            } else {
++                qemu_irq_lower(s->out_irq_swrst);
++                if (s->tx_ready) {
++                    s->tx_ready = false;
++                    if (msp430_usci_a_in_uart_mode(s)) {
++                        qemu_chr_fe_write(&s->chr, &s->ucaxtxbuf, 1);
++                    }
++                }
++            }
++        }
++
+         s->ucaxctl1 = value;
+         break;
+ 
+@@ -164,6 +238,14 @@ static void msp430_usci_a_mmio_write(void *opaque, hwaddr offset,
+     case 0xA:
+         /* UCAxTXBUF, USCI_Ax transmit buffer register */
+         s->ucaxtxbuf = value;
++        if (msp430_usci_a_in_uart_mode(s)) {
++            if (s->ucaxctl1 & UCSWRST) {
++                s->tx_ready = true;
++            } else {
++                s->tx_ready = false;
++                qemu_chr_fe_write(&s->chr, &s->ucaxtxbuf, 1);
++            }
++        }
+         break;
+ 
+     default:
+@@ -189,8 +271,8 @@ static void msp430_usci_a_instance_init(Object *obj)
+                           MSP430_USCI_A_MMIO, MSP430_USCI_A_MMIO_SIZE);
+     sysbus_init_mmio(SYS_BUS_DEVICE(obj), &s->mmio);
+ 
+-    sysbus_init_irq(SYS_BUS_DEVICE(obj), &s->out_irq_0);
+-    sysbus_init_irq(SYS_BUS_DEVICE(obj), &s->out_irq_1);
++    sysbus_init_irq(SYS_BUS_DEVICE(obj), &s->out_irq_rx);
++    sysbus_init_irq(SYS_BUS_DEVICE(obj), &s->out_irq_swrst);
+ }
+ 
+ static void msp430_usci_a_realize(DeviceState *dev, Error **errp)
+@@ -220,6 +302,11 @@ static void msp430_usci_a_reset(DeviceState *dev)
+     s->ucaxstat = 0x00;
+     s->ucaxrxbuf = 0x00;
+     s->ucaxtxbuf = 0x00;
++    s->rx_ready = false;
++    s->tx_ready = false;
++
++    qemu_irq_lower(s->out_irq_rx);
++    qemu_irq_raise(s->out_irq_swrst);
+ }
+ 
+ static void msp430_usci_a_unrealize(DeviceState *dev)
+@@ -247,6 +334,8 @@ static const VMStateDescription vmstate_msp430_usci_a = {
+         VMSTATE_UINT8(ucaxstat, MSP430USCIAState),
+         VMSTATE_UINT8(ucaxrxbuf, MSP430USCIAState),
+         VMSTATE_UINT8(ucaxtxbuf, MSP430USCIAState),
++        VMSTATE_BOOL(rx_ready, MSP430USCIAState),
++        VMSTATE_BOOL(tx_ready, MSP430USCIAState),
+         VMSTATE_END_OF_LIST()
+     }
+ };
+diff --git a/hw/msp430/msp430_wdt.c b/hw/msp430/msp430_wdt.c
+index 88b934b66f..02b44edb69 100644
+--- a/hw/msp430/msp430_wdt.c
++++ b/hw/msp430/msp430_wdt.c
+@@ -5,13 +5,65 @@
+ #include "hw/qdev-properties.h"
+ #include "hw/msp430/msp430_wdt.h"
+ #include "migration/vmstate.h"
++#include "hw/msp430/msp430_bcm.h"
++#include "sysemu/runstate.h"
+ 
+ #define MSP430_WDT_MMIO TYPE_MSP430_WDT "_mmio"
+ #define MSP430_WDT_MMIO_SIZE 0x2
+ 
++#define RESET_SYSTEM 1
++
++/* WDTCTL, Watchdog Timer+ Register
++ * */
++#define WDTISx_MASK     3
++#define WDTSSEL         (1 << 2)
++#define WDTCNTCL        (1 << 3)
++#define WDTTMSEL        (1 << 4)
++/* ...
++ * NMI pin control is not relevant.
++ * ... */
++#define WDTHOLD         (1 << 7)
++
++static const unsigned clock_scale[] = {
++        15 /* 32768 */,
++        13 /* 8192 */,
++        9 /* 512 */,
++        6 /* 64 */
++};
++
++static void update_timer(MSP430WDTState *s)
++{
++    if (s->wdtctl & WDTHOLD) {
++        timer_del(s->timer);
++    } else {
++        uint64_t src_freq;
++        if (s->wdtctl & WDTSSEL) {
++            src_freq = MSP430_BCM(s->bcm)->aclk_freq;
++        } else {
++            src_freq = MSP430_BCM(s->bcm)->smclk_freq;
++        }
++        uint64_t period_ns =
++            (1000000000UL << clock_scale[s->wdtctl & WDTISx_MASK]) / src_freq;
++
++        timer_mod(s->timer, qemu_clock_get_ns(QEMU_CLOCK_VIRTUAL) + period_ns);
++    }
++}
++
+ static void msp430_wdt_timer_cb(void *opaque)
+ {
+-    __attribute__((unused)) MSP430WDTState *s = MSP430_WDT(opaque);
++    MSP430WDTState *s = MSP430_WDT(opaque);
++
++    qemu_irq_raise(s->out_irq);
++
++    if (s->wdtctl & WDTTMSEL) {
++        /* Interval timer mode. */
++        update_timer(s);
++    } else {
++        printf("%s: WDT expired in watchdog mode. Reset.\n", __func__);
++#if RESET_SYSTEM
++        qemu_system_reset_request(SHUTDOWN_CAUSE_GUEST_RESET);
++#endif
++    }
+ }
+ 
+ static uint64_t msp430_wdt_mmio_read(void *opaque, hwaddr offset, unsigned size)
+@@ -20,7 +72,7 @@ static uint64_t msp430_wdt_mmio_read(void *opaque, hwaddr offset, unsigned size)
+     uint64_t ret = 0;
+ 
+     switch (offset) {
+-    case 0x0 ... 0x1:
++    case 0x0:
+         /* WDTCTL, Watchdog timer+ control register */
+         ret = s->wdtctl;
+         break;
+@@ -38,11 +90,29 @@ static void msp430_wdt_mmio_write(void *opaque, hwaddr offset, uint64_t value,
+                                   unsigned size)
+ {
+     MSP430WDTState *s = MSP430_WDT(opaque);
++    bool to_update_timer;
+ 
+     switch (offset) {
+-    case 0x0 ... 0x1:
++    case 0x0:
+         /* WDTCTL, Watchdog timer+ control register */
++
++        /* Note, timer re-scaling (WDTSSEL, WDTISx) will take place during
++         * after current period end. */
++        to_update_timer = (value ^ s->wdtctl) & (WDTCNTCL | WDTHOLD);
++
+         s->wdtctl = (value & 0x00FF) | (s->wdtctl & ~0x00FF);
++
++        if ((value & 0xFF00) != 0x5A00) {
++            printf("%s: incorrect password in high byte (0x%04x). Reset.\n",
++                   __func__, (int)(value & 0xFFFF));
++#if RESET_SYSTEM
++            qemu_system_reset_request(SHUTDOWN_CAUSE_GUEST_RESET);
++#endif
++        }
++
++        if (to_update_timer) {
++            update_timer(s);
++        }
+         break;
+ 
+     default:
+@@ -56,6 +126,7 @@ static const MemoryRegionOps msp430_wdt_mmio_ops = {
+     .read = msp430_wdt_mmio_read,
+     .write = msp430_wdt_mmio_write,
+     .impl = {
++        .min_access_size = 2,
+         .max_access_size = 2
+     }
+ };
+@@ -83,6 +154,7 @@ static void msp430_wdt_reset(DeviceState *dev)
+     MSP430WDTState *s = MSP430_WDT(dev);
+ 
+     s->wdtctl = 0x6900;
++    update_timer(s);
+ }
+ 
+ static void msp430_wdt_unrealize(DeviceState *dev)
+@@ -94,6 +166,7 @@ static void msp430_wdt_unrealize(DeviceState *dev)
+ }
+ 
+ static Property msp430_wdt_properties[] = {
++    DEFINE_PROP_LINK("bcm", MSP430WDTState, bcm, TYPE_MSP430_BCM, Object *),
+     DEFINE_PROP_END_OF_LIST()
+ };
+ 
+diff --git a/hw/msp430/msp430x2xx.c b/hw/msp430/msp430x2xx.c
+index a725ea1bb3..91bbc3438e 100644
+--- a/hw/msp430/msp430x2xx.c
++++ b/hw/msp430/msp430x2xx.c
+@@ -23,6 +23,8 @@
+ #include "hw/msp430/msp430_usi.h"
+ #include "hw/msp430/msp430_wdt.h"
+ #include "sysemu/reset.h"
++#include "cpu.h"
++#include "hw/loader.h"
+ 
+ static void msp430x2xx_cpu_reset(void *opaque)
+ {
+@@ -31,6 +33,12 @@ static void msp430x2xx_cpu_reset(void *opaque)
+     cpu_reset(cpu);
+ }
+ 
++#define UCA0RXIFG_IRQ           (1 << 8)
++#define UCA0TXIFG_IRQ           (1 << 9)
++/* TODO: enough for now */
++
++#define MULTI_SOURCE_INTERRUPTS (UCA0RXIFG_IRQ | UCA0TXIFG_IRQ)
++
+ static void init_msp430x2xx(MachineState *machine)
+ {
+     CPUState *cpu;
+@@ -61,7 +69,11 @@ static void init_msp430x2xx(MachineState *machine)
+     MemoryRegion *mem;
+     MemoryRegion *ram;
+ 
+-    cpu = cpu_create("msp430-cpu");
++    cpu = CPU(object_new("msp430-cpu"));
++    object_property_set_uint(OBJECT(cpu), "single-source-interrupts",
++        (uint32_t)(~MULTI_SOURCE_INTERRUPTS), NULL);
++    qdev_realize_and_unref(DEVICE(cpu), NULL, NULL);
++
+     qemu_register_reset(msp430x2xx_cpu_reset, cpu);
+ 
+     bcm = qdev_new(TYPE_MSP430_BCM);
+@@ -96,6 +108,7 @@ static void init_msp430x2xx(MachineState *machine)
+     sysbus_mmio_map(SYS_BUS_DEVICE(svs), 0, 0x55);
+ 
+     wdt = qdev_new(TYPE_MSP430_WDT);
++    object_property_set_link(OBJECT(wdt), "bcm", OBJECT(bcm), NULL);
+     sysbus_realize_and_unref(SYS_BUS_DEVICE(wdt), NULL);
+     sysbus_mmio_map(SYS_BUS_DEVICE(wdt), 0, 0x120);
+ 
+@@ -179,13 +192,34 @@ static void init_msp430x2xx(MachineState *machine)
+     ram = g_new(MemoryRegion, 1);
+     memory_region_init_ram(ram, NULL, "RAM", 0x200, NULL);
+     memory_region_add_subregion_overlap(mem, 0x200, ram, 1);
++
++    if (machine->kernel_filename) {
++        /* With kernel option FMC is overlapped with a simple ROM and FMC's
++         * content is effectively ignored. */
++        MemoryRegion *rom = g_new(MemoryRegion, 1);
++        memory_region_init_ram(rom, NULL, "ROM", 0xFC00, NULL);
++        memory_region_add_subregion_overlap(mem, 0x400, rom, 1);
++
++        /* load guest from an ELF */
++        load_elf(
++            machine->kernel_filename,
++            NULL, NULL, NULL, /* no address translation */
++            NULL, /* entry point is part of interrupt vector table */
++            NULL, NULL, /* bounds of loaded data is not interesting */
++            NULL, /* no pflags required */
++            0, /* little-endian */
++            105, /* Texas Instruments embedded microcontroller msp430 */
++            0, /* clearing LSB of symbol addresses is not required */
++            0 /* data bytes swapping is not required */
++        );
++    }
+ }
+ 
+ static void machine_msp430x2xx_class_init(ObjectClass *oc, void *opaque)
+ {
+     MachineClass *mc = MACHINE_CLASS(oc);
+ 
+-    mc->desc = "TODO: provide description for msp430x2xx";
++    mc->desc = "Generic model of series msp430x2xx (draft)";
+     mc->init = init_msp430x2xx;
+ }
+ 
+diff --git a/include/hw/msp430/msp430_bcm.h b/include/hw/msp430/msp430_bcm.h
+index 80406bfbd5..94828a0915 100644
+--- a/include/hw/msp430/msp430_bcm.h
++++ b/include/hw/msp430/msp430_bcm.h
+@@ -16,6 +16,11 @@ typedef struct MSP430BCMState {
+     uint8_t dcoctl;
+     uint8_t bcsctl1;
+     uint8_t bcsctl2;
++
++    uint64_t dco_freq; /* Digitally-Controlled Oscillator */
++    uint64_t mclk_freq; /* Master clock. */
++    uint64_t aclk_freq; /* Auxiliary clock. */
++    uint64_t smclk_freq; /* Sub-main clock. */
+ } MSP430BCMState;
+ 
+ #endif /* INCLUDE_MSP430_BCM_H */
+diff --git a/include/hw/msp430/msp430_ic.h b/include/hw/msp430/msp430_ic.h
+index 7d1258c4de..2aa723e280 100644
+--- a/include/hw/msp430/msp430_ic.h
++++ b/include/hw/msp430/msp430_ic.h
+@@ -11,10 +11,7 @@
+ typedef struct MSP430ICState {
+     SysBusDevice parent_obj;
+     MemoryRegion mmio;
+-    uint8_t ie1;
+-    uint8_t ie2;
+-    uint8_t ifg1;
+-    uint8_t ifg2;
++    CPUState *cpu;
+ } MSP430ICState;
+ 
+ #endif /* INCLUDE_MSP430_IC_H */
+diff --git a/include/hw/msp430/msp430_usci_a.h b/include/hw/msp430/msp430_usci_a.h
+index 926696fbd4..ca52359cdd 100644
+--- a/include/hw/msp430/msp430_usci_a.h
++++ b/include/hw/msp430/msp430_usci_a.h
+@@ -12,8 +12,15 @@
+ 
+ typedef struct MSP430USCIAState {
+     SysBusDevice parent_obj;
+-    qemu_irq out_irq_0;
+-    qemu_irq out_irq_1;
++
++    /* RX IRQ is set on input.
++     * The USCI model is always ready to transfer bytes except software
++     * reset state (UCSWRST bit in UCAxCTL1). That bit also affects interrupt
++     * bits in the interrupt controller. So, an IRQ (out_irq_swrst) is used
++     * to transfer its state to the interrupt controller.  */
++    qemu_irq out_irq_rx;
++    qemu_irq out_irq_swrst;
++
+     MemoryRegion mmio;
+     uint8_t ucaxabctl;
+     uint8_t ucaxirtctl;
+@@ -27,6 +34,9 @@ typedef struct MSP430USCIAState {
+     uint8_t ucaxrxbuf;
+     uint8_t ucaxtxbuf;
+     CharBackend chr;
++
++    bool rx_ready;
++    bool tx_ready;
+ } MSP430USCIAState;
+ 
+ #endif /* INCLUDE_MSP430_USCI_A_H */
+diff --git a/include/hw/msp430/msp430_wdt.h b/include/hw/msp430/msp430_wdt.h
+index 1bb0d5c6fc..7fd43050aa 100644
+--- a/include/hw/msp430/msp430_wdt.h
++++ b/include/hw/msp430/msp430_wdt.h
+@@ -14,6 +14,7 @@ typedef struct MSP430WDTState {
+     MemoryRegion mmio;
+     uint16_t wdtctl;
+     QEMUTimer *timer;
++    Object *bcm;
+ } MSP430WDTState;
+ 
+ #endif /* INCLUDE_MSP430_WDT_H */
+-- 
+2.33.1
+

--- a/examples/MSP430/script.rst
+++ b/examples/MSP430/script.rst
@@ -1,0 +1,476 @@
+#######
+|title|
+#######
+
+.. |title| replace:: Добавление архитектуры процессора и периферии в Qemu
+                     на примере микроконтроллера семейства msp430x2xx
+
+Данный текст знакомит с методиками автоматизированного:
+
+- добавления поддержки архитектуры процессора (MSP430);
+- добавления моделей периферийных устройств;
+- грубого тестирования архитектуры процессора;
+
+с использованием QDT.
+
+Материалы
+=========
+
+Общего назначения
+~~~~~~~~~~~~~~~~~
+
+Ниже приводится команда установки компонентов общего назначения для
+свежеустановленной Ubuntu 20.04.
+
+::
+
+	sudo apt install git git-cola meld libglib2.0-dev libfdt-dev \
+	    libpixman-1-dev zlib1g-dev meson libvte-2.91-dev libgtk-3-dev \
+	    python3-tk idle-python3.8 python3-pip python-is-python3
+
+	sudo python -m pip install --upgrade gitpython six graphviz path.py \
+	    construct serial psutil
+
+Обязательные
+~~~~~~~~~~~~
+
+- Среда разработки `Energia IDE <http://energia.nu/downloads/downloadv4.php?file=energia-1.8.10E23-linux64.tar.xz>`_
+
+Energia IDE содержит в себе утилиты компиляции, вспомогательные файлы,
+отладчик ``mspdebug``,
+а также программные библиотеки для написания кода в Arduino-подобном
+окружении и ряд вспомогательных программ и примеров кода.
+Некоторые шаги данного сценария можно выполнить, используя Energia IDE
+(возможность использования будет явно указываться),
+однако в основном используются перечисленные ниже необходимые компоненты,
+загружаемые по отдельности.
+
+- `Утилиты компиляции MSP430 <http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-9.2.0.50_linux64.tar.bz2>`_
+
+- `Вспомогательные файлы для утилит компиляции MSP430 <http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-support-files-1.210.zip>`_
+
+- Отладчик ``mspdebug``::
+
+	sudo apt install mspdebug
+
+- Утилиты, которые могут отсутствовать в системе::
+
+	sudo apt install git git-cola gitk meld
+
+Опциональные
+~~~~~~~~~~~~
+
+Следующее будет полезно в случае выполнения продвинутых действий на
+основе данного сценария.
+
+- Среда разработки `Eclipse IDE <https://www.eclipse.org/downloads/download.php?file=/technology/epp/downloads/release/2019-06/R/eclipse-java-2019-06-R-linux-gtk-x86_64.tar.gz>`_
+
+- Расширение `PyDev <https://www.pydev.org/download.html>`_ для среды
+  разработки Eclipse IDE для программирования на языке Python.
+
+Знакомство с Qemu
+=================
+
+Зависимости сборки
+~~~~~~~~~~~~~~~~~~
+
+Для сборки потребуются дополнительные библиотеки, которые могут отсутствовать
+в имеющейся системе.
+Команды установки некоторых из них::
+
+	sudo apt install ninja-build
+
+Загрузка исходного кода
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Обратите внимание, что полный путь директории, где выполняется данный
+сценарий, не должен содержать пробельных символов и двоеточий, иначе
+конфигурирование Qemu будет неудачным.
+Также не стоит использовать одинарные и двойные кавычки, чтобы избежать
+необходимости в экранировании.
+
+Исходный код можно загрузить с помощью Git::
+
+	mkdir -p qemu/build
+	git clone https://gitlab.com/qemu-project/qemu.git qemu/src
+	cd qemu/src
+	git checkout v5.1.0
+	# export GIT_SSL_NO_VERIFY=true # при проблемах с сертификатами
+	# git submodule sync --recursive
+	git submodule update --init --recursive
+	cd ../..
+
+Сборка
+~~~~~~
+
+::
+
+	cd qemu/build
+	../src/configure \
+	    --target-list=i386-softmmu \
+	    --prefix=$(cd .. && pwd)/install \
+	    --extra-cflags="-no-pie -gpubnames" \
+	    --disable-pie \
+	    --enable-debug
+
+	make -j8 install
+	cd ../..
+
+Проверочный запуск
+~~~~~~~~~~~~~~~~~~
+
+::
+
+	qemu/install/bin/qemu-system-i386
+
+Чистка исходного кода после сборки
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+	cd qemu/src
+	git reset --hard
+	cd ../..
+
+Автоматизированное добавление архитектуры MSP430
+================================================
+
+Загрузка Qemu Development Toolkit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+	git clone https://github.com/ispras/qdt.git qdt/src
+	cd qdt/src
+	git submodule update --init --recursive
+	cd ../..
+
+Первое открытие проекта
+~~~~~~~~~~~~~~~~~~~~~~~
+
+*Это действие можно пропустить.*
+
+Открыть проект в графическом интерфейсе пользователя (ГИП)::
+
+	qdt/src/qdc-gui.py \
+	    -b qemu/build \
+	    qdt/src/examples/MSP430/msp430/msp430_project.py \
+	    &
+
+Дождаться построения кэша.
+Это может занять несколько десятков минут.
+
+Разработка
+~~~~~~~~~~
+
+Создание отдельной ветки
+------------------------
+
+::
+
+	cd qemu/src
+	git-cola &
+	gitk &
+	git checkout -b msp430 v5.1.0
+	# git submodule update --init --recursive
+	cd ../..
+
+Генерация заготовки
+-------------------
+
+Запустить генерацию через ГИП (Ctrl-G) или командой::
+
+	qdt/src/qemu_device_creator.py \
+	    -b qemu/build \
+	    qdt/src/examples/MSP430/msp430/msp430_project.py
+
+*Если кэш не был построен в ГИП ранее, данное действие может
+занять около 10 минут.*
+
+Посмотреть и зафиксировать текущее состояние::
+
+	cd qemu/src
+	git add -A
+	git commit -m "MSP430: Generate boilerplate using QDT"
+	cd ../..
+
+В течение работы ``qemu_device_creator.py`` создаст файл
+``translate.inc.i3s.c`` с семантикой инструкций (на основе описания
+семантики из файлов ``msp430_sem.py`` и ``msp430x.py``) и автоматически
+транслирует её в генератор промежуточного представления TCG
+``translate.inc.c``.
+
+Если перед генерацией через ГИП в меню
+настроек была отключена автоматическая трансляция или семантика
+была вручную дописана, то транслировать семантику можно так::
+
+	python2 qdt/src/I3S/i3s_to_c.py \
+	    --in-file qemu/src/target/msp430/translate.inc.i3s.c \
+	    --out-file qemu/src/target/msp430/translate.inc.c
+
+Зафиксировать изменения в Git (если была дополнительно транслирована
+семантика)::
+
+	cd qemu/src
+	git add -A
+	git commit -m "MSP430: Translate I3S to TCG API"
+	cd ../..
+
+Просмотреть разницу между описанием семантики на I3S и API TCG::
+
+	meld \
+	    qemu/src/target/msp430/translate.inc.i3s.c \
+	    qemu/src/target/msp430/translate.inc.c \
+	    &
+
+Минимальный набор устройств
+---------------------------
+
+Доделать процессор, тестовую машину и аппаратный умножитель::
+
+	cd qemu/src
+	git am ../../qdt/src/examples/MSP430/patches/MSP430-CPU-reset-interrupts-GDB-RSP-access.patch
+	git am ../../qdt/src/examples/MSP430/patches/msp430_test-description-kernel-loading.patch
+	git am ../../qdt/src/examples/MSP430/patches/msp430-all-implement-HWM.patch
+	cd ../..
+
+Сборка
+------
+
+Переконфигурировать эмулятор на MSP430 и собрать::
+
+	cd qemu/build
+
+	../src/configure \
+	    --target-list=msp430-softmmu \
+	    --prefix=$(cd .. && pwd)/install \
+	    --extra-cflags="-no-pie -gpubnames" \
+	    --disable-pie \
+	    --enable-debug
+
+	#    --extra-cflags="-Wno-error=maybe-uninitialized"
+
+	make -j8 install
+	cd ../..
+
+Тестирование
+------------
+
+Рассмотрим тестирование добавленной архитектуры двумя способами:
+
+- грубое тестирование, основанное на проверке логики работы программы
+  на уровне языка Си;
+- сравнение с настоящим микроконтроллером.
+
+Проверка на уровне языка Си
+```````````````````````````
+
+Проверка архитектуры на уровне языка Си основывается на гипотезе, что
+детерминированная программа, написанная на языке Си (некоторое подмножество
+программ), должна работать одинаково независимо от вычислителя
+(т.е. должен быть пройден точно такой же путь выполнения, должны совпадать
+значения в переменных и т.п.).
+Таким образом, если скомпилировать программу под основную машину (напр.,
+AMD64) и проверяемую, а затем запустить под отладчиком на обеих, контролируя
+вычислительный процесс на уровне абстракций языка Си (значения переменных,
+номера строк выполняемых инструкций), то, в случае корректной реализации
+проверяемой архитектуры, выполнение не должно иметь наблюдаемых отличий.
+
+Хотя данный подход не позволяет проверить всю реализацию (т.к. есть
+ряд условий и ситуаций, проверка работы в которых не выражается на языке Си),
+грубые ошибки успешно обнаруживаются.
+
+Загрузить утилиты компиляции и вспомогательные файлы::
+
+	wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-9.2.0.50_linux64.tar.bz2
+	wget http://software-dl.ti.com/msp430/msp430_public_sw/mcu/msp430/MSPGCC/9_2_0_0/export/msp430-gcc-support-files-1.210.zip
+
+Распаковать архивы::
+
+	tar -xf msp430-gcc-9.2.0.50_linux64.tar.bz2
+	unzip msp430-gcc-support-files-1.210
+
+Протестировать процессор с помощью C2T::
+
+	export MSP430_SUPPORT=$(pwd)/msp430-gcc-support-files
+	export MSP430_TOOLCHAIN=$(pwd)/msp430-gcc-9.2.0.50_linux64
+	export MSP430_QEMU=$(pwd)/qemu/install/bin/qemu-system-msp430
+
+	qdt/src/c2t.py \
+	    -t ^.+\\.c$ \
+	    -s ^_readme_.*$ \
+	    -s ^.*m_stack_u?((32)|(64)).*$ \
+	    -j 8 \
+	    -e 0 \
+	    qdt/src/examples/MSP430/msp430/config_msp430g2553.py
+
+Оценить покрытие::
+
+	PYTHONPATH=$(pwd)/qdt/src \
+	qdt/src/misc/msp430x_tests_coverage.py \
+	    --output msp430.cov.verbose.csv \
+	    --summary msp430x.cov.summary.csv \
+	    qdt/src/c2t/tests/ir
+
+Сценарии, находящиеся **не** в корневом каталоге QDT, требуют для работы
+добавления корневого каталога в `PYTHONPATH`.
+
+Сравнение с настоящим микроконтроллером
+```````````````````````````````````````
+
+Тесты, не формулируемые на языке Си, а также нюансы, не достаточно подробно
+освещённые в документации, могут быть проверены путём запуска кода,
+написанного на ассемблере, на настоящем МК.
+
+Сравнить с "камнем"::
+
+	export MSP430_SUPPORT=\"$(pwd)/msp430-gcc-support-files\"
+	export MSP430_TOOLCHAIN=\"$(pwd)/msp430-gcc-9.2.0.50_linux64\"
+	export MSP430_TESTS_PATH=\"$(pwd)/qdt/src/examples/MSP430/msp430/tests\"
+	export QEMU_MSP430=\"$(pwd)/qemu/install/bin/qemu-system-msp430\"
+	export QEMU_MSP430_ARGS='["-M", "msp430_test", "-nographic"]'
+
+	PYTHONPATH=$(pwd)/qdt/src \
+	qdt/src/misc/msp430_test.py
+
+Наличие ``"`` или ``'`` вокруг значений переменных обязательно, т.к. значения
+являются вычисляемыми выражениями на языке Python (в данном случае строками).
+
+Также сравнение можно провести, используя Energia IDE.
+
+Загрузить Energia IDE::
+
+	wget -O energia-1.8.10E23-linux64.tar.xz http://energia.nu/downloads/downloadv4.php?file=energia-1.8.10E23-linux64.tar.xz
+
+Распаковать архив::
+
+	tar -xf energia-1.8.10E23-linux64.tar.xz
+
+Сравнить с "камнем"::
+
+	export ENERGIA_PATH=\"$(pwd)/energia-1.8.10E23\"
+	export MSP430_TESTS_PATH=\"$(pwd)/qdt/src/examples/MSP430/msp430/tests\"
+	export QEMU_MSP430=\"$(pwd)/qemu/install/bin/qemu-system-msp430\"
+	export QEMU_MSP430_ARGS='["-M", "msp430_test", "-nographic"]'
+
+	PYTHONPATH=$(pwd)/qdt/src \
+	qdt/src/misc/msp430_test.py
+
+После выполнения сценария ``msp430_test.py`` одним из вышеуказанных способов
+можно вычислить разницу::
+
+	cd qdt/src/examples/MSP430/msp430/tests
+	./diff-all.sh
+	cd ../../../../../..
+
+Посмотреть разницу::
+
+	export TEST=call_indexed_sp
+	meld \
+	    qdt/src/examples/MSP430/msp430/tests/$TEST.qemu.log \
+	    qdt/src/examples/MSP430/msp430/tests/$TEST.hw.log \
+	    &
+
+Перепроверить конкретный тест::
+
+	PYTHONPATH=$(pwd)/qdt/src \
+	qdt/src/misc/msp430_test.py call_indexed_sp
+
+Реализация модели ВМ семейства msp430x2xx
+-----------------------------------------
+
+Сгенерировать заготовку msp430x2xx::
+
+	qdt/src/qemu_device_creator.py \
+	    -b qemu/build \
+	    qdt/src/examples/MSP430/msp430/msp430x2xx.py
+
+Или через ГИП::
+
+	qdt/src/qdc-gui.py \
+	    -b qemu/build \
+	    qdt/src/examples/MSP430/msp430/msp430x2xx.py \
+	    &
+
+Зафиксировать изменения через Git::
+
+	cd qemu/src
+	git add -A
+	git commit -m "MSP430: msp430x2xx family boilerplate"
+	cd ../..
+
+Реализовать машину и устройства::
+
+	cd qemu/src
+	git am ../../qdt/src/examples/MSP430/patches/msp430x2xx-implement-some-devices-and-guest-loading.patch
+	cd ../..
+
+Пересобрать::
+
+	cd qemu/build
+	make -j8 install
+	cd ../..
+
+Проверка
+--------
+
+Проверить::
+
+	qemu/install/bin/qemu-system-msp430 -M msp430x2xx
+
+Выполнить в HMP::
+
+	info mtree
+	info qtree
+
+Запуск скетча
+`````````````
+
+Также можно запустить в эмуляторе "скетч", скомпилированный в Energia IDE.
+
+Скетч `ASCIITable <ASCIITable/ASCIITable.ino>`_ является примером,
+поставляемым в составе Energia IDE.
+Он рассчитан на работу на настоящем микроконтроллере.
+Его функция заключается в выводе на UART таблицы ASCII.
+
+Команды для загрузки и распаковки Energia IDE приведены в разделе Тестирование.
+
+Запустить Energia IDE и сразу же загрузить нужный скетч::
+
+	energia-1.8.10E23/energia energia-1.8.10E23/examples/04.Communication/ASCIITable/ASCIITable.ino
+
+Или запустить IDE и загрузить скетч через меню::
+
+	energia-1.8.10E23/energia
+	Файл > Примеры > 04. Communication > ASCIITable
+
+Сборку скетча следует производить, выбрав правильный МК в меню::
+
+	Инструменты > Плата > MSP-EXP430G2 w/ MSP430G2553
+
+Energia IDE не выдаёт собранные ELF файлы явно.
+Однако путь можно найти в консоли, если включить опцию в меню::
+
+	Файл > Настройки
+	Опция "Показать подробный вывод"
+	Поставить галочку напротив "Компиляция"
+	Нажать "OK" для применения изменений
+
+Произвести компиляцию скетча, выбрав в меню::
+
+	Скетч > Проверить/Компилировать
+
+Запустить в эмуляторе скетч, скомпилированный в Energia IDE
+(поправьте путь на свой)::
+
+	qemu/install/bin/qemu-system-msp430 -M msp430x2xx -kernel /tmp/arduino_build_19993/ASCIITable.ino.elf
+
+Обратите внимание, что запускать скетч нужно, не закрывая Energia IDE,
+так как при закрытии удаляются все временные файлы, включая собранный ELF файл.
+
+Увидеть результат работы можно, переключившись на вкладку виртуального
+терминала Qemu, подключённого к UART МК (Ctrl-Alt-2 или через меню
+"View" (если Qemu собран с GTK)).
+
+Текущая реализация модели msp430x2xx является неполной.
+Ввиду чего запуск многих других примеров из Energia IDE будет безуспешным.

--- a/locale/ru_RU/LC_MESSAGES/qdc.po
+++ b/locale/ru_RU/LC_MESSAGES/qdc.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: qdc 0.1.0\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-07-11 18:10+0300\n"
-"PO-Revision-Date:  2019-02-20 17:57+0300\n"
+"PO-Revision-Date:  2020-11-08 23:02+0300\n"
 "Last-Translator: Efimov Vasily <real@ispras.ru>\n"
 "Language-Team: Russian <real@ispras.ru>\n"
 "Language: Russian\n"
@@ -43,6 +43,50 @@ msgstr "Повторить"
 #: qdc-gui.py:297
 msgid "Edit"
 msgstr "Правка"
+
+#: misc/msp430x_tests_coverage.py:828
+msgid "Mnemonic"
+msgstr "Мнемоника"
+
+#: misc/msp430x_tests_coverage.py:829
+msgid "Occurrences"
+msgstr "Вхождения"
+
+#: misc/msp430x_tests_coverage.py:830
+msgid "Variants met"
+msgstr "Встречено вариантов"
+
+#: misc/msp430x_tests_coverage.py:831
+msgid "Variants total"
+msgstr "Всего вариантов"
+
+#: misc/msp430x_tests_coverage.py:892
+msgid "Mode"
+msgstr "Режим"
+
+#: misc/msp430x_tests_coverage.py:893
+msgid "FI arg1"
+msgstr "FI 1 аргумент"
+
+#: misc/msp430x_tests_coverage.py:894
+msgid "FI arg2"
+msgstr "FI 2 аргумент"
+
+#: misc/msp430x_tests_coverage.py:895
+msgid "FII arg"
+msgstr "FII аргумент"
+
+#: misc/msp430x_tests_coverage.py:896
+msgid "FIII arg"
+msgstr "FIII аргумент"
+
+#: misc/msp430x_tests_coverage.py:911
+msgid "YES"
+msgstr "ДА"
+
+#: misc/msp430x_tests_coverage.py:912
+msgid "NO"
+msgstr "НЕТ"
 
 #: qdc-gui.py:98
 msgid "Generation completed"

--- a/misc/msp430_test.py
+++ b/misc/msp430_test.py
@@ -1,0 +1,417 @@
+#!/usr/bin/python
+
+from os.path import (
+    isdir,
+    join,
+    isfile,
+    exists,
+)
+from os import (
+    listdir
+)
+from common import (
+    pypath,
+    ee,
+    ThreadStreamCopier,
+    PortPool,
+)
+from subprocess import (
+    Popen,
+    PIPE
+)
+from c2t import (
+    get_new_rsp,
+)
+from debug import (
+    RSPWatcher,
+)
+from threading import (
+    Thread,
+    Lock,
+    Condition,
+)
+from argparse import (
+    ArgumentParser,
+)
+# use ours pyrsp
+with pypath("..pyrsp"):
+    from pyrsp.utils import (
+        wait_for_tcp_port
+    )
+
+
+ENERGIA_PATH = ee("ENERGIA_PATH", "None")
+MSP430_TOOLCHAIN = ee("MSP430_TOOLCHAIN", "None")
+MSP430_SUPPORT = ee("MSP430_SUPPORT", "None")
+QEMU_MSP430 = ee("QEMU_MSP430", "None")
+QEMU_MSP430_ARGS = ee("QEMU_MSP430_ARGS",
+    '["-M", "msp430x2xx", "-nographic"]'
+)
+
+TESTS_PATH = ee("MSP430_TESTS_PATH")
+
+
+def set_paths():
+    global TOOLCHAIN_BIN
+    global MSPDEBUG
+    global MSP430_PFX
+    global EXTRA_CFLAGS
+
+    if ENERGIA_PATH is None:
+        if (MSP430_TOOLCHAIN and MSP430_SUPPORT) is None:
+            print("Set either ENERGIA_PATH or MSP430_TOOLCHAIN/MSP430_SUPPORT"
+                " env. variables"
+            )
+            exit(3)
+        if not isdir(MSP430_TOOLCHAIN) or not isdir(MSP430_SUPPORT):
+            print("Set both MSP430_TOOLCHAIN and MSP430_SUPPORT or set "
+                "ENERGIA_PATH env.var."
+            )
+            exit(4)
+
+        TOOLCHAIN_BIN = join(MSP430_TOOLCHAIN, "bin")
+        # sudo apt install mspdebug
+        MSPDEBUG = "mspdebug"
+        MSP430_PFX = "msp430-elf-"
+        EXTRA_CFLAGS = [
+            "-L" + join(MSP430_SUPPORT, "include"),
+        ]
+    else:
+        if not isdir(ENERGIA_PATH):
+            print("Check ENERGIA_PATH env. var.")
+            exit(1)
+
+        TOOLCHAIN_BIN = join(
+            ENERGIA_PATH, "hardware", "tools", "msp430", "bin"
+        )
+        MSPDEBUG = join(
+            ENERGIA_PATH, "hardware", "tools", "mspdebug", "mspdebug"
+        )
+        MSP430_PFX = "msp430-"
+        EXTRA_CFLAGS = []
+
+    if not isdir(TESTS_PATH):
+        print("Check MSP430_TESTS_PATH env. var.")
+        exit(2)
+
+    if QEMU_MSP430 is None or not isfile(QEMU_MSP430):
+        print("Set path to qemu executable through QEMU_MSP430 env. var.")
+        exit(5)
+
+set_paths()
+
+GCC = join(TOOLCHAIN_BIN, MSP430_PFX + "gcc")
+AS = join(TOOLCHAIN_BIN, MSP430_PFX + "as")
+READELF = join(TOOLCHAIN_BIN, MSP430_PFX + "readelf")
+OBJCOPY = join(TOOLCHAIN_BIN, MSP430_PFX + "objcopy")
+OBJDUMP = join(TOOLCHAIN_BIN, MSP430_PFX + "objdump")
+GDB = join(TOOLCHAIN_BIN, MSP430_PFX + "gdb")
+
+
+def msp430_as(name, mcu = "msp430g2553"):
+    # msp430-as -c -mmcu=msp430g2553 -o test.o test.s
+    p = Popen([AS, "-c", "-mmcu=" + mcu,
+            "-g",
+            "-o", name + ".o", name + ".s"
+        ],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+    return p.wait()
+
+
+def msp430_link(name, mcu = "msp430g2553"):
+    # msp430-gcc -fno-rtti -fno-exceptions -Wl,--gc-sections,-u,main
+    #    -mmcu=msp430g2553 -L{SUPPORT_INCLUDE} -o test.elf test.o
+    p = Popen([GCC] + EXTRA_CFLAGS + [
+            "-g",
+            "-mmcu=" + mcu, "-o", name + ".elf",
+            name + ".o", "main.o"
+        ],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+    return p.wait()
+
+
+def msp430_disas(name):
+    with open(join(TESTS_PATH, name + ".disas"), "wb") as f:
+        p = Popen([OBJDUMP, "-d", name + ".elf"],
+            stdout = f,
+            stdin = PIPE,
+            cwd = TESTS_PATH,
+        )
+        return p.wait()
+
+
+def msp430_readelf(name):
+    with open(join(TESTS_PATH, name + ".elf.txt"), "wb") as f:
+        p = Popen([READELF, "-a", name + ".elf"],
+            stdout = f,
+            stdin = PIPE,
+            cwd = TESTS_PATH,
+        )
+        return p.wait()
+
+
+def msp430_objcopy(name):
+    # msp430-objcopy -O ihex -R .eeprom test.elf test.hex
+    p = Popen([OBJCOPY, "-O", "ihex", "-R", ".eeprom", name + ".elf",
+            name + ".hex"
+        ],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+    return p.wait()
+
+
+def msp430_load(name):
+    # mspdebug rf2500 --force-reset prog test.hex
+    p = Popen([MSPDEBUG, "rf2500", "--force-reset", "prog %s.hex" % name],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+    return p.wait()
+
+
+def msp430_start_debug():
+    # mspdebug rf2500 gdb
+    return Popen([MSPDEBUG, "rf2500", "gdb"],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+
+
+def msp430_gdb_py(name):
+    pass
+
+
+MSP430_REGS = tuple(("r%d" % i) for i in range(16))
+
+MSP430RSP = get_new_rsp(MSP430_REGS, "r0", 16)
+
+
+class MSPDebugRSP(MSP430RSP):
+
+    @property
+    def thread(self):
+        return self._thread
+
+    @thread.setter
+    def thread(self, pid_tid):
+        self._thread = pid_tid
+        # mspdebug's RSP does not support Hg command
+
+
+# We only have one board and should share it among threads carefully
+BOARD_LOCK = Lock()
+
+
+copier = ThreadStreamCopier.catch_stdout()
+
+port_pool = PortPool()
+
+
+def main():
+    ap = ArgumentParser("MSP430 Hardware Based Test Utility")
+    ap.add_argument("tests",
+        nargs = "*",
+        help = "select specific tests in MSP430_TESTS_PATH directory"
+            " (without .s suffix)"
+    )
+
+    set_paths()
+
+    args = ap.parse_args()
+
+    jobs = 8
+
+    QEMU_MSP430_ARGS.append("-S")
+
+    if args.tests:
+        tests = list(args.tests)
+        for t in tests:
+            t_full = join(TESTS_PATH, t + ".s")
+            if not exists(t_full):
+                raise ValueError("No such test file: " + t_full)
+    else:
+        tests = []
+        for n in listdir(TESTS_PATH):
+            if n.endswith(".s"):
+                tests.append(n[:-2])
+
+    if not tests:
+        print("No tests found")
+        return 0 # it's not an error
+
+    mcu = "msp430g2553"
+
+    p = Popen([GCC] + EXTRA_CFLAGS + [
+            "-c",
+            "-g",
+            "-mmcu=" + mcu, "-o", "main.o", "main.c"
+        ],
+        stdin = PIPE,
+        cwd = TESTS_PATH,
+    )
+    if p.wait():
+        print("Can't build main wrapper")
+        return 3
+
+    print("tests: " + ", ".join(tests))
+
+    hw_test_ready = Condition()
+    hw_tests_queue = []
+
+    qemu_test_ready = Condition()
+    qemu_tests_queue = []
+
+    for n in range(jobs // 2):
+        Thread(
+            name = "test_job_hw#" + str(n),
+            target = test_job,
+            args = (hw_tests_queue, hw_test_ready, hardware_handler, "hw")
+        ).start()
+
+        Thread(
+            name = "test_job_qemu#" + str(n),
+            target = test_job,
+            args = (qemu_tests_queue, qemu_test_ready, qemu_handler, "qemu")
+        ).start()
+
+
+    for t in tests:
+        print("Preparing test: " + t)
+
+        # create object file
+        if msp430_as(t):
+            continue
+
+        # create ELF file
+        if msp430_link(t):
+            continue
+
+        msp430_disas(t)
+        msp430_readelf(t)
+
+        # create HEX file
+        if msp430_objcopy(t):
+            continue
+
+        print("Preparation succeeded: " + t)
+
+        with hw_test_ready:
+            hw_tests_queue.append(t)
+            hw_test_ready.notify(1)
+
+        with qemu_test_ready:
+            qemu_tests_queue.append(t)
+            qemu_test_ready.notify(1)
+
+    with hw_test_ready:
+        hw_tests_queue.append(None) # None means no more tests
+        hw_test_ready.notify_all()
+
+    with qemu_test_ready:
+        qemu_tests_queue.append(None)
+        qemu_test_ready.notify_all()
+
+
+def test_job(queue, cond, handler, backed_name):
+    while True:
+        while True:
+            with cond:
+                if queue:
+                    if queue[0] is None:
+                        print("No more tests")
+                        return
+                    t = queue.pop(0)
+                    break
+
+                cond.wait()
+
+        log_file_name = join(TESTS_PATH, t + "." + backed_name + ".log")
+        with open(log_file_name, "w") as log_file:
+            with copier(log_file):
+                do_test_job(t, handler)
+
+
+def do_test_job(t, handler):
+    ns = {}
+    with pypath(TESTS_PATH):
+        with pypath("..pyrsp"):
+            exec("from %s import *" % t, ns)
+
+    watchers = []
+
+    for n, cls in ns.items():
+        if not isinstance(cls, type):
+            continue
+        if cls is RSPWatcher:
+            continue
+        if issubclass(cls, RSPWatcher):
+            print("Using " + n)
+            watchers.append(cls)
+
+    if not watchers:
+        raise NotImplementedError("No RSPWatcher subclass class defined")
+
+    def test_func(rsp, elf_file_name):
+        for w in watchers:
+            w(rsp, elf_file_name)
+
+        rsp.run(setpc = False)
+
+    handler(t, test_func)
+
+
+def hardware_handler(t, test_func):
+    with BOARD_LOCK:
+        print("###\nTest: " + t + "\n###\n")
+
+        # load HEX file
+        if msp430_load(t):
+            return
+
+        # start debug server
+        p = msp430_start_debug()
+
+        try:
+            wait_for_tcp_port(2000)
+
+            rsp = MSPDebugRSP("2000")
+
+            test_func(rsp, join(TESTS_PATH, t + ".elf"))
+        finally:
+            p.terminate()
+            p.wait()
+
+
+def qemu_handler(t, test_func):
+    print("###\nTest: " + t + "\n###\n")
+
+    elf_file_name = join(TESTS_PATH, t + ".elf")
+
+    with port_pool() as port:
+        p = Popen([QEMU_MSP430] + QEMU_MSP430_ARGS + [
+                "-gdb", "tcp:localhost:" + str(port),
+                "-S",
+                "-kernel", elf_file_name
+            ],
+            stdin = PIPE,
+            cwd = TESTS_PATH,
+        )
+
+        try:
+            wait_for_tcp_port(port)
+
+            rsp = MSPDebugRSP(str(port))
+
+            test_func(rsp, elf_file_name)
+        finally:
+            p.terminate()
+            p.wait()
+
+
+if __name__ == "__main__":
+    exit(main() or 0)

--- a/misc/msp430x_tests_coverage.py
+++ b/misc/msp430x_tests_coverage.py
@@ -1,0 +1,970 @@
+#!/usr/bin/python
+
+from argparse import (
+    ArgumentTypeError,
+    ArgumentParser,
+)
+from os.path import (
+    abspath,
+    isdir,
+    join,
+    basename,
+    splitext
+)
+from glob import (
+    glob
+)
+from re import (
+    compile
+)
+from collections import (
+    defaultdict,
+    OrderedDict
+)
+from common import (
+    mlget as _,
+    ee
+)
+from operator import (
+    itemgetter
+)
+from codecs import (
+    open
+)
+
+
+PRINT_IGNORED_LINES = ee("TESTS_COVERAGE_PRINT_IGNORED_LINES", "False")
+PRINT_IGNORED_SECTIONS = ee("TESTS_COVERAGE_PRINT_IGNORED_SECTIONS", "False")
+
+
+# msp430x instruction set description based on:
+# doc1: SLAU208Q - MSP430x5xx and MSP430x6xx Family
+# doc2: SLAU144J - MSP430x2xx Family
+
+
+# addressing modes
+
+class RegisterMode:
+    pass
+
+
+class RegisterModeR0(RegisterMode):
+    pass
+
+
+class RegisterModeR1(RegisterMode):
+    pass
+
+
+class RegisterModeR2(RegisterMode):
+    pass
+
+
+# Note: impossible as source register - interpreted as 0 constant
+# ("R3, As = 00", doc2 page 46)
+# pointless as destination register - cannot be used as source
+#class RegisterModeR3(RegisterMode):
+#    pass
+
+
+# R4-R15 registers
+class RegisterModeRn(RegisterMode):
+    pass
+
+
+class IndexedMode:
+    pass
+
+
+# Note, used for coding SymbolicMode
+# class IndexedModeR0(IndexedMode):
+#     pass
+
+
+class IndexedModeR1(IndexedMode):
+    pass
+
+
+# Note, used for coding AbsoluteMode
+# class IndexedModeR2(IndexedMode):
+#     pass
+
+
+# Note, used for coding Plus1 mode
+# class IndexedModeR3(IndexedMode):
+#     pass
+
+
+# R4-R15 registers
+class IndexedModeRn(IndexedMode):
+    pass
+
+
+# X(PC), X(R0) Indexed mode is used for coding
+class SymbolicMode:
+    pass
+
+
+# X(SR), X(R2) Indexed mode is used for coding
+class AbsoluteMode:
+    pass
+
+
+class IndirectRegisterMode:
+    pass
+
+
+class IndirectRegisterModeR0(IndirectRegisterMode):
+    pass
+
+
+class IndirectRegisterModeR1(IndirectRegisterMode):
+    pass
+
+
+# Note, used for coding Plus4 mode
+# class IndirectRegisterModeR2(IndirectRegisterMode):
+#     pass
+
+
+# Note, used for coding Plus2 mode
+# class IndirectRegisterModeR3(IndirectRegisterMode):
+#     pass
+
+
+class IndirectRegisterModeRn(IndirectRegisterMode):
+    pass
+
+
+class IndirectAutoincrementMode:
+    pass
+
+
+# Note, used for coding Immediate mode for all instructions, except MOVA and
+# its emulated instructions
+class IndirectAutoincrementModeR0(IndirectAutoincrementMode):
+    pass
+
+
+class IndirectAutoincrementModeR1(IndirectAutoincrementMode):
+    pass
+
+
+# Note, used for coding Plus8 mode
+# class IndirectAutoincrementModeR2(IndirectAutoincrementMode):
+#     pass
+
+
+# Note, used for coding Minus1 mode
+# class IndirectAutoincrementModeR3(IndirectAutoincrementMode):
+#     pass
+
+
+# R4-R15 registers
+class IndirectAutoincrementModeRn(IndirectAutoincrementMode):
+    pass
+
+
+# @PC+ Indirect Autoincrement mode is used for coding
+class ImmediateMode:
+    pass
+
+
+# $N
+class LabelMode:
+    pass
+
+
+class ConstantGenerator:
+    pass
+
+
+# ("R2, As = 10", doc1 page 193)
+class Plus4(ConstantGenerator):
+    pass
+
+
+# ("R2, As = 11", doc1 page 193)
+class Plus8(ConstantGenerator):
+    pass
+
+
+# ("R3, As = 00", doc1 page 193)
+class Zero(ConstantGenerator):
+    pass
+
+
+# ("R3, As = 01", doc1 page 193)
+class Plus1(ConstantGenerator):
+    pass
+
+
+# ("R3, As = 10", doc1 page 193)
+class Plus2(ConstantGenerator):
+    pass
+
+
+# ("R3, As = 11", doc1 page 193)
+class Minus1(ConstantGenerator):
+    pass
+
+
+ModeToStr = {
+    RegisterModeR0: "PC",
+    RegisterModeR1: "SP",
+    RegisterModeR2: "SR",
+    # RegisterModeR3: "R3",
+    RegisterModeRn: "Rn",
+    # IndexedModeR0: "X(PC)",
+    IndexedModeR1: "X(SP)",
+    # IndexedModeR2: "X(SR)",
+    # IndexedModeR3: "X(R3)",
+    IndexedModeRn: "X(Rn)",
+    SymbolicMode: "ADDR",
+    AbsoluteMode: "&ADDR",
+    IndirectRegisterModeR0: "@PC",
+    IndirectRegisterModeR1: "@SP",
+    IndirectRegisterModeRn: "@Rn",
+    IndirectAutoincrementModeR0: "@PC+",
+    IndirectAutoincrementModeR1: "@SP+",
+    # IndirectAutoincrementModeR2: "@SR+",
+    # IndirectAutoincrementModeR3: "@R3+",
+    IndirectAutoincrementModeRn: "@Rn+",
+    ImmediateMode: "#N",
+    LabelMode: "$N",
+    Plus4: "#4",
+    Plus8: "#8",
+    Zero: "#0",
+    Plus1: "#1",
+    Plus2: "#2",
+    Minus1: "#-1"
+}
+
+RegisterModes = [
+    RegisterModeR0,
+    RegisterModeR1,
+    RegisterModeR2,
+    # RegisterModeR3, # doc2 page 46 - R3 used for CG
+    RegisterModeRn
+]
+
+OtherModes = [
+    IndexedModeR1,
+    IndexedModeRn,
+    SymbolicMode,
+    AbsoluteMode,
+    IndirectRegisterModeR0,
+    IndirectRegisterModeR1,
+    IndirectRegisterModeRn,
+    IndirectAutoincrementModeR1,
+    IndirectAutoincrementModeRn
+]
+
+ImmediateModes = [
+    Plus4,
+    Plus8,
+    Zero,
+    Plus1,
+    Plus2,
+    Minus1,
+    ImmediateMode # other values
+]
+
+SrcAddrModes = RegisterModes + OtherModes + ImmediateModes
+
+DstAddrModes = RegisterModes + [
+    IndexedModeR1,
+    # TODO: IndexedModeR3 for dst possible?
+    IndexedModeRn,
+    SymbolicMode,
+    AbsoluteMode
+]
+
+
+def parse_arg_mode(instr, arg):
+    # TODO: can't distinguish the Constant Generator value from an Immediate
+    if arg[0] == "#":
+        tail = arg[1:]
+        if tail == "4":
+            return Plus4
+        elif tail == "8":
+            return Plus8
+        elif tail == "0":
+            return Zero
+        elif tail == "1":
+            return Plus1
+        elif tail == "2":
+            return Plus2
+        elif tail == "-1":
+            return Minus1
+        else:
+            return ImmediateMode
+
+    if arg[0] == "$":
+        return LabelMode
+
+    if arg[0] == "&":
+        return AbsoluteMode
+
+    if arg[0] == "@" and arg[1] in ["r", "R"]:
+        if arg[-1] == "+":
+            tail = arg[2:-1]
+            if tail == "0":
+                return IndirectAutoincrementModeR0
+            elif tail == "1":
+                return IndirectAutoincrementModeR1
+            # elif tail == "2":
+            #     return IndirectAutoincrementModeR2
+            # elif tail == "3":
+            #     return IndirectAutoincrementModeR3
+            else:
+                return IndirectAutoincrementModeRn
+        else:
+            tail = arg[2:]
+            if tail == "0":
+                return IndirectRegisterModeR0
+            elif tail == "1":
+                return IndirectRegisterModeR1
+            else:
+                return IndirectRegisterModeRn
+
+    if arg[-4:]  in ["(r0)", "(R0)"]:
+        return SymbolicMode
+
+    if arg[-1] == ")":
+        tail = arg.split("(")[1][1:-1]
+        if tail == "1":
+            return IndexedModeR1
+        else:
+            return IndexedModeRn
+
+    if arg[0] in ["r", "R"]:
+        tail = arg[1:]
+        if tail == "0":
+            return RegisterModeR0
+        elif tail == "1":
+            return RegisterModeR1
+        elif tail == "2":
+            return RegisterModeR2
+        # see notes about RegisterModeR3
+        # elif tail == "3":
+        #     return RegisterModeR3
+        else:
+            return RegisterModeRn
+
+    raise RuntimeError("Mode not recognized: %s (%s)" % (arg, instr))
+
+instructions = OrderedDict()
+mnemonic_aliases = {}
+emulated2real_instructions = {}
+real2emulated_instructions = defaultdict(list)
+
+not_found_mnemonics = defaultdict(int)
+
+def FI(name,
+    AddrMode1 = SrcAddrModes,
+    AddrMode2 = DstAddrModes,
+    flags = [".W", ".B"]
+):
+    for flag in flags:
+        for arg1Type in AddrMode1:
+            for arg2Type in AddrMode2:
+                # doc2 page 45:
+                # SR can be used in the register mode only addressed with word
+                # instructions
+                if (    (   arg1Type == RegisterModeR2
+                         or arg2Type == RegisterModeR2
+                    )
+                    and flag != ".W"
+                ):
+                    continue
+                instructions[
+                    (name + flag, arg1Type, arg2Type)
+                ] = []
+    if ".W" in flags:
+        mnemonic_aliases[name] = name + ".W"
+
+def FII(name, AddrMode = DstAddrModes, flags = [".W", ".B"]):
+    for flag in flags:
+        if AddrMode:
+            for arg1Type in AddrMode:
+                instructions[(name + flag, arg1Type)] = []
+        else:
+            instructions[(name + flag,)] = []
+    if ".W" in flags:
+        mnemonic_aliases[name] = name + ".W"
+
+def J(name):
+    instructions[(name, LabelMode)] = []
+
+def A(name,
+    AddrMode1 = RegisterModes + ImmediateModes,
+    AddrMode2 = RegisterModes
+):
+    for arg1Type in AddrMode1:
+        for arg2Type in AddrMode2:
+            instructions[(name, arg1Type, arg2Type)] = []
+
+def add_e_instr(emulated_instr, real_instr):
+    # add emulated instruction to dictionary
+    emulated2real_instructions[emulated_instr] = real_instr
+    real2emulated_instructions[real_instr].append(emulated_instr)
+
+def gen_e_instrs(new_name, old_name, arg1 = None, arg2 = None):
+    # search real instructions by pattern and add emulated instruction
+    if arg1 is not None and arg2 is not None:
+        raise RuntimeError("At least one of the args must be None")
+    for i in instructions:
+        if i[0] == old_name:
+            if arg2 and i[2] == arg2:
+                # Case: instr src -> instr src, FIXED
+                add_e_instr((new_name, i[1]), i)
+            elif arg1 and i[1] == arg1:
+                # Case: instr dst -> instr FIXED, dst
+                add_e_instr((new_name, i[2]), i)
+            elif arg1 is None and arg2 is None and i[1] == i[2]:
+                # Case: instr dst -> instr dst, dst
+                add_e_instr((new_name, i[1]), i)
+
+def gen_e_instrs_wb(new_name, old_name, arg1 = None, arg2 = None):
+    # add W or B flags to mnemonic before search real instruction
+    gen_e_instrs(new_name + ".W", old_name + ".W", arg1, arg2)
+    mnemonic_aliases[new_name] = new_name + ".W"
+    gen_e_instrs(new_name + ".B", old_name + ".B", arg1, arg2)
+
+def gen_e_instrs_awb(new_name, old_name, arg1 = None, arg2 = None):
+    # add A, W or B flags to mnemonic before search real instruction
+    gen_e_instrs(new_name + ".A", old_name + ".A", arg1, arg2)
+    gen_e_instrs(new_name + ".W", old_name + ".W", arg1, arg2)
+    mnemonic_aliases[new_name] = new_name + ".W"
+    gen_e_instrs(new_name + ".B", old_name + ".B", arg1, arg2)
+
+def instr_to_str(instr):
+    return "%s%s%s" % (
+        instr[0],
+        " " if len(instr) > 1 else "",
+        ", ".join(ModeToStr[arg] for arg in instr[1:])
+    )
+
+def fill_instructions(with_x_instrs):
+    # MSP430 Double-Operand (Format I) Instructions
+    # &
+    # MSP430X Extended Double-Operand (Format I) Instructions
+    for i in [
+        "MOV",
+        "ADD",
+        "ADDC",
+        "SUB",
+        "SUBC",
+        "CMP",
+        "DADD",
+        "BIT",
+        "BIC",
+        "BIS",
+        "XOR",
+        "AND"
+    ]:
+        FI(i)
+        if with_x_instrs:
+            FI(i + "X", flags = [".A", ".W", ".B"])
+
+    # MSP430 Single-Operand (Format II) Instructions
+    for i in [
+        # doc2 page 145 - all modes except Immediate
+        ("RRC", RegisterModes + OtherModes),
+
+        # doc2 page 145 - all modes except Immediate
+        ("RRA", RegisterModes + OtherModes),
+
+        # arg is src (not dst)
+        ("PUSH", SrcAddrModes),
+
+        # doc2 page 145 - all modes except Immediate, no flag
+        ("SWPB", RegisterModes + OtherModes, [""]),
+
+        # no flag
+        ("CALL", SrcAddrModes, [""]),
+
+        # no explicit dst, no flag
+        ("RETI", None, [""]),
+
+        # doc2 page 145 - all modes except Immediate, no flag
+        ("SXT", RegisterModes + OtherModes, [""])
+    ]:
+        FII(*i)
+
+    # MSP430 Jump Instructions
+    for i in [
+        "JEQ",
+        "JNE",
+        "JC",
+        "JNC",
+        "JN",
+        "JGE",
+        "JL",
+        "JMP"
+    ]:
+        J(i)
+    mnemonic_aliases["JZ"] = "JEQ"
+    mnemonic_aliases["JNZ"] = "JNE"
+    mnemonic_aliases["JLO"] = "JNC"
+    mnemonic_aliases["JHS"] = "JC"
+
+    # MSP430 Emulated Instructions
+    gen_e_instrs_wb("ADC", "ADDC", Zero)
+    gen_e_instrs("BR", "MOV.W", arg2 = RegisterModeR0)
+    gen_e_instrs_wb("CLR", "MOV", Zero)
+    add_e_instr(("CLRC",), ("BIC.W", Plus1, RegisterModeR2))
+    add_e_instr(("CLRN",), ("BIC.W", Plus4, RegisterModeR2))
+    add_e_instr(("CLRZ",), ("BIC.W", Plus2, RegisterModeR2))
+    gen_e_instrs_wb("DADC", "DADD", Zero)
+    gen_e_instrs_wb("DEC", "SUB", Plus1)
+    gen_e_instrs_wb("DECD", "SUB", Plus2)
+    add_e_instr(("DINT",), ("BIC.W", Plus8, RegisterModeR2))
+    add_e_instr(("EINT",), ("BIS.W", Plus8, RegisterModeR2))
+    gen_e_instrs_wb("INC", "ADD", Plus1)
+    gen_e_instrs_wb("INCD", "ADD", Plus2)
+    gen_e_instrs_wb("INV", "XOR", Minus1)
+
+    #add_e_instr(("NOP",), ("MOV.W", Zero, RegisterModeR3))
+    # add as non-emulated instruction, because RegisterModeR3 gone
+    instructions[("NOP",)] = []
+
+    gen_e_instrs("POP", "MOV.W", IndirectAutoincrementModeR1)
+    add_e_instr(("RET",),
+        ("MOV.W", IndirectAutoincrementModeR1, RegisterModeR0)
+    )
+    gen_e_instrs_wb("RLA", "ADD")
+    gen_e_instrs_wb("RLC", "ADDC")
+    gen_e_instrs_wb("SBC", "SUBC", Zero)
+    add_e_instr(("SETC",), ("BIS.W", Plus1, RegisterModeR2))
+    add_e_instr(("SETN",), ("BIS.W", Plus4, RegisterModeR2))
+    add_e_instr(("SETZ",), ("BIS.W", Plus2, RegisterModeR2))
+    gen_e_instrs_wb("TST", "CMP", Zero)
+
+    if not with_x_instrs:
+        return
+
+    # MSP430X Extended Single-Operand (Format II) Instructions
+    for i in [
+        ("CALLA", DstAddrModes, [""]),
+        ("POPM", RegisterModes, [".A", ".W"]),
+        ("PUSHM", RegisterModes, [".A", ".W"]),
+        ("PUSHX", SrcAddrModes, [".A", ".W", ".B"]), # arg is src (not dst)
+        ("RRCM", RegisterModes, [".A", ".W"]),
+        ("RRUM", RegisterModes, [".A", ".W"]),
+        ("RRAM", RegisterModes, [".A", ".W"]),
+        ("RLAM", RegisterModes, [".A", ".W"]),
+        ("RRCX", DstAddrModes, [".A", ".W", ".B"]),
+        ("RRUX", RegisterModes, [".A", ".W", ".B"]), # Rdst operand
+
+        # TODO: no immediate mode (doc1 page 226)?
+        ("RRAX", DstAddrModes, [".A", ".W", ".B"]),
+
+        ("SWPBX", DstAddrModes, [".A", ".W"]),
+        ("SXTX", DstAddrModes, [".A", ".W"])
+    ]:
+        FII(*i)
+
+    # MSP430X Address Instructions
+    for i in [
+        "ADDA",
+        #"MOVA", # moved to a separate case
+        "CMPA",
+        "SUBA"
+    ]:
+        A(i)
+
+    # TODO: no SymbolicMode for dst?
+    A("MOVA", SrcAddrModes + [IndirectAutoincrementModeR0], RegisterModes)
+    A("MOVA", RegisterModes, [IndexedMode, AbsoluteMode])
+
+    # MSP430X Extended Emulated Instructions
+    # Note, CLRA, DECDA, INCDA, TSTA do not require additional checking of the
+    # 2nd argument, since there are only real instructions like "#imm, Rdst"
+    gen_e_instrs_awb("ADCX", "ADDCX", Zero)
+    gen_e_instrs("BRA", "MOVA", arg2 = RegisterModeR0)
+    add_e_instr(("RETA",),
+        ("MOVA", IndirectAutoincrementModeR1, RegisterModeR0)
+    )
+
+    # MOVA: doc2 page 155 - mistake, doc2 page 263 - true TODO CHECK
+    gen_e_instrs("CLRA", "MOVA", Zero)
+
+    gen_e_instrs_awb("CLRX", "MOVX", Zero)
+    gen_e_instrs_awb("DADCX", "DADDX", Zero)
+    gen_e_instrs_awb("DECX", "SUBX", Plus1)
+    gen_e_instrs("DECDA", "SUBA", Plus2)
+    gen_e_instrs_awb("DECDX", "SUBX", Plus2)
+    gen_e_instrs_awb("INCX", "ADDX", Plus1)
+    gen_e_instrs("INCDA", "ADDA", Plus2)
+    gen_e_instrs_awb("INCDX", "ADDX", Plus2)
+    gen_e_instrs_awb("INVX", "XORX", Minus1)
+    gen_e_instrs_awb("RLAX", "ADDX")
+    gen_e_instrs_awb("RLCX", "ADDCX")
+
+    # SUBCX: doc2 page 155 - true, doc2 page 249 - mistake TODO CHECK
+    gen_e_instrs_awb("SBCX", "SUBCX", Zero)
+
+    gen_e_instrs("TSTA", "CMPA", Zero)
+    gen_e_instrs_awb("TSTX", "CMPX", Zero)
+    gen_e_instrs_awb("POPX", "MOVX", IndirectAutoincrementModeR1)
+
+def arg_type_directory(string):
+    if not isdir(string):
+        raise ArgumentTypeError(string + " is not directory")
+    return string
+
+def zip_with_scalar(l, o):
+    return list(zip(l, [o] * len(l)))
+
+def main():
+    parser = ArgumentParser(description = "MSP430x tests coverage")
+
+    parser.add_argument(
+        "irdirs",
+        nargs = "*",
+        default = [],
+        type = arg_type_directory,
+        metavar = "/path/to/c2t/tests/ir/directory",
+        help = "Paths to directories with disas files from C2T tests"
+    )
+    parser.add_argument("-o", "--output",
+        metavar = "coverage.csv",
+        default = "ir_disas_table.csv",
+        help = "Name of output verbose coverage table",
+    )
+    parser.add_argument("-s", "--summary",
+        metavar = "summary.csv",
+        help = "Name of coverage summary table (name and some counters)"
+    )
+    parser.add_argument("-a", "--addressing-modes",
+        metavar = "coverage_addressing_modes.csv",
+        help = "Name of coverage addressing modes table"
+    )
+    parser.add_argument("-x", "--xinstrs",
+        action = "store_true",
+        help = "Add coverage of extended instructions"
+    )
+    parser.add_argument("-m", "--markdown",
+        action = "store_true",
+        help = "Generate all selected tables in markdown format too"
+    )
+    parser.add_argument("-b", "--boardtests",
+        nargs = "*",
+        default = [],
+        type = arg_type_directory,
+        metavar = "/path/to/asm/ir/directory",
+        # Note: process code between "test" and "_unexpected_" labels only
+        help = "Paths to directories with disas files from asm tests"
+    )
+
+    arguments = parser.parse_args()
+
+    irdirs = []
+    if arguments.irdirs:
+        irdirs.extend(zip_with_scalar(arguments.irdirs, False))
+    if arguments.boardtests:
+        irdirs.extend(zip_with_scalar(arguments.boardtests, True))
+    if not irdirs:
+        parser.error("at least one directory with disas files is needed")
+
+    fill_instructions(arguments.xinstrs)
+
+    tests = []
+    line_with_label = compile("^[0-9a-f]+ <(.+)>:$")
+    line_with_instr = compile(
+        "^ +[0-9a-f]+:\t" # offset
+        "(?:[0-9a-f][0-9a-f] )+ *\t" # machine code
+        "([^;]+?)" # assembly code
+        " *\t*(?:;.*)?$" # comment
+    )
+    instr_to_parts = compile(
+        "^([^ \t,]+)" # mnemonic
+        "(?:\t([^ \t,]+)" # first argument
+        "(?:,\t?([^ \t,]+))?)?$" # second argument
+    )
+
+    processed_instructions_count = 0
+    not_parsed_instructions_count = 0
+    not_found_instructions_count = 0
+
+    ignored_sections = set()
+
+    for i, (irdir, asm_test) in enumerate(irdirs):
+        for irfile in glob(join(abspath(irdir), "*.disas")):
+            test = splitext(basename(irfile))[0]
+            if test in tests:
+                # add dir sequential number to make unique test name
+                test = test + "#" + str(i)
+            tests.append(test)
+            with open(irfile, "r") as f:
+                lines = f.readlines()
+
+            ignore_section = True
+            ignore_code = True
+
+            for line in lines:
+                if "Disassembly of section " in line:
+                    section_name = line[23:-2]
+                    ignore_section = section_name not in [".lowtext", ".text"]
+                    if ignore_section:
+                        ignored_sections.add(section_name)
+                    continue
+                else:
+                    if ignore_section:
+                        continue
+
+                if asm_test:
+                    mi = line_with_label.match(line)
+                    if mi:
+                        label = mi.group(1)
+                        if label == "test":
+                            ignore_code = False
+                        elif label == "_unexpected_":
+                            ignore_code = True
+                    if ignore_code:
+                        continue
+
+                mi = line_with_instr.match(line)
+                if not mi:
+                    if PRINT_IGNORED_LINES:
+                        line_strip = line.strip()
+                        # show message only for lines with some text
+                        if len(line_strip) > 0:
+                            print('IGNORED: "%s" from "%s"' % (
+                                line_strip, test
+                            ))
+                    continue
+
+                assembly_code = mi.group(1)
+
+                if "rpt" in assembly_code:
+                    # TODO: the repeat prefix is simply discarded
+                    # need accounting?
+                    assembly_code = assembly_code.split("{")[1][1:]
+
+                message = '"%s" from "%s"' % (assembly_code, test)
+
+                mi = instr_to_parts.match(assembly_code)
+                if not mi:
+                    print("NOT PARSED: %s" % message)
+                    not_parsed_instructions_count += 1
+                    continue
+
+                instr_mnem = mi.group(1).upper()
+                instr_mnem = mnemonic_aliases.get(instr_mnem, instr_mnem)
+
+                if mi.group(3):
+                    # instruction with 2 arguments
+                    src_mode = parse_arg_mode(message, mi.group(2))
+                    dst_mode = parse_arg_mode(message, mi.group(3))
+
+                    if instr_mnem in [
+                        "POPM.W", "POPM.A",
+                        "PUSHM.W", "PUSHM.A",
+                        "RRCM.W", "RRCM.A",
+                        "RRUM.W", "RRUM.A",
+                        "RRAM.W", "RRAM.A",
+                        "RLAM.W", "RLAM.A"
+                    ]:
+                        # doc2 page 154
+                        # the source argument coded without CG or Immediate
+                        # the value doesn't matter
+                        instr = (instr_mnem, dst_mode)
+                    else:
+                        instr = (instr_mnem, src_mode, dst_mode)
+                elif mi.group(2):
+                    # instruction with 1 argument
+                    arg_mode = parse_arg_mode(message, mi.group(2))
+                    instr = (instr_mnem, arg_mode)
+                else:
+                    # instruction without arguments
+                    instr = (instr_mnem,)
+
+                instr = emulated2real_instructions.get(instr, instr)
+
+                try:
+                    instructions[instr].append(test)
+                    processed_instructions_count += 1
+                except KeyError:
+                    print("NOT FOUND: %s" % message)
+                    not_found_instructions_count += 1
+                    not_found_mnemonics[instr_mnem] += 1
+
+    tested_instr_count = 0
+
+    with open(arguments.output, "w") as f:
+        f.write("Instruction;Emulated;Tests%s\n" % (";" * (len(tests) - 1)))
+        f.write(";;%s\n" % ";".join(tests))
+        for instr_desc, instr_tests in instructions.items():
+            f.write("%s;%s;%s\n" % (
+                instr_to_str(instr_desc),
+                " | ".join(instr_to_str(i)
+                    for i in real2emulated_instructions[instr_desc]
+                ),
+                ";".join(
+                    ("+" if test in instr_tests else "") for test in tests
+                )
+            ))
+            if instr_tests:
+                tested_instr_count += 1
+
+    if arguments.summary:
+        summary_stat = OrderedDict()
+        for instr_desc, instr_tests in instructions.items():
+            instr = instr_desc[0]
+            occurences, variants_met, variants_total = (
+                summary_stat.get(instr, (0, 0, 0))
+            )
+            instr_tests_count = len(instr_tests)
+            if instr_tests_count > 0:
+                occurences += len(instr_tests)
+                variants_met += 1
+            variants_total += 1
+            summary_stat[instr] = (occurences, variants_met, variants_total)
+
+        columns = [
+            _("Mnemonic").get(),
+            _("Occurrences").get(),
+            _("Variants met").get(),
+            _("Variants total").get()
+        ]
+
+        csv_text = (
+            u";".join(columns) + u"\n" +
+            u"\n".join(
+                u"%s;%s" % (instr, u";".join(map(str, counters)))
+                for instr, counters in summary_stat.items()
+            )
+        )
+        with open(arguments.summary, "wb", encoding = "utf-8") as f:
+            f.write(csv_text)
+
+        if arguments.markdown:
+            columns_len = [len(col) for col in columns]
+            row_formatter = (
+                u"| " + u" | ".join(u"{:<%d}" % cl for cl in columns_len) +
+                u" |\n"
+            )
+            rows_delimiter = (
+                u"+" + u"+".join(u"-" * (cl + 2) for cl in columns_len) +
+                u"+\n"
+            )
+
+            md_text = (
+                rows_delimiter +
+                row_formatter.format(*columns) +
+                rows_delimiter.replace(u"-", u"=") + # header delimiter
+                rows_delimiter.join(
+                    row_formatter.format(instr, *counters)
+                    for instr, counters in summary_stat.items()
+                ) +
+                rows_delimiter
+            )
+            with open(splitext(arguments.summary)[0] + ".md", "wb",
+                encoding = "utf-8"
+            ) as f:
+                f.write(md_text)
+
+    if arguments.addressing_modes:
+        FI_arg1 = set()
+        FI_arg2 = set()
+        FII_arg = set()
+        J_arg = False
+        for instr_desc, instr_tests in instructions.items():
+            if len(instr_tests) == 0:
+                continue
+            instr_desc_len = len(instr_desc)
+            if instr_desc_len == 3:
+                # instruction with 2 arguments
+                FI_arg1.add(instr_desc[1])
+                FI_arg2.add(instr_desc[2])
+            elif instr_desc_len == 2:
+                # instruction with 1 argument
+                mode = instr_desc[1]
+                if mode == LabelMode:
+                    J_arg = True
+                    continue
+                FII_arg.add(instr_desc[1])
+
+        columns = [
+            _("Mode").get(),
+            _("FI arg1").get(),
+            _("FI arg2").get(),
+            _("FII arg").get(),
+            _("FIII arg").get()
+        ]
+        columns_len = [len(col) for col in columns]
+        columns_len[0] = max(len(s) for s in ModeToStr.values())
+        row_formatter = (
+            u"| " + u" | ".join(u"{:<%d}" % cl for cl in columns_len) + u" |\n"
+        )
+        rows_delimiter = (
+            u"+" + u"+".join(u"-" * (cl + 2) for cl in columns_len) + u"+\n"
+        )
+
+        csv_text = u";".join(columns) + u"\n"
+        md_text = rows_delimiter + row_formatter.format(*columns)
+        md_text += rows_delimiter.replace(u"-", u"=") # header delimiter
+
+        yes = _("YES").get()
+        no =  _("NO").get()
+        for mode, s_mode in sorted(
+            ModeToStr.items(),
+            key = itemgetter(1)
+        ):
+            # TODO: no IndirectAutoincrementModeR0 in msp430 - ignored
+            if mode in [IndirectAutoincrementModeR0]:
+                continue
+
+            params = (
+                s_mode,
+                # Note, empty space - not available
+                yes if mode in FI_arg1 else no if mode in SrcAddrModes else "",
+                yes if mode in FI_arg2 else no if mode in DstAddrModes else "",
+                # Note, not all modes are available for every FII instruction
+                yes if mode in FII_arg else no if mode != LabelMode else "",
+                (yes if J_arg else no) if mode == LabelMode else ""
+            )
+
+            csv_text += u";".join(params) + u"\n"
+            md_text += row_formatter.format(*params) + rows_delimiter
+
+            with open(arguments.addressing_modes, "wb",
+                encoding = "utf-8"
+            ) as f:
+                f.write(csv_text)
+
+            if arguments.markdown:
+                with open(splitext(arguments.addressing_modes)[0] + ".md",
+                    "wb",
+                    encoding = "utf-8"
+                ) as f:
+                    f.write(md_text)
+
+    instructions_count = len(instructions)
+    if instructions_count:
+        print("Coverage: %.2f%% (%d from %d)" % (
+            100.0 * tested_instr_count / instructions_count,
+            tested_instr_count, instructions_count
+        ))
+    print("Processed instructions: %d" % processed_instructions_count)
+    if not_parsed_instructions_count > 0:
+        print("Not parsed instructions: %d" % not_parsed_instructions_count)
+    if not_found_instructions_count > 0:
+        print("Not found instructions: %d" % not_found_instructions_count)
+        for item in sorted(
+            not_found_mnemonics.items(),
+            key = itemgetter(1),
+            reverse = True
+        ):
+            print("%s: %d" % item)
+    if PRINT_IGNORED_SECTIONS and len(ignored_sections) > 0:
+        print("Ignored sections:\n%s" % "\n".join(ignored_sections))
+
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main() or 0)

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -1186,6 +1186,8 @@ def patch_configure(src, arch_bigendian, target_name):
 
     fixed_target_bigendian = False
 
+    configure_changed = False
+
     for i, line in enumerate(lines):
         if line == 'TARGET_ABI_DIR=""\n':
             found_target_abi_dir = True
@@ -1198,9 +1200,11 @@ def patch_configure(src, arch_bigendian, target_name):
             if arch_bigendian:
                 if target_name not in bigendian_list:
                     bigendian_list.append(target_name)
+                    configure_changed = True
             else:
                 if target_name in bigendian_list:
                     bigendian_list.remove(target_name)
+                    configure_changed = True
             lines[ind] = "  " + "|".join(bigendian_list) + ")\n"
             fixed_target_bigendian = True
 
@@ -1217,6 +1221,7 @@ def patch_configure(src, arch_bigendian, target_name):
 """.format(tn = target_name)
                 )
                 inserted_target = True
+                configure_changed = True
 
         if found_disas_config and not inserted_disas_config:
             if line == target_in_config:
@@ -1230,6 +1235,7 @@ def patch_configure(src, arch_bigendian, target_name):
 """ % (target_name, target_name.upper())
                 )
                 inserted_disas_config = True
+                configure_changed = True
 
         if (    fixed_target_bigendian
             and inserted_target
@@ -1237,8 +1243,9 @@ def patch_configure(src, arch_bigendian, target_name):
         ):
             break
 
-    with open(configure_path, "w") as f:
-        f.write("".join(lines))
+    if configure_changed:
+        with open(configure_path, "w") as f:
+            f.write("".join(lines))
 
 
 re_arch_enum_definition = compile("^    (\w+) = \(1 << (\d+)\),\n$")

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -1058,13 +1058,9 @@ class CPUType(QOMCPU):
         # TODO: this code is generic enough to be part of `source` module.
         spec_and_len2type = {}
         for specifiers, info in spec_and_len2typename.items():
-            len2type = {}
-
-            for length, typename in info.items():
-                if typename.endswith('*'):
-                    len2type[length] = Pointer(Type[typename[:-1]])
-                else:
-                    len2type[length] = Type[typename]
+            len2type = {
+                length: Type[typename] for length, typename in info.items()
+            }
 
             for specifier in specifiers:
                 spec_and_len2type[specifier] = len2type

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -39,6 +39,7 @@ from common import (
     mlget as _,
     ee,
     pypath,
+    shadow_open,
 )
 from itertools import (
     count,
@@ -371,7 +372,7 @@ class CPUType(QOMCPU):
             else:
                 graphs_prefix = None
 
-            with open(path, mode = "wb", encoding = "utf-8") as f_writer:
+            with shadow_open(path) as f_writer:
                 sf.generate(f_writer,
                     graphs_prefix = graphs_prefix,
                     gen_debug_comments = with_debug_comments,
@@ -384,7 +385,7 @@ class CPUType(QOMCPU):
 
         yield True
 
-        with open(join(src, translate_inc_c_file.path), "w") as f:
+        with shadow_open(join(src, translate_inc_c_file.path)) as f:
             if translate_cpu_semantics:
                 ast = parse_file(i3s_path)
                 convert_i3s_to_c(ast, DEBUG_I3S_TRANSLATOR)
@@ -1030,7 +1031,7 @@ class CPUType(QOMCPU):
         c.add_type(restore_state_to_opc)
 
     def _gen_target_makefile(self, src):
-        with open(src, "w") as mkf:
+        with shadow_open(src) as mkf:
             mkf.write("obj-y +=")
 
             for f in self.gen_files.values():
@@ -1040,7 +1041,7 @@ class CPUType(QOMCPU):
             mkf.write("\n")
 
     def _gen_helper_h(self, src):
-        with open(src, "w") as h:
+        with shadow_open(src) as h:
             h.write("DEF_HELPER_1(debug, void, env)\n")
             h.write("DEF_HELPER_1(illegal, void, env)\n")
 
@@ -1167,7 +1168,7 @@ class CPUType(QOMCPU):
 def create_default_config(src, target_name):
     default_config = join(src, "default-configs", target_name + "-softmmu.mak")
 
-    with open(default_config, "w") as f:
+    with shadow_open(default_config) as f:
         f.write("# Default configuration for %s-softmmu\n" % target_name)
 
 

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -518,6 +518,11 @@ class CPUType(QOMCPU):
         exec_c.add_reference(Type["TARGET_PAGE_SIZE"])
         exec_c.add_inclusion(h)
 
+        # XXX: the "cpu.h" header is already included in the "exec/gdbstub.h"
+        # header but on a short path and in `ifdef` block.
+        # The tool cannot find such an inclusion yet.
+        Header["exec/gdbstub.h"].add_inclusion(h)
+
         if not get_vp("cpu-param header exists"):
             for name, value in self.attributes.items():
                 m = Macro(name, text = value)

--- a/qemu/cpu/instruction.py
+++ b/qemu/cpu/instruction.py
@@ -275,6 +275,13 @@ class Instruction(object):
         for name, parts in operands_dict.items():
             yield name, sorted(parts, key = lambda x: (x.num, x.subnum))
 
+    def __call__(self, semantics):
+        "Can be applied as a `@decorator` for semantics generation function"
+        self.semantics = semantics
+        if semantics.__doc__ is not None:
+            self.comment = semantics.__doc__
+        return semantics
+
 
 class InstructionTreeNode(object):
 

--- a/qemu/cpu/instruction.py
+++ b/qemu/cpu/instruction.py
@@ -540,7 +540,9 @@ def build_instruction_tree(node, instructions, read_bitsize,
     max_bitsize = max(i.bitsize for i in instructions)
 
     if BUILD_INSTRUCTION_TREE_DEBUG:
-        print("DEBUG: Instructions (depth %d):" % depth)
+        print("DEBUG: Instructions (depth %d, count %d):" % (
+            depth, len(instructions)
+        ))
         print_instructions(instructions, max_bitsize = max_bitsize)
 
     if len(instructions) == 1:

--- a/qemu/machine.py
+++ b/qemu/machine.py
@@ -24,11 +24,8 @@ from source import (
     NewLine,
     Call,
     Pointer,
-    Macro,
-    Source,
     Type,
     TypeNotRegistered,
-    Function
 )
 from .machine_nodes import (
     CPUNode,
@@ -49,20 +46,13 @@ from .machine_nodes import (
 from common import (
     cached,
     reset_cache,
-    mlget as _,
     sort_topologically
-)
-from os.path import (
-    join as join_path
 )
 from .version import (
     get_vp
 )
 from six import (
     integer_types
-)
-from collections import (
-    OrderedDict
 )
 
 class UnknownMachineNodeType(ValueError):

--- a/qemu/machine.py
+++ b/qemu/machine.py
@@ -152,6 +152,10 @@ class IRQHubLayout(object):
         root_name = self.gen.node_map[self.hub]
         return self._gen_irq_get(root_name, self.root, root_name)
 
+
+def is_type_in_str(val):
+    return isinstance(val, str) and Type.exists(val)
+
 class MachineType(QOMType):
 
     def __init__(self, name, directory,
@@ -222,7 +226,7 @@ class MachineType(QOMType):
                 self.provide_name_for_node(n, n.var_base)
 
     def gen_prop_val(self, prop):
-        if isinstance(prop.prop_val, str) and Type.exists(prop.prop_val):
+        if is_type_in_str(prop.prop_val):
             self.use_type_name(prop.prop_val)
             return prop.prop_val
         if prop.prop_type == QOMPropertyTypeString:
@@ -395,7 +399,7 @@ class MachineType(QOMType):
                     self.use_type_name(p.prop_type.set_f)
                     if Type.exists(p.prop_name):
                         self.use_type_name(p.prop_name)
-                    if isinstance(p.prop_val, str) and Type.exists(p.prop_val):
+                    if is_type_in_str(p.prop_val):
                         self.use_type_name(p.prop_val)
 
                     props_code += prop_set_fmt.format(
@@ -496,7 +500,7 @@ class MachineType(QOMType):
                             self.use_type_name("sysbus_mmio_map")
                             self.use_type_name("SYS_BUS_DEVICE")
 
-                            if isinstance(mmio, str) and Type.exists(mmio):
+                            if is_type_in_str(mmio):
                                 self.use_type_name(mmio)
                                 mmio_val = str(mmio)
                             else:
@@ -589,9 +593,9 @@ qdev_get_child_bus(@aDEVICE({bridge_name}),@s"{bus_child_name}")\
                 )
             elif isinstance(node, MemoryNode):
                 self.use_type_name("MemoryRegion")
-                if isinstance(node.size, str) and Type.exists(node.size):
+                if is_type_in_str(node.size):
                     self.use_type_name(node.size)
-                if Type.exists(node.name):
+                if is_type_in_str(node.name):
                     self.use_type_name(node.name)
 
                 mem_name = self.node_map[node]
@@ -614,7 +618,7 @@ qdev_get_child_bus(@aDEVICE({bridge_name}),@s"{bus_child_name}")\
     memory_region_init_alias(@a{mem_name},@sNULL,@s{dbg_name},@s{orig},@s{offset},@s{size});
 """.format(
     mem_name = mem_name,
-    dbg_name = node.name if Type.exists(node.name) else "\"%s\"" % node.name,
+    dbg_name = node.name if is_type_in_str(node.name) else '"%s"' % node.name,
     size = node.size,
     orig = self.node_map[node.alias_to],
     offset = node.alias_offset
@@ -630,7 +634,7 @@ qdev_get_child_bus(@aDEVICE({bridge_name}),@s"{bus_child_name}")\
     memory_region_init_ram(@a{mem_name},@sNULL,@s{dbg_name},@s{size},@sNULL);{glob}
 """.format(
     mem_name = mem_name,
-    dbg_name = node.name if Type.exists(node.name) else "\"%s\"" % node.name,
+    dbg_name = node.name if is_type_in_str(node.name) else '"%s"' % node.name,
     size = node.size,
     glob = (("\n    vmstate_register_ram_global(%s);" % mem_name) if glob_mem
         else ""
@@ -643,20 +647,16 @@ qdev_get_child_bus(@aDEVICE({bridge_name}),@s"{bus_child_name}")\
     memory_region_init(@a{mem_name},@sNULL,@s{dbg_name},@s{size});
 """.format(
     mem_name = mem_name,
-    dbg_name = node.name if Type.exists(node.name) else "\"%s\"" % node.name,
+    dbg_name = node.name if is_type_in_str(node.name) else '"%s"' % node.name,
     size = node.size
                     )
 
                 if node.parent is not None:
-                    if (isinstance(node.offset, str)
-                    and Type.exists(node.offset)
-                    ):
+                    if is_type_in_str(node.offset):
                         self.use_type_name(node.offset)
                     if node.may_overlap:
                         self.use_type_name("memory_region_add_subregion_overlap")
-                        if (isinstance(node.priority, str)
-                        and Type.exists(node.priority)
-                        ):
+                        if is_type_in_str(node.priority):
                             self.use_type_name(node.priority)
 
                         def_code += """\
@@ -669,9 +669,7 @@ qdev_get_child_bus(@aDEVICE({bridge_name}),@s"{bus_child_name}")\
                         )
                     else:
                         self.use_type_name("memory_region_add_subregion")
-                        if (isinstance(node.priority, str)
-                        and Type.exists(node.priority)
-                        ):
+                        if is_type_in_str(node.priority):
                             self.use_type_name(node.priority)
 
                         def_code += """\

--- a/qemu/project.py
+++ b/qemu/project.py
@@ -31,7 +31,8 @@ from .version_description import (
 from common import (
     same_sets,
     callco,
-    co_find_eq
+    co_find_eq,
+    shadow_open,
 )
 from .makefile_patching import (
     patch_makefile
@@ -194,10 +195,7 @@ class QProject(object):
             spath = join(src, s.path)
             sdir, sname = split(spath)
 
-            if isfile(spath):
-                yield True
-                remove(spath)
-            elif not isdir(sdir):
+            if not isdir(sdir):
                 yield True
                 makedirs(sdir)
 
@@ -216,7 +214,7 @@ class QProject(object):
             else:
                 graphs_prefix = None
 
-            with open(spath, mode = "wb", encoding = "utf-8") as stream:
+            with shadow_open(spath) as stream:
                 f.generate(stream,
                     graphs_prefix = graphs_prefix,
                     gen_debug_comments = with_debug_comments,

--- a/qemu/qom.py
+++ b/qemu/qom.py
@@ -898,11 +898,8 @@ class QOMType(object):
                         StrConcat(
                             "%s: unimplemented write to 0x%",
                             MCall("HWADDR_PRIx"),
-                            StrConcat(
-                                ", size %d, ",
-                                "value 0x%",
-                                delim = "@s"
-                            ),
+                            ", size %d, ",
+                            "value 0x%",
                             MCall("PRIx64"),
                             "\\n",
                             delim = "@s"

--- a/source/function/bindings.py
+++ b/source/function/bindings.py
@@ -11,9 +11,6 @@ from ..model import (
     NodeVisitor,
     Variable
 )
-from six import (
-    StringIO
-)
 from common import (
     CodeWriter
 )
@@ -48,7 +45,7 @@ class BodyTree(CNode):
 
     def __str__(self):
         VarUsageAnalyzer(self).visit()
-        cw = CodeWriter(backend = StringIO())
+        cw = CodeWriter()
         cw.add_lang("c", "    ")
         cw.add_lang("cpp", "  ", "#")
         cw.new_line = True

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -679,6 +679,10 @@ class OpIndex(Operator):
         self.delim = "["
         self.suffix = "]"
 
+    def add_child(self, child):
+        # Note, ignore `Operator.add_child` to suppress unnecessary parentheses
+        super(Operator, self).add_child(child)
+
 
 class OpSDeref(Operator):
 

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -221,6 +221,36 @@ class CNode(Node):
     def out_child(child, writer):
         child.__c__(writer)
 
+    def __add__(self, arg):
+        return OpAdd(self, arg)
+
+    def __radd__(self, arg):
+        return OpAdd(arg, self)
+
+    def __and__(self, arg):
+        return OpAnd(self, arg)
+
+    def __sub__(self, arg):
+        return OpSub(self, arg)
+
+    def __rsub__(self, arg):
+        return OpSub(arg, self)
+
+    def __or__(self, arg):
+        return OpOr(self, arg)
+
+    def __xor__(self, arg):
+        return OpXor(self, arg)
+
+    def __lshift__(self, arg):
+        return OpLShift(self, arg)
+
+    def __rshift__(self, arg):
+        return OpRShift(self, arg)
+
+    def __invert__(self):
+        return OpNot(self)
+
 
 class Comment(Node):
 

--- a/source/model.py
+++ b/source/model.py
@@ -1280,6 +1280,78 @@ class Variable(TypeContainer):
             return NotImplemented
         return self.name < other.name
 
+    def __add__(self, arg):
+        from .function import (
+            OpAdd
+        )
+        return OpAdd(self, arg)
+
+    def __radd__(self, arg):
+        from .function import (
+            OpAdd
+        )
+        return OpAdd(arg, self)
+
+    def __and__(self, arg):
+        from .function import (
+            OpAnd
+        )
+        return OpAnd(self, arg)
+
+    def __getitem__(self, arg):
+        from .function import (
+            OpIndex
+        )
+        return OpIndex(self, arg)
+
+    def __sub__(self, arg):
+        from .function import (
+            OpSub
+        )
+        return OpSub(self, arg)
+
+    def __or__(self, arg):
+        from .function import (
+            OpOr
+        )
+        return OpOr(self, arg)
+
+    def __xor__(self, arg):
+        from .function import (
+            OpXor
+        )
+        return OpXor(self, arg)
+
+    def __lshift__(self, arg):
+        from .function import (
+            OpLShift
+        )
+        return OpLShift(self, arg)
+
+    def __rlshift__(self, arg):
+        from .function import (
+            OpLShift
+        )
+        return OpLShift(arg, self)
+
+    def __rshift__(self, arg):
+        from .function import (
+            OpRShift
+        )
+        return OpRShift(self, arg)
+
+    def __rrshift__(self, arg):
+        from .function import (
+            OpRShift
+        )
+        return OpRShift(arg, self)
+
+    def __invert__(self):
+        from .function import (
+            OpNot
+        )
+        return OpNot(self)
+
     __type_references__ = ["type", "initializer"]
 
 

--- a/source/model.py
+++ b/source/model.py
@@ -621,6 +621,12 @@ class EnumerationElement(Type):
     def __c__(self, writer):
         writer.write(self.c_name)
 
+    def __or__(self, arg):
+        from .function import (
+            OpOr
+        )
+        return OpOr(self, arg)
+
     __type_references__ = ["initializer"]
 
 

--- a/source/model.py
+++ b/source/model.py
@@ -115,17 +115,38 @@ class TypeNotRegistered(RuntimeError):
     pass
 
 
+def pointer_name(name):
+    asterisks = 0
+    while True:
+        name = name.rstrip()
+        if name[-1] == '*':
+            asterisks += 1
+            name = name[:-1]
+        else:
+            break
+
+    return name, asterisks
+
+
 @add_metaclass(registry)
 class Type(TypeContainer):
     reg = {}
 
     @staticmethod
     def lookup(name):
+        name, asterisks = pointer_name(name)
+
         if name not in Type.reg:
             raise TypeNotRegistered("Type with name %s is not registered"
                 % name
             )
-        return Type.reg[name]
+
+        t = Type.reg[name]
+        while asterisks:
+            t = Pointer(t)
+            asterisks -= 1
+
+        return t
 
     @staticmethod
     def exists(name):

--- a/widgets/scrollframe.py
+++ b/widgets/scrollframe.py
@@ -175,6 +175,9 @@ pass it with name "inner_kw" in "kw".
         while m is not None:
             if m is inner:
                 break
+            if isinstance(m, str): # E.g., combobox's popdown list.
+                # Can't determine.
+                return
             m = m.master
         else:
             # Outer widget


### PR DESCRIPTION
This is the example of addition of TCG front-end and hardware model of MSP430.
Test suite is also included.

### v2
- fixup misprints

### v1
- `script.rst` was tested on Ubuntu 20.04 and is updated

### v0.9
- work on `script.rst`

### v0.8
- reorder and squash commits
- fixup misprints

### v0.7
- work on `script.rst`
- generic `Instruction.__call__` added, removed `MSP430XInstruction`
- `flat_list` uses `functools.update_wrapper`
- `msp430x.py` refactored; instructions `comment`s do not contain instruction
  name anymore (however it's not needed because of nearby code)
- coding style

### v0.6
- `PortPool` add names to constants
- cache `uint64_t` type and `memop` elements
- remove changing file permissions from patches
- fixup misprints
- `pyrsp`: use current `master`
- add little more syntactic sugar

### v0.5
- reorder commits
- fix naming style of symbolic names in c2t asm
- rename `_PortLease_.cache` -> `_PortLease_.pool`
- cut lines with more than 80 symbols in `msp430x_tests_coverage` script
- `pyrsp`: use main repo again
- `script.md`: convert to reStructuredText & update

### v0.4
- fixup misprints
- remove patches whose changes have been taken into account in the `master`
- cache `int`, `uint32_t`, `tcg`, `memop` types
- beautify code:
  - add newlines
  - delete some commas
- fix `Cleaner` to work properly on Windows
- add context manager which prevents the file from being overwritten with the same content
- add syntactic sugar draft
- outline `ThreadStreamCopier` and `PortPool` (`PortCache` previously)
- pyrsp: required patches are only available in [laerreal's fork](https://github.com/laerreal/pyrsp)

### v0.3
- rebase onto new `master`

### v0.2
- remove extra files and notes for ISPOpen 2020
- remove unnecessary changes
- prettify commits