### PR TITLE
A new "import all" technique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /locale/*/LC_MESSAGES/*.mo
 /c2t/tests/ir
 /c2t/tests/bin
+*/this.py

--- a/c2t/__init__.py
+++ b/c2t/__init__.py
@@ -1,9 +1,9 @@
 from common import (
     pypath,
-    iter_submodules
+    update_this,
 )
+update_this()
 
 # This module uses pyrsp which import elftools. It must import our elftools.
 with pypath("..debug.pyelftools"):
-    for mod in iter_submodules():
-        exec("from ." + mod + " import *")
+    from .this import *

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,5 +1,3 @@
-from .pypath import (
-    iter_submodules
-)
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+from .import_tools import update_this
+update_this()
+from .this import *

--- a/common/import_tools.py
+++ b/common/import_tools.py
@@ -1,0 +1,56 @@
+__all__ = [
+    "iter_import_lines"
+  , "gen_import_code"
+  , "update_this"
+]
+
+from os.path import (
+    splitext,
+    dirname,
+    join,
+    exists,
+)
+from .pypath import (
+    caller_file_name,
+    iter_submodules,
+)
+
+
+def iter_import_lines(module_dir):
+    for n in sorted(iter_submodules(cur_dir = module_dir)):
+        if n == "this":
+            continue
+        yield "from ." + splitext(n)[0] + " import *"
+
+
+def gen_import_code(module_dir):
+    return "\n".join(iter_import_lines(module_dir))
+
+
+def update_this():
+    """ It creates/updates this.py file that imports all submodules and can
+be parsed by IDEs.
+
+Use it in such a way in __init__.py:
+
+from common import (
+    update_this,
+)
+update_this()
+from .this import *
+    """
+
+    cur_dir = dirname(caller_file_name())
+    importer_name = join(cur_dir, "this.py")
+
+    code = gen_import_code(cur_dir)
+
+    if exists(importer_name):
+        with open(importer_name, "r") as f:
+            generate = (f.read() != code)
+    else:
+        generate = True
+
+    if generate:
+        with open(importer_name, "w") as f:
+            f.write(code)

--- a/common/pypath.py
+++ b/common/pypath.py
@@ -24,8 +24,9 @@ from os import (
 )
 
 
-def iter_submodules():
-    cur_dir = dirname(caller_file_name())
+def iter_submodules(cur_dir = None):
+    if cur_dir is None:
+        cur_dir = dirname(caller_file_name())
 
     for item in listdir(cur_dir):
         if item[-3:] == ".py":

--- a/debug/__init__.py
+++ b/debug/__init__.py
@@ -1,9 +1,9 @@
 from common import (
-    iter_submodules,
-    pypath
+    pypath,
+    update_this,
 )
+update_this()
 
 # this module uses custom pyelftools
 with pypath("pyelftools"):
-    for mod in iter_submodules():
-        exec("from ." + mod + " import *")
+    from .this import *

--- a/qemu/__init__.py
+++ b/qemu/__init__.py
@@ -1,6 +1,5 @@
 from common import (
-    iter_submodules
+    update_this,
 )
-
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+update_this()
+from .this import *

--- a/qemu/cpu/__init__.py
+++ b/qemu/cpu/__init__.py
@@ -1,6 +1,5 @@
 from common import (
-    iter_submodules
+    update_this,
 )
-
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+update_this()
+from .this import *

--- a/source/__init__.py
+++ b/source/__init__.py
@@ -1,6 +1,5 @@
 from common import (
-    iter_submodules
+    update_this,
 )
-
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+update_this()
+from .this import *

--- a/source/function/__init__.py
+++ b/source/function/__init__.py
@@ -1,6 +1,5 @@
 from common import (
-    iter_submodules
+    update_this,
 )
-
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+update_this()
+from .this import *

--- a/widgets/__init__.py
+++ b/widgets/__init__.py
@@ -1,6 +1,5 @@
 from common import (
-    iter_submodules
+    update_this,
 )
-
-for mod in iter_submodules():
-    exec("from ." + mod + " import *")
+update_this()
+from .this import *


### PR DESCRIPTION
The idea is to generate `this.py` in a module directory.
`this.py` imports all from submodules using `from` statement.
It's compatible with IDE's code analysis unlike current `exec`-based technique.