### PR TITLE
Fixes 9

### DIFF
--- a/misc/patch_edit.py
+++ b/misc/patch_edit.py
@@ -395,7 +395,7 @@ class PatchEditorFrame(
     @patch_set.setter
     def patch_set(self, patch_set):
         # patch set is set directly, current patch_file_name does not
-        # correslond to it likely.
+        # correspond to it likely.
         self.patch_file_name = None
         self.__patch_set = patch_set
 
@@ -1080,8 +1080,7 @@ class PatchSeriesEditorFrame(
             else:
                 self._cef.commit_info = ci
 
-            # one or none
-            break
+            break # one or none
         else:
             self._pef.patch_file_name = None
 
@@ -1128,7 +1127,7 @@ class PatchSeriesEditorFrame(
                 # not modified
                 tv.item(_id, values = [""])
 
-            break  # one or none
+            break # one or none
 
     def _on_reload_patch(self):
         self.notify_popup_command()
@@ -1163,7 +1162,7 @@ class PatchSeriesEditorFrame(
             # reset "changed" mark
             tv.item(_id, values = [""])
 
-            break  # one or none
+            break # one or none
 
     def _on_rename_patch(self):
         self.notify_popup_command()

--- a/qdc-gui.py
+++ b/qdc-gui.py
@@ -117,7 +117,8 @@ class ProjectGeneration(CoTask):
 
         yield self.p.co_gen_all(self.s,
             known_targets = cur_qvd.qvc.known_targets,
-            with_chunk_graph = self.gen_chunk_graphs
+            with_chunk_graph = self.gen_chunk_graphs,
+            include_paths = tuple(path for path, _ in cur_qvd.include_paths)
         )
 
     def on_failed(self):

--- a/qemu/cpu/code_generation.py
+++ b/qemu/cpu/code_generation.py
@@ -204,7 +204,7 @@ def fill_class_init_body(cputype, function, num_core_regs, vmstate):
         NewLine()
     )
 
-    if get_vp("device_class_set_parent_realize exists"):
+    if get_vp("device_class_set_parent_reset|realize exists"):
         body(
             Call(
                 "device_class_set_parent_realize",

--- a/qemu/cpu/code_generation.py
+++ b/qemu/cpu/code_generation.py
@@ -530,10 +530,7 @@ def fill_env_get_cpu_body(cputype, function):
 
 def fill_gdb_rw_register_body(cputype, function, comment):
     cpu = Pointer(Type[cputype.struct_instance_name])("cpu")
-    cc = Pointer(Type["CPUClass"])("cc")
     env = Pointer(Type[cputype.struct_name])("env")
-
-    ret_0 = Return(0)
 
     function.body = BodyTree()(
         Comment(comment),
@@ -545,24 +542,12 @@ def fill_gdb_rw_register_body(cputype, function, comment):
         ),
         Declare(
             OpDeclareAssign(
-                cc,
-                MCall("CPU_GET_CLASS", function.args[0])
-            )
-        ),
-        Declare(
-            OpDeclareAssign(
                 env,
                 OpAddr(OpSDeref(cpu, "env"))
             )
         ),
         NewLine(),
-        BranchIf(
-            OpGreater(
-                function.args[2],
-                OpSDeref(cc, "gdb_num_core_regs")
-            )
-        )(ret_0),
-        ret_0
+        Return(0)
     )
 
 def fill_gen_intermediate_code_body(cputype, function, cpu_env):

--- a/qemu/cpu/code_generation.py
+++ b/qemu/cpu/code_generation.py
@@ -210,7 +210,7 @@ def fill_class_init_body(cputype, function, num_core_regs, vmstate):
                 "device_class_set_parent_realize",
                 dc,
                 Type[fn_name("realizefn")],
-                OpAddr(OpSDeref(mcc, "parent_realize")),
+                OpAddr(OpSDeref(mcc, "parent_realize"))
             )
         )
     else:

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -256,6 +256,7 @@ class CPUType(QOMCPU):
         with_chunk_graph = False,
         intermediate_chunk_graphs = False,
         with_debug_comments = False,
+        include_paths = tuple(),
         **_
     ):
         import cpu_imports
@@ -355,7 +356,8 @@ class CPUType(QOMCPU):
 
                 sf.generate(f_writer,
                     graphs_prefix = graphs_prefix,
-                    gen_debug_comments = with_debug_comments
+                    gen_debug_comments = with_debug_comments,
+                    include_paths = include_paths
                 )
 
         path = self.gen_files["translate.inc.c"].path

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -798,18 +798,14 @@ class CPUType(QOMCPU):
             fn_name("gdb_read_register"),
             static = True
         )
-        fill_gdb_rw_register_body(self, gdb_read_register,
-            "TODO: implement gdb_read_register"
-        )
+        fill_gdb_rw_register_body(self, gdb_read_register)
         c.add_type(gdb_read_register)
 
         gdb_write_register = cpu_class.gdb_write_register.gen_callback(
             fn_name("gdb_write_register"),
             static = True
         )
-        fill_gdb_rw_register_body(self, gdb_write_register,
-            "TODO: implement gdb_write_register"
-        )
+        fill_gdb_rw_register_body(self, gdb_write_register, is_write = True)
         c.add_type(gdb_write_register)
 
         realizefn = Type["DeviceRealize"].type.use_as_prototype(

--- a/qemu/cpu/cpu.py
+++ b/qemu/cpu/cpu.py
@@ -901,10 +901,14 @@ class CPUType(QOMCPU):
 
         helper_debug = self.gen_helper_debug()
         fill_helper_debug_body(helper_debug)
+        # avoid warning about missing prototypes
+        helper_debug.extra_references = {Type["HELPER_PROTO_H"]}
         c.add_type(helper_debug)
 
         helper_illegal = self.gen_helper_illegal()
         fill_helper_illegal_body(helper_illegal)
+        # avoid warning about missing prototypes
+        helper_debug.extra_references = {Type["HELPER_PROTO_H"]}
         c.add_type(helper_illegal)
 
         Header["exec/helper-gen.h"].add_types([

--- a/qemu/cpu/info.py
+++ b/qemu/cpu/info.py
@@ -24,6 +24,7 @@ class CPURegister(object):
             ))
 
         self.name = name
+        self.raw_bitsize = bitsize
         # Note, possible values 32 or 64 bits
         self.field_bitsize = (bitsize + 31) & ~31
         self.reg_names = reg_names

--- a/qemu/project.py
+++ b/qemu/project.py
@@ -170,7 +170,8 @@ class QProject(object):
         with_chunk_graph = False,
         intermediate_chunk_graphs = False,
         known_targets = None,
-        with_debug_comments = False
+        with_debug_comments = False,
+        include_paths = tuple()
     ):
         qom_t = desc.gen_type()
 
@@ -203,7 +204,8 @@ class QProject(object):
             with open(spath, mode = "wb", encoding = "utf-8") as stream:
                 f.generate(stream,
                     graphs_prefix = graphs_prefix,
-                    gen_debug_comments = with_debug_comments
+                    gen_debug_comments = with_debug_comments,
+                    include_paths = include_paths
                 )
 
             if with_chunk_graph:

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -615,10 +615,15 @@ def define_only_qemu_2_6_0_types():
             ),
             name = "DeviceUnrealize"
         ),
+        Pointer(
+            Function(args = [ Pointer(Type["DeviceState"])("dev") ]),
+            name = "DeviceReset"
+        ),
         Structure("DeviceClass",
             # These are required fields only
             Type["DeviceRealize"]("realize"),
             Type["DeviceUnrealize"]("unrealize"),
+            Type["DeviceReset"]("reset")
         ),
         Type("Property", False),
         Function(
@@ -637,10 +642,11 @@ def define_only_qemu_2_6_0_types():
         Function(name = "qdev_connect_gpio_out"),
         Function(name = "qdev_connect_gpio_out_named")
     ])
-    if get_vp("device_class_set_parent_realize exists"):
-        qdev_core_header.add_type(
+    if get_vp("device_class_set_parent_reset|realize exists"):
+        qdev_core_header.add_types([
+            Function(name = "device_class_set_parent_reset"),
             Function(name = "device_class_set_parent_realize")
-        )
+        ])
     if get_vp("use device_class_set_props"):
         qdev_core_header.add_type(
             Function(
@@ -1419,9 +1425,9 @@ qemu_heuristic_db = {
     ],
     u'46795cf2e2f643ace9454822022ba8b1e9c0cf61':
     [
-        # `device_class_set_parent_realize` function was added
+        # `device_class_set_parent_reset|realize` function was added
         QEMUVersionParameterDescription(
-            "device_class_set_parent_realize exists",
+            "device_class_set_parent_reset|realize exists",
             old_value = False,
             new_value = True
         )

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -1602,6 +1602,15 @@ qemu_heuristic_db = {
             old_value = False,
             new_value = True
         )
+    ],
+    u"fc59d2d870caddf5cd9c85836ee4a8c59ffe7617":
+    [
+        # qemu_log_lock/unlock now preserves the qemu_logfile handle
+        QEMUVersionParameterDescription(
+            "qemu_log_lock|unlock preserves logfile handle",
+            old_value = False,
+            new_value = True
+        )
     ]
 }
 

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -1580,6 +1580,15 @@ qemu_heuristic_db = {
             new_value = True,
             old_value = False
         )
+    ],
+    u"781c67ca5585b38a29076093ecdff4f273db5a35":
+    [
+        # cpu: Use DeviceClass reset
+        QEMUVersionParameterDescription(
+            "device_class_set_parent_reset used for cpu",
+            old_value = False,
+            new_value = True
+        )
     ]
 }
 

--- a/qemu/version.py
+++ b/qemu/version.py
@@ -327,8 +327,12 @@ def define_only_qemu_2_6_0_types():
             Function(
                 ret_type = Type["int"],
                 args = [
-                    Pointer(Type["CPUState"])("cs"),
-                    Pointer(Type["uint8_t"])("mem_buf"),
+                    Pointer(Type["CPUState"])("cs")
+                ] + (
+                    [ Pointer(Type["GByteArray"])("buf") ] if
+                    get_vp("gdb_read_register buf type is GByteArray")
+                    else [ Pointer(Type["uint8_t"])("mem_buf") ]
+                ) + [
                     Type["int"]("n")
                 ]
             )("gdb_read_register"),
@@ -1586,6 +1590,15 @@ qemu_heuristic_db = {
         # cpu: Use DeviceClass reset
         QEMUVersionParameterDescription(
             "device_class_set_parent_reset used for cpu",
+            old_value = False,
+            new_value = True
+        )
+    ],
+    u"a010bdbe719c52c8959ca058000d7ac7d559abb8":
+    [
+        # gdbstub: extend GByteArray to read register helpers
+        QEMUVersionParameterDescription(
+            "gdb_read_register buf type is GByteArray",
             old_value = False,
             new_value = True
         )

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -644,6 +644,16 @@ class QemuVersionDescription(object):
 
             # make new QVC active and begin construction
             prev_qvc = self.qvc.use()
+
+            # gen version description
+            yield self.qvc.co_computing_parameters(self.repo, self.commit_sha)
+            self.qvc.version_desc[QVD_QH_HASH] = qemu_heuristic_hash
+
+            yield True
+
+            # set Qemu version heuristics according to current version
+            initialize_version(self.qvc.version_desc)
+
             yield Header.co_build_inclusions(tmp_work_dir, self.include_paths)
 
             self.qvc.list_headers = self.qvc.stc.create_header_db()
@@ -654,10 +664,6 @@ class QemuVersionDescription(object):
             yield self.co_init_device_tree()
 
             yield self.co_gen_known_targets()
-
-            # gen version description
-            yield self.qvc.co_computing_parameters(self.repo, self.commit_sha)
-            self.qvc.version_desc[QVD_QH_HASH] = qemu_heuristic_hash
 
             # Search for PCI Ids
             PCIClassification.build()
@@ -691,6 +697,11 @@ class QemuVersionDescription(object):
                 )
                 self.qvc.version_desc[QVD_QH_HASH] = qemu_heuristic_hash
 
+            yield True
+
+            # set Qemu version heuristics according to current version
+            initialize_version(self.qvc.version_desc)
+
             dt = self.qvc.device_tree
             if dt:
                 # Targets to be added to the cache
@@ -705,11 +716,6 @@ class QemuVersionDescription(object):
 
             if is_outdated or has_new_target:
                 yield self.co_overwrite_cache()
-
-        yield True
-
-        # set Qemu version heuristics according to current version
-        initialize_version(self.qvc.version_desc)
 
         yield True
 

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -550,18 +550,26 @@ class QemuVersionDescription(object):
 
         print("Qemu version is {}".format(self.qemu_version))
 
-        self.include_paths = (
-            # path, need recursion
-            ("include", True),
-            ("tcg", False)
-        )
-
-        self.include_abs_paths = list(
-            join(self.src_path, d) for d, _ in self.include_paths
-        )
-
         self.qvc = None
         self.qvc_is_ready = False
+
+    @lazy
+    def include_paths(self):
+        if get_vp("tcg headers prefix") == "tcg/":
+            return (
+                # path, need recursion
+                ("include", True),
+            )
+        else:
+            return (
+                # path, need recursion
+                ("include", True),
+                ("tcg", False)
+            )
+
+    @lazy
+    def include_abs_paths(self):
+        return tuple(join(self.src_path, d) for d, _ in self.include_paths)
 
     # The method made the description active
     def use(self):

--- a/qemu_device_creator.py
+++ b/qemu_device_creator.py
@@ -129,7 +129,8 @@ def main():
         intermediate_chunk_graphs = arguments.gen_intermediate_chunk_graphs,
         with_chunk_graph = arguments.gen_chunk_graphs,
         known_targets = qvd.qvc.known_targets,
-        with_debug_comments = arguments.gen_debug_comments
+        with_debug_comments = arguments.gen_debug_comments,
+        include_paths = tuple(path for path, _ in qvd.include_paths)
     )
 
     return 0

--- a/source/base_types.py
+++ b/source/base_types.py
@@ -133,3 +133,12 @@ def add_base_types():
         Type(name = "wint_t", incomplete = False, base = False),
         Type(name = "wchar_t", incomplete = False, base = False)
     ])
+
+    try:
+        h = Header["glib.h"]
+    except:
+        h = Header("glib.h", is_global = True)
+
+    h.add_types([
+        Type(name = "GByteArray", incomplete = False, base = False)
+    ])

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -1238,7 +1238,7 @@ digraph Chunks {
                 self.remove_dup_chunk(ch, prev_ch)
                 func_dec[f] = ch
 
-    def header_paths_shortening(self):
+    def header_paths_shortening(self, include_paths):
         origin_dir = dirname(self.origin.path)
 
         for ch in self.chunks:
@@ -1250,15 +1250,14 @@ digraph Chunks {
                 path = (basename(header_path),)
             else:
                 path = path2tuple(header_path)
-                # TODO: those are domain specific values, make them global
-                # parameters
-                if path[0] in ("include", "tcg"):
+                if path[0] in include_paths:
                     path = path[1:]
             ch.path = path
 
     def generate(self, writer,
         graphs_prefix = None,
-        gen_debug_comments = False
+        gen_debug_comments = False,
+        include_paths = tuple()
     ):
         # check for duplicate chunks for same origin
         self.remove_chunks_with_same_origin()
@@ -1271,7 +1270,7 @@ digraph Chunks {
         if OPTIMIZE_INCLUSIONS:
             self.optimize_inclusions(graphs_prefix = graphs_prefix)
 
-        self.header_paths_shortening()
+        self.header_paths_shortening(include_paths)
 
         # semantic sort
         self.chunks = OrderedSet(sorted(self.chunks))


### PR DESCRIPTION
The main goal is to change the cpu boilerplate to take into account QEMU changes up to version 5.1.0.

### v2
- add comments
- simplify logic of `QEMU_ARCH_NONE_val` check
- caches `buf` function argument

### v1.1
- `QemuVersionDescription.include_abs_paths` is immutable