### PR TITLE
Wave 1

### DIFF
--- a/common/co_dispatcher.py
+++ b/common/co_dispatcher.py
@@ -258,6 +258,8 @@ after last statement in the corresponding callable object.
             except KeyError:
                 continue
 
+            ready = True
+
             del self.callees[task]
             # All callers of finished task may continue execution.
             for caller in callers:

--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -266,6 +266,10 @@ def init_submodules_from_cache(repo, cache_dir, revert_urls = False):
         # If path is absent, it's considered equal to name.
         sm_path = props.get(".path", sm)
 
+        if not repo_path_in_tree(repo, sm_path):
+            # The submodule has likely been removed from tree.
+            continue
+
         if exists(sub_cache):
             if revert_urls:
                 url_back = git.config(

--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -234,7 +234,7 @@ as fast as possible. A clone is neither honest nor independent, so be careful.
 
     return new_repo
 
-def init_submodules_from_cache(repo, cache_dir):
+def init_submodules_from_cache(repo, cache_dir, revert_urls = False):
     git = repo.git
 
     if not exists(join(repo.working_tree_dir, ".gitmodules")):
@@ -256,12 +256,21 @@ def init_submodules_from_cache(repo, cache_dir):
                 name = full_key[:-len(prop)]
                 submodules.setdefault(name, {})[prop] = value
 
+    # Previous value of submodule URL used when `revert_urls`.
+    url_back = None
+
     for sm, props in submodules.items():
         sub_cache = join(cache_dir, sm)
         # If path is absent, it's considered equal to name.
         sm_path = props.get(".path", sm)
 
         if exists(sub_cache):
+            if revert_urls:
+                url_back = git.config(
+                    "submodule." + sm + ".url",
+                    file = ".gitmodules"
+                )
+
             # https://stackoverflow.com/a/30675130/7623015
             git.config(
                 "submodule." + sm + ".url",
@@ -279,7 +288,17 @@ def init_submodules_from_cache(repo, cache_dir):
         git.submodule("update", "--init", sm_path)
 
         sub_repo = Repo(join(repo.working_tree_dir, sm_path))
-        init_submodules_from_cache(sub_repo, join(sub_cache, "modules"))
+        init_submodules_from_cache(sub_repo, join(sub_cache, "modules"),
+            revert_urls = revert_urls
+        )
+
+        if url_back is not None:
+            git.config(
+                "submodule." + sm + ".url",
+                url_back,
+                file = ".gitmodules"
+            )
+            url_back = None
 
 
 def git_find_commit(repo, version):

--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -283,6 +283,16 @@ def init_submodules_from_cache(repo, cache_dir, revert_urls = False):
                 sub_cache,
                 file = ".gitmodules"
             )
+            # When initializing submodules of a local clone setting URL in
+            # .gitmodules is sufficient to force Git use local cache during
+            # "update" command.
+            # However, initialization of a worktree (see "git worktree")
+            # submodules still uses original URLs. The "sync" command fixes it.
+            #
+            # Note that Git keeps cache of worktree submodules in a different
+            # place (i.e. caches of main work tree submodules are not re-used):
+            # .git/worktrees/[worktree name]/modules/[path to submodule]
+            git.submodule("sync", sm_path)
         else:
             print("Submodule %s has no cache at '%s'."
                   " Default URL will be used." % (
@@ -305,6 +315,8 @@ def init_submodules_from_cache(repo, cache_dir, revert_urls = False):
                 file = ".gitmodules"
             )
             url_back = None
+            # Updates URL in cache "config" file.
+            git.submodule("sync", sm_path)
 
 
 def git_find_commit(repo, version):

--- a/common/git_tools.py
+++ b/common/git_tools.py
@@ -6,6 +6,7 @@ __all__ = [
   , "fast_repo_clone"
   , "git_find_commit"
   , "init_submodules_from_cache"
+  , "repo_path_in_tree"
 ]
 
 from collections import (
@@ -21,6 +22,7 @@ from tempfile import (
     mkdtemp
 )
 from os.path import (
+    sep,
     exists,
     join
 )
@@ -315,3 +317,26 @@ a remote head.
                     return ref.commit
 
         raise
+
+
+# Based on: https://stackoverflow.com/a/25961128/7623015
+def repo_path_in_tree(repo, path):
+    """
+@param repo: is a gitPython Repo object
+@param path: is the full path to a file/directory from the repository root
+
+Returns `true` if path exists in the repo in current version,
+        `false` otherwise.
+    """
+
+    # Build up reference to desired repo path
+    rsub = repo.head.commit.tree
+
+    for path_element in path.split(sep):
+        # If dir on file path is not in repo, neither is file/directory.
+        try :
+            rsub = rsub[path_element]
+        except KeyError:
+            return False
+
+    return True

--- a/common/pygen.py
+++ b/common/pygen.py
@@ -22,7 +22,7 @@ from .reflection import (
     get_class_total_args
 )
 from .visitor import (
-    BreakVisiting,
+    SkipVisiting,
     ObjectVisitor
 )
 from collections import (
@@ -617,7 +617,7 @@ class PyGenDepsCatcher(PyGenDepsVisitor):
         cur = self.cur
         if hasattr(cur, "__gen_code__") or hasattr(cur, "__pygen_pass__"):
             self.deps.append(cur)
-            raise BreakVisiting()
+            raise SkipVisiting()
 
 
 def default_gen_pass(obj, gen):

--- a/common/pygen.py
+++ b/common/pygen.py
@@ -199,23 +199,27 @@ require reference to the current object.
                     normalized += "\\x%02x" % code
                 elif code == 92: # \
                     normalized += "\\\\"
+                # Do not use multiline strings ("""/''') because of auto
+                # indentation.
+                elif code == 0x0A: # \n
+                    normalized += r"\n"
+                elif code == 0x0D: # \r
+                    normalized += r"\r"
                 else:
                     if code == 34: # "
                         dquote += 1
                     elif code == 38: # '
                         squote += 1
-                    elif code == 0x0A or code == 0x0D:
-                        multiline = True
                     normalized += chr(code)
 
             if dquote > squote:
                 escaped = normalized.replace("'", "\\'")
-                quotes = "'''" if multiline else "'"
-                return prefix + quotes + escaped + quotes
+                quotes = "'"
             else:
                 escaped = normalized.replace('"', '\\"')
-                quotes = '"""' if multiline else '"'
-                return prefix + quotes + escaped + quotes
+                quotes = '"'
+
+            return prefix + quotes + escaped + quotes
         else:
             return repr(c)
 

--- a/common/trie.py
+++ b/common/trie.py
@@ -1,9 +1,19 @@
 __all__ = [
-    "trie_add"
+    "iter_trie_items"
+  , "iter_trie_paths"
+  , "trie_add"
+  , "trie_build"
   , "trie_find"
 ]
 
 # Helpers to build trie of `dict`s
+
+
+def trie_build(iterable):
+    res = {}
+    for path, value in iterable:
+        trie_add(res, path, value, replace = True)
+    return res
 
 
 def trie_add(trie, path, value, replace = False):
@@ -120,3 +130,16 @@ def iter_trie_paths(trie):
                     yield (p,) + subpath
     else:
         yield trie[1]
+
+
+def iter_trie_items(trie):
+    if isinstance(trie, dict):
+        for p, subtrie in trie.items():
+            if p is None:
+                # There is something at root of (sub)trie.
+                yield tuple()
+            else:
+                for subpath, value in iter_trie_items(subtrie):
+                    yield (p,) + subpath, value
+    else:
+        yield trie[1], trie[0]

--- a/common/visitor.py
+++ b/common/visitor.py
@@ -1,12 +1,12 @@
 __all__ = [
     "ObjectVisitor"
-  , "BreakVisiting"
+  , "SkipVisiting"
   , "VisitingIsNotImplemented"
 ]
 
 
 # Not an `Exception`. It's (ab)using of `try` logic.
-class BreakVisiting(BaseException):
+class SkipVisiting(BaseException):
     pass
 
 
@@ -42,11 +42,11 @@ the current object are also stored in the last entry of `self.path`.
 Default `on_visit` (`on_leave`) does nothing.
 The user should override it to define needed behaviour.
 
-To prevent traversing of subtree the `on_visit` can raise `BreakVisiting`.
-`on_leave` is called even if `BreakVisiting` was raised.
+To prevent traversing of subtree the `on_visit` can raise `SkipVisiting`.
+`on_leave` is called even if `SkipVisiting` was raised.
 
 The `replace` could be called to replace current object in its parent.
-Note that `replace` method raises `BreakVisiting` by default.
+Note that `replace` method raises `SkipVisiting` by default.
 
 Features (+) implemented, (-) TODO:
  - detection for cycles
@@ -92,7 +92,7 @@ Features (+) implemented, (-) TODO:
         """ Replaces current (being replaced) node within its container with.
 
     :param skip_trunk:
-        Skip subtree of `new_value` by raising `BreakVisiting` (no return).
+        Skip subtree of `new_value` by raising `SkipVisiting` (no return).
         Subtree of previous value will be skipped because of replacement.
         Keep in mind that setting the argument to `False` may quite easy
         lead to fall into a dead loop.
@@ -120,7 +120,7 @@ Features (+) implemented, (-) TODO:
         # print self.path_str() + " <- " + str(new_value) 
 
         if skip_trunk:
-            raise BreakVisiting()
+            raise SkipVisiting()
 
     def path_str(self):
         return ".".join(str(n) + "{%s}" % str(o) for o, n in self.path[1:])
@@ -175,7 +175,7 @@ Features (+) implemented, (-) TODO:
     def __visit__(self, attr):
         try:
             self.on_visit()
-        except BreakVisiting:
+        except SkipVisiting:
             return
         else:
             self.__visit_items__(attr)

--- a/common/visitor.py
+++ b/common/visitor.py
@@ -5,7 +5,8 @@ __all__ = [
 ]
 
 
-class BreakVisiting(Exception):
+# Not an `Exception`. It's (ab)using of `try` logic.
+class BreakVisiting(BaseException):
     pass
 
 

--- a/misc/fast-clone.py
+++ b/misc/fast-clone.py
@@ -1,0 +1,34 @@
+"""
+A script for testing of `init_submodules_from_cache` operation.
+"""
+
+from common import (
+    init_submodules_from_cache
+)
+from git import (
+    Repo
+)
+from sys import (
+    argv
+)
+from os.path import (
+    join
+)
+
+
+if __name__ == "__main__":
+    try:
+        path = argv[1]
+    except IndexError:
+        print("Need Git repo path")
+        exit(1)
+
+    repo = Repo(path)
+
+    clone_path = path + ".clone"
+    repo_clone = repo.clone(clone_path, shared = True)
+
+    init_submodules_from_cache(repo_clone,
+        join(repo.working_tree_dir, ".git", "modules"),
+        revert_urls = True
+    )

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -91,6 +91,32 @@ class QType(object):
         for t in co_find_eq(self.root().descendants(), **request):
             yield t
 
+    def merge(self, tree):
+        # cache
+        children = self.children
+        macros = self.macros
+        add_child = self.add_child
+
+        for m in tree.macros:
+            if m not in macros:
+                macros.append(m)
+
+        self.arches.update(tree.arches)
+
+        for n, other_c in tree.children.items():
+
+            if n in children:
+                c = children[n]
+            else:
+                c = type(other_c)(
+                    name = n,
+                    macros = other_c.macros,
+                    arches = other_c.arches,
+                )
+                add_child(c)
+
+            c.merge(other_c)
+
     # Tree will be traversed from the root to the child nodes
     # The children will be serialized first
     __pygen_deps__ = ("children",)

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -49,10 +49,10 @@ class QType(object):
         else:
             parent.add_child(self)
 
-        self.macros = macros if macros else []
+        self.macros = list(macros) if macros else []
 
         # set of CPU architectures found in QOM type tree
-        self.arches = arches if arches else set()
+        self.arches = set(arches) if arches else set()
 
     def __remove_child(self, child):
         child.parent = None

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -16,9 +16,6 @@ from common import (
     pypath,
     co_find_eq
 )
-from os.path import (
-    join
-)
 from subprocess import (
     Popen
 )

--- a/qemu/qom_hierarchy.py
+++ b/qemu/qom_hierarchy.py
@@ -117,6 +117,9 @@ class QType(object):
 
             c.merge(other_c)
 
+    def __contains__(self, name):
+        return name in self.children
+
     # Tree will be traversed from the root to the child nodes
     # The children will be serialized first
     __pygen_deps__ = ("children",)

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -682,10 +682,14 @@ class QemuVersionDescription(object):
             rmtree(tmp_work_dir)
             get_cleaner().cancel(clean_work_dir_task)
 
-            yield self.co_init_device_tree()
-
             # Search for PCI Ids
             PCIClassification.build()
+
+            # Save cache after long running operation because device tree
+            # initialization is frequently buggy.
+            yield self.co_overwrite_cache()
+
+            yield self.co_init_device_tree()
 
             yield self.co_overwrite_cache()
         else:

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -725,6 +725,10 @@ class QemuVersionDescription(object):
             # set Qemu version heuristics according to current version
             initialize_version(self.qvc.version_desc)
 
+            # Save cache after long running operation because consequent
+            # initialization can be buggy.
+            yield self.co_overwrite_cache()
+
             dt = self.qvc.device_tree
             if dt:
                 # Targets to be added to the cache

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -332,6 +332,8 @@ class QemuVersionCache(object):
                                     else:
                                         exc_raise = True
                                     if exc_raise:
+                                        # Hint: try to add `old_value` equal to
+                                        #       previous `new_value`.
                                         raise Exception("Contradictory definition of param " \
 "'%s' in commit %s (%s != %s)" % (p, c.sha, cur_node.param_nval[p], c.param_nval[p])
                                         )

--- a/qemu/version_description.py
+++ b/qemu/version_description.py
@@ -272,7 +272,8 @@ class QemuVersionCache(object):
 
     :param sorted_vd_keys:
         keys of qemu_heuristic_db sorted in ascending order by num of
-        QemuCommitDesc. It's necessary to optimize the graph traversal.
+        QemuCommitDesc (elder first). It's necessary to optimize the graph
+        traversal.
 
     :param vd:
         qemu_heuristic_db

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -81,7 +81,7 @@ from ..type_container import (
 )
 from common import (
     ee,
-    BreakVisiting,
+    SkipVisiting,
     lazy
 )
 from six import (
@@ -109,7 +109,7 @@ class DeclarationSearcher(NodeVisitor):
     def on_visit(self):
         if isinstance(self.cur, Declare):
             self.have_declaration = True
-            raise BreakVisiting()
+            raise SkipVisiting()
 
 
 def flat_iter(gen):

--- a/source/function/tree.py
+++ b/source/function/tree.py
@@ -838,7 +838,11 @@ class OpCast(UnaryOperator):
 
     __type_references__ = ("type",)
 
-    def __init__(self, type_name, arg):
+    def __init__(self, type_or_name, arg):
+        if isinstance(type_or_name, Type):
+            type_name = type_or_name.c_name
+        else:
+            type_name = type_or_name
         super(OpCast, self).__init__("(" + type_name + ")", arg)
         self.type = Type[type_name]
 

--- a/source/model.py
+++ b/source/model.py
@@ -23,7 +23,7 @@ from itertools import (
 from common import (
     ee,
     ObjectVisitor,
-    BreakVisiting
+    SkipVisiting
 )
 from six import (
     add_metaclass,
@@ -1113,7 +1113,7 @@ class TypesCollector(TypeReferencesVisitor):
         cur = self.cur
         if isinstance(cur, Type):
             self.used_types.add(cur)
-            raise BreakVisiting()
+            raise SkipVisiting()
 
 
 class GlobalsCollector(NodeVisitor):

--- a/source/model.py
+++ b/source/model.py
@@ -173,10 +173,11 @@ class Type(TypeContainer):
             self.name = name
             self.c_name = name.split('.', 1)[0]
 
-            if name in Type.reg:
-                raise RuntimeError("Type %s is already registered" % name)
-
-            Type.reg[name] = self
+            t = Type.reg.setdefault(name, self)
+            if t is not self:
+                raise RuntimeError("Type %s is already registered (%s)" % (
+                    name, t.definer
+                ))
 
     def gen_var(self, name,
         pointer = False,

--- a/source/source_file.py
+++ b/source/source_file.py
@@ -32,7 +32,7 @@ from six import (
     add_metaclass,
 )
 from common import (
-    BreakVisiting,
+    SkipVisiting,
     ee,
     OrderedSet,
     path2tuple,
@@ -342,7 +342,7 @@ class TypeFixerVisitor(TypeReferencesVisitor):
             t = self.cur
 
             if t.base:
-                raise BreakVisiting()
+                raise SkipVisiting()
 
             if not t.is_named:
                 return
@@ -368,7 +368,7 @@ class TypeFixerVisitor(TypeReferencesVisitor):
                 self.required_types.append(t)
 
             # Do not enter another source (`t`ype's definer).
-            raise BreakVisiting()
+            raise SkipVisiting()
 
     def visit(self):
         ret = super(TypeFixerVisitor, self).visit()

--- a/update-translation.py
+++ b/update-translation.py
@@ -73,7 +73,9 @@ for l in langs:
     messages_po = join(directory, "messages.po")
     qdc_po = join(directory, "qdc.po")
 
-    call(["xgettext", "-o", messages_po] + list(locale_files.keys()))
+    call(["xgettext", "--from-code", "utf-8", "-o", messages_po]
+         + list(locale_files.keys())
+    )
 
     if isfile(qdc_po):
         call(["msgmerge", "-U", "-N", qdc_po, messages_po])

--- a/widgets/canvas_frame.py
+++ b/widgets/canvas_frame.py
@@ -76,6 +76,7 @@ resizing capabilities.
     """
 
     def __init__(self, canvas, x, y, *a, **kw):
+        canvas_kw = kw.pop("canvas_kw", {})
         kw["padx"] = kw["pady"] = RESIZE_GAP + 2
         GUIFrame.__init__(self, canvas, *a, **kw)
 
@@ -93,7 +94,11 @@ resizing capabilities.
         self.x, self.y = RESIZE_GAP * 2, RESIZE_GAP * 2
         self.__cursor = self.cget("cursor")
 
-        self.id = canvas.create_window(x, y, window = self, anchor = NW)
+        canvas_kw = dict(canvas_kw) # preserve user's `dict`
+        canvas_kw["window"] = self
+        canvas_kw["anchor"] = NW
+
+        self.id = canvas.create_window(x, y, **canvas_kw)
 
     def _set_cursor(self, c):
         if self.__cursor != c:

--- a/widgets/canvas_frame.py
+++ b/widgets/canvas_frame.py
@@ -94,9 +94,12 @@ resizing capabilities.
         self.x, self.y = RESIZE_GAP * 2, RESIZE_GAP * 2
         self.__cursor = self.cget("cursor")
 
-        canvas_kw = dict(canvas_kw) # preserve user's `dict`
+        # preserve user's `dict`
+        canvas_kw = dict(canvas_kw)
+        assert "window" not in canvas_kw, "%s IS the the window" % self
         canvas_kw["window"] = self
-        canvas_kw["anchor"] = NW
+        assert "anchor" not in canvas_kw, "implementation relies on NW anchor"
+        canvas_kw.setdefault("anchor", NW)
 
         self.id = canvas.create_window(x, y, **canvas_kw)
 

--- a/widgets/device_settings.py
+++ b/widgets/device_settings.py
@@ -421,7 +421,12 @@ class DeviceSettingsWidget(QOMInstanceSettingsWidget):
         self.event_generate(DeviceSettingsWidget.EVENT_BUS_SELECTED)
 
     def on_press_select_qom_type(self):
-        DeviceTreeWidget(self)
+        device_tree = qvd_get(
+            self.mach.project.build_path,
+            version = self.mach.project.target_version
+        ).qvc.device_tree
+
+        DeviceTreeWidget(self, qom_tree = device_tree)
 
     def gen_uniq_prop_name(self):
         for x in count(0, 1):

--- a/widgets/device_tree_widget.py
+++ b/widgets/device_tree_widget.py
@@ -11,6 +11,8 @@ from qemu import (
     qvd_get
 )
 from six.moves.tkinter import (
+    NORMAL,
+    DISABLED,
     Frame,
     Radiobutton,
     Checkbutton,
@@ -66,7 +68,7 @@ class DeviceTreeWidget(GUIDialog):
         dt.heading("Macros", text = _("Macros"))
 
         dt.bind("<<TreeviewSelect>>", self._on_device_tv_select, "+")
-        self.v_sel_type = StringVar(self)
+        self.v_sel_type = v_sel_type = StringVar(self)
 
         dt.grid(
             row = 0,
@@ -94,7 +96,8 @@ class DeviceTreeWidget(GUIDialog):
             command = self.on_select_qom_type
         )
         self.add_button.grid(row = 2, column = 0, sticky = "EW")
-        self.add_button.config(state = "disabled")
+        self.add_button.config(state = DISABLED)
+        v_sel_type.trace("w", self._on_v_sel_type_w)
 
         qtype_dt = self.qtype_dt = qvd_get(
             root.mach.project.build_path,
@@ -277,7 +280,6 @@ class DeviceTreeWidget(GUIDialog):
 
         item = sel[0]
 
-        self.add_button.config(state = "normal")
         for widget in self.fr_qt.winfo_children():
             widget.destroy()
 
@@ -307,3 +309,10 @@ class DeviceTreeWidget(GUIDialog):
                 b.pack(anchor = "w")
 
         b.select()
+
+    def _on_v_sel_type_w(self, *__):
+        v_sel_type = self.v_sel_type
+        if v_sel_type.get():
+            self.add_button.config(state = NORMAL)
+        else:
+            self.add_button.config(state = DISABLED)

--- a/widgets/device_tree_widget.py
+++ b/widgets/device_tree_widget.py
@@ -66,6 +66,7 @@ class DeviceTreeWidget(GUIDialog):
         dt.heading("Macros", text = _("Macros"))
 
         dt.bind("<ButtonPress-1>", self.on_b1_press_dt)
+        self.v_sel_type = StringVar(self)
 
         dt.grid(
             row = 0,
@@ -263,7 +264,7 @@ class DeviceTreeWidget(GUIDialog):
                 dt.detach(*to_detach)
 
     def on_select_qom_type(self):
-        self.qom_type_var.set(self.v.get())
+        self.qom_type_var.set(self.v_sel_type.get())
         self.destroy()
 
     # write selected qom type in qom_type_var
@@ -278,12 +279,14 @@ class DeviceTreeWidget(GUIDialog):
             widget.destroy()
 
         dt_type = self.device_tree.item(item, "text")
-        self.v = StringVar()
-        self.v.set(dt_type)
+
+        v_sel_type = self.v_sel_type
+        # Note, value of `v_sel_type` will be assigned automatically by
+        # `Radiobutton`s `select` below.
 
         b = Radiobutton(self.fr_qt,
             text = dt_type,
-            variable = self.v,
+            variable = v_sel_type,
             value = dt_type
         )
         b.pack(anchor = "w")
@@ -295,7 +298,7 @@ class DeviceTreeWidget(GUIDialog):
                 b = Radiobutton(
                     self.fr_qt,
                     text = mstr,
-                    variable = self.v,
+                    variable = v_sel_type,
                     value = mstr
                 )
                 b.pack(anchor = "w")

--- a/widgets/device_tree_widget.py
+++ b/widgets/device_tree_widget.py
@@ -7,9 +7,6 @@ from .var_widgets import (
     VarButton,
     VarLabelFrame
 )
-from qemu import (
-    qvd_get
-)
 from six.moves.tkinter import (
     NORMAL,
     DISABLED,
@@ -44,7 +41,10 @@ ItemDesc = namedtuple(
 
 
 class DeviceTreeWidget(GUIDialog):
+
     def __init__(self, root, *args, **kw):
+        self.qom_tree = qom_tree = kw.pop("qom_tree")
+
         GUIDialog.__init__(self, master = root, *args, **kw)
         self.qom_type_var = root.qom_type_var
 
@@ -99,11 +99,6 @@ class DeviceTreeWidget(GUIDialog):
         self.bt_select.config(state = DISABLED)
         v_sel_type.trace("w", self._on_v_sel_type_w)
 
-        qtype_dt = self.qtype_dt = qvd_get(
-            root.mach.project.build_path,
-            version = root.mach.project.target_version
-        ).qvc.device_tree
-
         arch_buttons = Frame(fr_at, borderwidth = 0)
         arch_buttons.pack(fill = "x")
 
@@ -129,7 +124,7 @@ class DeviceTreeWidget(GUIDialog):
         )
         bt_invert_arches.grid(row = 0, column = 2, sticky = "EW")
 
-        if not qtype_dt.arches:
+        if not qom_tree.arches:
             bt_all_arches.config(state = "disabled")
             bt_none_arches.config(state = "disabled")
             bt_invert_arches.config(state = "disabled")
@@ -141,7 +136,7 @@ class DeviceTreeWidget(GUIDialog):
         )
 
         ac = self.arches_checkbox = []
-        for a in sorted(list(qtype_dt.arches)):
+        for a in sorted(list(qom_tree.arches)):
             v = IntVar()
             c = Checkbutton(arch_selector,
                 text = a,
@@ -162,7 +157,7 @@ class DeviceTreeWidget(GUIDialog):
 
         self.disabled_arches = set()
 
-        self.qom_create_tree("", qtype_dt.children)
+        self.qom_create_tree("", qom_tree.children)
 
     def select_arches(self):
         all_items = self.all_items
@@ -194,7 +189,7 @@ class DeviceTreeWidget(GUIDialog):
                 self.detached_items[i] = self.all_items[i]
 
         dt.detach(*to_detach)
-        self.disabled_arches = set(self.qtype_dt.arches)
+        self.disabled_arches = set(self.qom_tree.arches)
 
         for c in self.arches_checkbox:
             c.deselect()

--- a/widgets/device_tree_widget.py
+++ b/widgets/device_tree_widget.py
@@ -65,7 +65,7 @@ class DeviceTreeWidget(GUIDialog):
         dt.heading("#0", text = _("Devices"))
         dt.heading("Macros", text = _("Macros"))
 
-        dt.bind("<ButtonPress-1>", self.on_b1_press_dt)
+        dt.bind("<<TreeviewSelect>>", self._on_device_tv_select, "+")
         self.v_sel_type = StringVar(self)
 
         dt.grid(
@@ -268,17 +268,20 @@ class DeviceTreeWidget(GUIDialog):
         self.destroy()
 
     # write selected qom type in qom_type_var
-    def on_b1_press_dt(self, event):
-        item = self.device_tree.identify('item', event.x, event.y)
+    def _on_device_tv_select(self, __):
+        dt = self.device_tree
+        sel = dt.selection()
 
-        if not item:
+        if len(sel) != 1:
             return
+
+        item = sel[0]
 
         self.add_button.config(state = "normal")
         for widget in self.fr_qt.winfo_children():
             widget.destroy()
 
-        dt_type = self.device_tree.item(item, "text")
+        dt_type = dt.item(item, "text")
 
         v_sel_type = self.v_sel_type
         # Note, value of `v_sel_type` will be assigned automatically by
@@ -291,7 +294,7 @@ class DeviceTreeWidget(GUIDialog):
         )
         b.pack(anchor = "w")
 
-        macros = self.device_tree.item(item, "values")[0]
+        macros = dt.item(item, "values")[0]
         if macros != "None":
             l = macros.split(", ")
             for mstr in l:

--- a/widgets/device_tree_widget.py
+++ b/widgets/device_tree_widget.py
@@ -90,13 +90,13 @@ class DeviceTreeWidget(GUIDialog):
         self.fr_qt = VarLabelFrame(column_fr, text = _("Select QOM type"))
         self.fr_qt.grid(row = 1, column = 0, sticky = "SEWN")
 
-        self.add_button = VarButton(
+        self.bt_select = VarButton(
             column_fr,
             text = _("Select"),
-            command = self.on_select_qom_type
+            command = self._on_bt_select
         )
-        self.add_button.grid(row = 2, column = 0, sticky = "EW")
-        self.add_button.config(state = DISABLED)
+        self.bt_select.grid(row = 2, column = 0, sticky = "EW")
+        self.bt_select.config(state = DISABLED)
         v_sel_type.trace("w", self._on_v_sel_type_w)
 
         qtype_dt = self.qtype_dt = qvd_get(
@@ -266,7 +266,7 @@ class DeviceTreeWidget(GUIDialog):
             if to_detach:
                 dt.detach(*to_detach)
 
-    def on_select_qom_type(self):
+    def _on_bt_select(self):
         self.qom_type_var.set(self.v_sel_type.get())
         self.destroy()
 
@@ -313,6 +313,6 @@ class DeviceTreeWidget(GUIDialog):
     def _on_v_sel_type_w(self, *__):
         v_sel_type = self.v_sel_type
         if v_sel_type.get():
-            self.add_button.config(state = NORMAL)
+            self.bt_select.config(state = NORMAL)
         else:
-            self.add_button.config(state = DISABLED)
+            self.bt_select.config(state = DISABLED)

--- a/widgets/gui_tk.py
+++ b/widgets/gui_tk.py
@@ -26,8 +26,8 @@ class GUITaskManager(TkCoDispatcher):
         TkCoDispatcher.__activate__(self, task)
         self.__notify_activated(task)
 
-    def __finish__(self, task):
-        TkCoDispatcher.__finish__(self, task)
+    def __finish__(self, task, ret):
+        TkCoDispatcher.__finish__(self, task, ret)
         self.__notify_finished(task)
 
     def __failed__(self, task, exception):

--- a/widgets/irq_settings.py
+++ b/widgets/irq_settings.py
@@ -179,14 +179,14 @@ class IRQSettingsWidget(SettingsWidget):
                 var = getattr(self, pfx + "_" + attr + "_var")
                 new_val = var.get()
                 if not new_val:
-                    if attr is "irq_idx":
+                    if attr == "irq_idx":
                         new_val = 0
                     else:
                         new_val = None
 
                 cur_val = getattr(irq, pfx + "_" +attr)
 
-                if attr is "irq_idx":
+                if attr == "irq_idx":
                     cur_type = type(cur_val)
                     try: # to preserve current value type
                         new_val = cur_type(new_val)

--- a/widgets/memory_tree_widget.py
+++ b/widgets/memory_tree_widget.py
@@ -331,7 +331,7 @@ snapshot mode or the command should be disabled too.
                     values = ("", hwaddr_val(mem.alias_offset),)
                 )
 
-            if op.attr is "name":
+            if op.attr == "name":
                 for n in self.mach.id2node.values():
                     if isinstance(n, MemoryAliasNode):
                         if n.alias_to is mem:

--- a/widgets/project_widget.py
+++ b/widgets/project_widget.py
@@ -25,6 +25,7 @@ from common import (
     mlget as _
 )
 from qemu import (
+    MachineDescription,
     QType,
     QemuTypeName,
     SysBusDeviceDescription,
@@ -373,8 +374,12 @@ class ProjectWidget(PanedWindow, TkPopupHelper, QDCGUISignalHelper):
                     pass
                 else:
                     qtn = QemuTypeName(desc_name)
-                    t = next(qt.find(name = qtn.for_id_name))
-                    t.unparent()
+                    try:
+                        t = next(qt.find(name = qtn.for_id_name))
+                    except StopIteration:
+                        pass
+                    else:
+                        t.unparent()
             else: # added
                 self.__add_qtype_for_description(desc)
         elif isinstance(op, DOp_SetAttr):
@@ -499,6 +504,12 @@ class ProjectWidget(PanedWindow, TkPopupHelper, QDCGUISignalHelper):
             parent = next(parent.find(name = "sys-bus-device"))
         elif isinstance(desc, PCIExpressDeviceDescription):
             parent = next(parent.find(name = "pci-device"))
+        elif isinstance(desc, MachineDescription):
+            # currently, only "device"s are in QOM Tree
+            return
+        else:
+            # Not implemented
+            return
 
         qtn = QemuTypeName(desc.name)
         QType(qtn.for_id_name,

--- a/widgets/var_widgets.py
+++ b/widgets/var_widgets.py
@@ -86,10 +86,10 @@ class VarLabel(Label):
         if "text" in kw:
             text = kw.pop("text")
             if isinstance(text, variables):
-                kw["text"] = text.get()
                 self.text_var = text
             else:
                 self.text_var = StringVar(value = text)
+            kw["text"] = self.text_var.get()
         else:
             self.text_var = StringVar()
         Label.__init__(self, *args, **kw)


### PR DESCRIPTION
Next wave of patches from `devel`.

# v2
- add new patches on top to fix `SyntaxWarning` under Py3.8
- explicitly forbid user to pass window and anchor to `CanvasFrame`
  (a new patch, not squashed)
- fixed typos in commit messages and comments
- squashed 'init_submodules_from_cache: update reverted URL in submodule cache "config"'
- dot in 'QemuVersionCache.co_propagate_new_param: clarify docstring'
