### PR TITLE
Git substring search based commits pick helper

### DIFF
--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -42,6 +42,13 @@ done
 IFS=$IFSBack
 
 
+if [[ 0 == $# ]]
+then
+	echo "no rev-id" 1>&2
+	echo "$Usage" 1>&2
+	exit 1
+fi
+
 LogRevId=$1
 shift
 

--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -66,9 +66,9 @@ then
 fi
 
 
-SearchedSrings=( "$@" )
+SearchedStrings=( "$@" )
 
-if [[ 0 == ${#SearchedSrings[@]} ]]
+if [[ 0 == ${#SearchedStrings[@]} ]]
 then
 	echo "no strings for commit selection from $LogRevId" 1>&2
 	echo "$Usage" 1>&2
@@ -92,7 +92,7 @@ do
 		continue
 	fi
 
-	for SS in ${SearchedSrings[*]}
+	for SS in ${SearchedStrings[*]}
 	do
 		if [[ "$Line" == *"$SS"* ]]
 		then

--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+Help="Given a Git rev-id and list of regular expressions $0 searches \
+branch starting from rev-id for commits whose 'git log' lines matches at \
+least one regular expression given. \
+Selected commit hashes are printed to stdout, other messages to stderr.\n\
+\n\
+Example:\n\n\
+git cherry-pick \$($0 branch_name \\\\\n\
+'feature regular expression' \\\\\n\
+'author name' \\\\\n\
+'commit message prefix' \\\\\n\
+2>>/dev/null)\n\
+"
+
+Usage="usage: $0 [-h] [--help] rev-id regex [regex [...]]"
+
+
+IFSBack=$IFS
+IFS=$'\n'
+while [[ "$1" =~ ^-.+$ ]]
+do
+	case "$1" in
+	"-h" )
+		echo "$Usage" 1>&2
+		echo -e "\n$Help" 1>&2
+		exit 0
+		;;
+	"--help" )
+		echo "$Usage" 1>&2
+		echo -e "\n$Help" 1>&2
+		exit 0
+		;;
+	* )
+		echo "unknown argument $1" 1>&2
+		echo "$Usage" 1>&2
+		exit 1
+		;;
+	esac
+	shift
+done
+IFS=$IFSBack
+
+
+LogRevId=$1
+shift
+
+
+IFSBack=$IFS
+IFS=$'\n'
+LogLines=( $(git log -q "$LogRevId") )
+IFS=$IFSBack
+
+if [[ 0 == ${#LogLines[@]} ]]
+then
+	echo "no log for rev-id $LogRevId" 1>&2
+	echo "$Usage" 1>&2
+	exit 1
+fi
+
+
+MessagesRe=( "$@" )
+
+if [[ 0 == ${#MessagesRe[@]} ]]
+then
+	echo "no regular expressions for commit selection from $LogRevId" 1>&2
+	echo "$Usage" 1>&2
+	exit 1
+fi
+
+ToCherryPick=( )
+
+IFSBack=$IFS
+IFS=$'\n'
+for Line in ${LogLines[*]}
+do
+	if [[ "$Line" =~ ^commit\ ([a-f0-9]+)$ ]]
+	then
+		RevId="${BASH_REMATCH[1]}"
+	fi
+	for Re in ${MessagesRe[*]}
+	do
+		if [[ "$Line" =~ "$Re" ]]
+		then
+			echo "$Re -> $RevId $Line" 1>&2
+
+			AlreadySelected=0
+			for SelectedRevId in ${ToCherryPick[*]}
+			do
+				if [ $SelectedRevId == $RevId ]
+				then
+					AlreadySelected=1
+					break
+				fi
+			done
+
+			if [[ 1 == $AlreadySelected ]]
+			then
+				echo "$RevId: multiple match, take once" 1>&2
+			else
+				# reverse order
+				ToCherryPick=($RevId "${ToCherryPick[@]}")
+			fi
+		fi
+	done
+done
+IFS=$IFSBack
+
+for RevId in ${ToCherryPick[*]}
+do
+	echo "$RevId"
+done

--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 
-Help="Given a Git rev-id and list of regular expressions $0 searches \
-branch starting from rev-id for commits whose 'git log' lines matches at \
-least one regular expression given. \
+Help="Given a Git rev-id and list of strings $0 searches \
+branch starting from rev-id for commits whose 'git log' lines contain at \
+least one string given. \
 Selected commit hashes are printed to stdout, other messages to stderr.\n\
 \n\
 Example:\n\n\
 git cherry-pick \$($0 branch_name \\\\\n\
-'feature regular expression' \\\\\n\
+a_SHA1 \\\\\n\
 'author name' \\\\\n\
-'commit message prefix' \\\\\n\
+'commit: message prefix' \\\\\n\
 2>>/dev/null)\n\
 "
 
-Usage="usage: $0 [-h] [--help] rev-id regex [regex [...]]"
+Usage="usage: $0 [-h] [--help] rev-id string [string [...]]"
 
 
 IFSBack=$IFS
@@ -59,11 +59,11 @@ then
 fi
 
 
-MessagesRe=( "$@" )
+SearchedSrings=( "$@" )
 
-if [[ 0 == ${#MessagesRe[@]} ]]
+if [[ 0 == ${#SearchedSrings[@]} ]]
 then
-	echo "no regular expressions for commit selection from $LogRevId" 1>&2
+	echo "no strings for commit selection from $LogRevId" 1>&2
 	echo "$Usage" 1>&2
 	exit 1
 fi
@@ -85,11 +85,11 @@ do
 		continue
 	fi
 
-	for Re in ${MessagesRe[*]}
+	for SS in ${SearchedSrings[*]}
 	do
-		if [[ "$Line" =~ "$Re" ]]
+		if [[ "$Line" == *"$SS"* ]]
 		then
-			echo "$Re -> $RevId $Line" 1>&2
+			echo "$SS -> $RevId $Line" 1>&2
 
 			# reverse order
 			ToCherryPick=($RevId "${ToCherryPick[@]}")

--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -77,30 +77,25 @@ do
 	if [[ "$Line" =~ ^commit\ ([a-f0-9]+)$ ]]
 	then
 		RevId="${BASH_REMATCH[1]}"
+		# Assume that `commit` is always first line of log record.
+		AlreadySelected=0
+	elif [[ 1 == $AlreadySelected ]]
+	then
+		# Skip rest lines of the log record. It's already selected.
+		continue
 	fi
+
 	for Re in ${MessagesRe[*]}
 	do
 		if [[ "$Line" =~ "$Re" ]]
 		then
 			echo "$Re -> $RevId $Line" 1>&2
 
-			AlreadySelected=0
-			for SelectedRevId in ${ToCherryPick[*]}
-			do
-				if [ $SelectedRevId == $RevId ]
-				then
-					AlreadySelected=1
-					break
-				fi
-			done
+			# reverse order
+			ToCherryPick=($RevId "${ToCherryPick[@]}")
 
-			if [[ 1 == $AlreadySelected ]]
-			then
-				echo "$RevId: multiple match, take once" 1>&2
-			else
-				# reverse order
-				ToCherryPick=($RevId "${ToCherryPick[@]}")
-			fi
+			AlreadySelected=1
+			break
 		fi
 	done
 done

--- a/misc/git_pick.sh
+++ b/misc/git_pick.sh
@@ -13,8 +13,11 @@ a_SHA1 \\\\\n\
 2>>/dev/null)\n\
 "
 
-Usage="usage: $0 [-h] [--help] rev-id string [string [...]]"
+Usage="\
+usage: $0 [-h] [--help] [-[-]arg-to-git-log [..]] rev-id string [string [..]]"
 
+
+ArgsToGitLog=( )
 
 IFSBack=$IFS
 IFS=$'\n'
@@ -32,9 +35,8 @@ do
 		exit 0
 		;;
 	* )
-		echo "unknown argument $1" 1>&2
-		echo "$Usage" 1>&2
-		exit 1
+		echo "argument to git log: $1" 1>&2
+		ArgsToGitLog+=( "$1" )
 		;;
 	esac
 	shift
@@ -55,7 +57,7 @@ shift
 
 IFSBack=$IFS
 IFS=$'\n'
-LogLines=( $(git log -q "$LogRevId") )
+LogLines=( $(git log "${ArgsToGitLog[@]}" "$LogRevId") )
 IFS=$IFSBack
 
 if [[ 0 == ${#LogLines[@]} ]]


### PR DESCRIPTION
### v3
- handle no rev-id use case
- `SearchedS`**t**`rings`
- unknown args are passed to git log
- update the request name

### v2
- simplified commit selection
- search for substring instead of regex