### PR TITLE
C PreProcessor evaluation tools

### DIFF
--- a/common/byN.py
+++ b/common/byN.py
@@ -1,0 +1,13 @@
+__all__ = [
+    "byN"
+]
+
+
+from itertools import (
+    zip_longest,
+)
+
+
+def byN(N, iterable, fillvalue = None):
+    "Iterates `iterable` by N values at once."
+    return zip_longest(*[iter(iterable)] * N, fillvalue = fillvalue)

--- a/misc/cppevaluate.sh
+++ b/misc/cppevaluate.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+export PYTHONPATH="..:$PYTHONPATH"
+
+QEMU_SRC="$HOME/work/qemu/src"
+QEMU_BUILD="$HOME/work/qemu/debug/build"
+
+CPPTEST_ARGS=" \
+	$QEMU_SRC \
+	-t 3600 \
+	-I$QEMU_BUILD \
+	-I$QEMU_BUILD/slirp/src \
+	-I$QEMU_SRC \
+	-I$QEMU_SRC/accel/tcg \
+	-I$QEMU_SRC/capstone/include \
+	-I$QEMU_SRC/dtc/libfdt \
+	-I$QEMU_SRC/include \
+	-I$QEMU_SRC/net \
+	-I$QEMU_SRC/slirp/src \
+	-I$QEMU_SRC/target/i386 \
+	-I$QEMU_SRC/tcg/i386 \
+	-I/usr/include/at-spi-2.0 \
+	-I/usr/include/at-spi2-atk/2.0 \
+	-I/usr/include/atk-1.0 \
+	-I/usr/include/cairo \
+	-I/usr/include/dbus-1.0 \
+	-I/usr/include/freetype2 \
+	-I/usr/include/gdk-pixbuf-2.0 \
+	-I/usr/include/gio-unix-2.0 \
+	-I/usr/include/gio-unix-2.0 \
+	-I/usr/include/glib-2.0 \
+	-I/usr/include/gtk-3.0 \
+	-I/usr/include/harfbuzz \
+	-I/usr/include/libpng16 \
+	-I/usr/include/libusb-1.0 \
+	-I/usr/include/libxml2 \
+	-I/usr/include/p11-kit-1 \
+	-I/usr/include/pango-1.0 \
+	-I/usr/include/pixman-1 \
+	-I/usr/include/vte-2.91 \
+	-I/usr/lib/x86_64-linux-gnu/dbus-1.0/include \
+	-I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
+"
+
+$(cd ../ply && git checkout base)
+
+if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+
+$(cd ../ply && git checkout refactor)
+
+if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+
+$(cd ../ply && git checkout inc_cache)
+
+if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+
+$(cd ../ply && git checkout incd_cache)
+
+if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi

--- a/misc/cppevaluate.sh
+++ b/misc/cppevaluate.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-export PYTHONPATH="..:$PYTHONPATH"
-
+FILE_DIR=$(dirname $0)
+QDT_ROOT=$(cd "$FILE_DIR/.." && pwd)
+export PYTHONPATH="$QDT_ROOT:$PYTHONPATH"
 QEMU_SRC="$HOME/work/qemu/src"
 QEMU_BUILD="$HOME/work/qemu/debug/build"
 
@@ -42,18 +43,18 @@ CPPTEST_ARGS=" \
 	-I/usr/lib/x86_64-linux-gnu/glib-2.0/include \
 "
 
-$(cd ../ply && git checkout base)
+$(cd "$QDT_ROOT/ply" && git checkout base)
 
-if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
 
-$(cd ../ply && git checkout refactor)
+$(cd "$QDT_ROOT/ply" && git checkout refactor)
 
-if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
 
-$(cd ../ply && git checkout inc_cache)
+$(cd "$QDT_ROOT/ply" && git checkout inc_cache)
 
-if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
 
-$(cd ../ply && git checkout incd_cache)
+$(cd "$QDT_ROOT/ply" && git checkout incd_cache)
 
-if ! python cpptest.py $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi

--- a/misc/cppevaluate.sh
+++ b/misc/cppevaluate.sh
@@ -45,16 +45,28 @@ CPPTEST_ARGS=" \
 
 $(cd "$QDT_ROOT/ply" && git checkout base)
 
-if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" --tag base $CPPTEST_ARGS
+then
+	exit 1
+fi
 
 $(cd "$QDT_ROOT/ply" && git checkout refactor)
 
-if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" --tag refactor $CPPTEST_ARGS
+then
+	exit 1
+fi
 
 $(cd "$QDT_ROOT/ply" && git checkout inc_cache)
 
-if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" --tag inc_cache $CPPTEST_ARGS
+then
+	exit 1
+fi
 
 $(cd "$QDT_ROOT/ply" && git checkout incd_cache)
 
-if ! python "$QDT_ROOT/misc/cpptest.py" $CPPTEST_ARGS ; then exit 1 ; fi
+if ! python "$QDT_ROOT/misc/cpptest.py" --tag incd_cache $CPPTEST_ARGS
+then
+	exit 1
+fi

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -71,6 +71,7 @@ def main():
     )
     arg("-I",
         action = "append",
+        default = [],
         help = "extra CPP search path for #include",
         metavar = "include_dir",
     )

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -265,7 +265,7 @@ def main():
                                 if '\n' in prev_spaces:
                                     write('\n')
                                 else:
-                                    write(next(iter(prev_spaces)))
+                                    write(' ')
                                 clear_spaces()
 
                             write(tok.value)
@@ -302,7 +302,7 @@ def main():
                                 if '\n' in prev_spaces:
                                     write('\n')
                                 else:
-                                    write(next(iter(prev_spaces)))
+                                    write(' ')
                                 clear_spaces()
 
                             write(tok.value)

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -1,8 +1,6 @@
 from common import (
     qdtdirs,
     makedirs,
-)
-from libe.common.pypath import (
     pypath,
 )
 from source import (

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -80,6 +80,11 @@ def main():
         help = "time limit",
         metavar = "seconds",
     )
+    arg("--tag",
+        default = "",
+        help = "a tag for log file",
+        metavar = "tag",
+    )
 
     args = ap.parse_args()
 
@@ -96,6 +101,7 @@ def main():
     logWrite = logFile.write
 
     log("logFileName   : " + logFileName)
+    log("tag           : " + args.tag)
     log("inDir         : " + inDir)
     log("pattern       : " + pattern)
     log("outDir        : " + outDir)

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -432,7 +432,8 @@ def main():
                 log(
                     "diff:\n\t%s" % (statsNow - statsPrev).lines(indent = "\t")
                 )
-                limit_cache(inc_cache, tReadyTokensLimit)
+                if inc_cache is not None:
+                    limit_cache(inc_cache, tReadyTokensLimit)
                 statsNow = CacheStats.compute(inc_cache)
                 log(
             "after_limit statsNow:\n\t%s" % statsNow.lines(indent = "\t")

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -77,7 +77,6 @@ def system_cpp(
           "-P",
           # no standard includes (all must be in CPPPaths)
           "-nostdinc",
-          "-nostdinc++",
         ]
       + [fullInPath],
         stdout = PIPE,

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -124,7 +124,7 @@ def main():
         metavar = "output_dir",
     )
     arg("-p",
-        default = ".*[.](h|c|(cpp)|(hpp))$",
+        default = ".*[.](c|(cpp))$",
         help = "inclusion pattern",
         metavar = "pattern",
     )

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -151,7 +151,7 @@ def main():
     inc_cache = None
 
     for dirPath, __, fileNames in walk(inDir):
-        for fileName in fileNames:
+        for fileName in sorted(fileNames):
             fullInPath = join(dirPath, fileName)
             if not matches(fullInPath):
                 continue

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -134,8 +134,8 @@ def main():
     log("inDir:\n\t" + inDir)
     log("pattern:\n\t" + pattern)
     log("outDir:\n\t" + outDir)
-    log("systemCPPPaths:\n\t" + "\n\t-I".join(systemCPPPaths))
-    log("CPPPaths:\n\t" + "\n\t-I".join(CPPPaths))
+    log("systemCPPPaths:" + "\n\t-I".join(("",) + systemCPPPaths))
+    log("CPPPaths:" + "\n\t-I".join([""] + CPPPaths))
     log("tLimit:\n\t" + str(tLimit))
 
     rePattern = compile(pattern)

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -1,7 +1,7 @@
 from common import (
-    qdtdirs,
     makedirs,
     pypath,
+    qdtdirs,
 )
 from source import (
     get_cpp_search_paths,

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -13,6 +13,7 @@ from argparse import (
 )
 from itertools import (
     chain,
+    zip_longest,
 )
 from os import (
     walk,
@@ -94,26 +95,12 @@ def system_cpp(
     return stdo
 
 
-def by3(iterable):
-    i = iter(iterable)
-    for n0 in i:
-        try:
-            n1 = next(i)
-        except StopIteration:
-            n1 = ""
-            n2 = ""
-        else:
-            try:
-                n2 = next(i)
-            except StopIteration:
-                n2 = ""
-        yield (n0, n1, n2)
-
-
 def log_mem_usage():
     mu = str(proc.memory_info().rss)
     mu = "_".join(reversed(tuple(
-        "".join(reversed(t)) for t in by3(reversed(mu))
+        "".join(reversed(t)) for t in zip_longest(*[iter(reversed(mu))] * 3,
+            fillvalue = "",
+        )
     )))
     log("memory:\n\t" + mu)
 

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -245,9 +245,12 @@ def main():
             write = outFile.write
 
             if cpp:
-                outData = system_cpp(fullInPath,
-                    CPPPaths = (dirPath,) + allIncPaths,
-                )
+                try:
+                    outData = system_cpp(fullInPath,
+                        CPPPaths = (dirPath,) + allIncPaths,
+                    )
+                except:
+                    outData = ""
 
                 if normalize:
                     lex = CPPLexer.clone()

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -71,8 +71,13 @@ def system_cpp(
     p = Popen(
         ["cpp"]
       + paths_args
-      + ["-E"]
-      # + ["-traditional-cpp"]
+      + [
+          # preprocess only, as desired
+          "-E",
+          # no standard includes (all must be in CPPPaths)
+          "-nostdinc",
+          "-nostdinc++",
+        ]
       + ["-o", outFilePath, inFilePath],
         stdin = PIPE,
     )
@@ -207,7 +212,7 @@ def main():
 
             if cpp:
                 system_cpp(fullInPath, fullOutPath,
-                    CPPPaths = CPPPaths,
+                    CPPPaths = allIncPaths,
                 )
             else:
                 p = Preprocessor(CPPLexer)

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -63,6 +63,7 @@ proc = Process()
 def system_cpp(
     fullInPath,
     CPPPaths = tuple(),
+    P = True,
 ):
     paths_args = []
     for CPPPath in CPPPaths:
@@ -75,11 +76,13 @@ def system_cpp(
       + [
           # preprocess only, as desired
           "-E",
-          # no line markers
-          "-P",
           # no standard includes (all must be in CPPPaths)
           "-nostdinc",
         ]
+      + (
+            # no line markers
+            ["-P"] if P else []
+        )
       + [fullInPath],
         stdout = PIPE,
         stderr = PIPE,
@@ -147,6 +150,10 @@ def main():
         action = "store_true",
         help = "use system cpp",
     )
+    arg("-P",
+        action = "store_true",
+        help = "do not pass -P to system cpp",
+    )
     arg("-t",
         default = "60.",
         help = "time limit",
@@ -171,6 +178,7 @@ def main():
     CPPPaths = sorted(set(args.I))
     tLimit = float(args.t)
     cpp = args.cpp
+    P = args.P
     normalize = args.normalize
 
     logFileName = join(outDir, "log.txt")
@@ -186,6 +194,7 @@ def main():
     log("systemCPPPaths:" + "\n\t-I".join(("",) + systemCPPPaths))
     log("CPPPaths:" + "\n\t-I".join([""] + CPPPaths))
     log("using system cpp:\n\t" + str(cpp))
+    log("no -P to system cpp:\n\t" + str(P))
     log("normalize:\n\t" + str(normalize))
     log("tLimit:\n\t" + str(tLimit))
 
@@ -248,6 +257,7 @@ def main():
                 try:
                     outData = system_cpp(fullInPath,
                         CPPPaths = (dirPath,) + allIncPaths,
+                        P = not P,
                     )
                 except:
                     outData = ""

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -214,7 +214,7 @@ def main():
 
             if cpp:
                 system_cpp(fullInPath, fullOutPath,
-                    CPPPaths = allIncPaths,
+                    CPPPaths = (dirPath,) + allIncPaths,
                 )
             else:
                 p = Preprocessor(CPPLexer)
@@ -229,6 +229,7 @@ def main():
                 else:
                     p.inc_cache = inc_cache
 
+                p.add_path(dirPath)
                 for __ in map(p.add_path, allIncPaths): pass
                 p.parse(inData, fullInPath)
 

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -1,4 +1,5 @@
 from common import (
+    byN,
     makedirs,
     pypath,
     qdtdirs,
@@ -13,7 +14,6 @@ from argparse import (
 )
 from itertools import (
     chain,
-    zip_longest,
 )
 from os import (
     walk,
@@ -98,9 +98,7 @@ def system_cpp(
 def log_mem_usage():
     mu = str(proc.memory_info().rss)
     mu = "_".join(reversed(tuple(
-        "".join(reversed(t)) for t in zip_longest(*[iter(reversed(mu))] * 3,
-            fillvalue = "",
-        )
+        "".join(reversed(t)) for t in byN(3, reversed(mu), fillvalue = "")
     )))
     log("memory:\n\t" + mu)
 

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -74,6 +74,8 @@ def system_cpp(
       + [
           # preprocess only, as desired
           "-E",
+          # no line markers
+          "-P",
           # no standard includes (all must be in CPPPaths)
           "-nostdinc",
           "-nostdinc++",

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -23,6 +23,9 @@ from os.path import (
     join,
     sep,
 )
+from psutil import (
+    Process,
+)
 with pypath("..ply"):
     import ply.cpp
     from ply.cpp import (
@@ -48,6 +51,32 @@ def log(msg):
 
 systemCPPPaths = get_cpp_search_paths()
 CPPLexer = lex(ply.cpp)
+proc = Process()
+
+
+def by3(iterable):
+    i = iter(iterable)
+    for n0 in i:
+        try:
+            n1 = next(i)
+        except StopIteration:
+            n1 = ""
+            n2 = ""
+        else:
+            try:
+                n2 = next(i)
+            except StopIteration:
+                n2 = ""
+        yield (n0, n1, n2)
+
+
+def log_mem_usage():
+    mu = str(proc.memory_info().rss)
+    mu = "_".join(reversed(tuple(
+        "".join(reversed(t)) for t in by3(reversed(mu))
+    )))
+    log("memory: " + mu)
+
 
 def main():
     global logWrite
@@ -127,6 +156,8 @@ def main():
             if not matches(fullInPath):
                 continue
 
+            log_mem_usage()
+
             pathSfx = fullInPath[pathSlice]
             fullOutPath = join(outDir, pathSfx) + ".pp"
             curOutDir = dirname(fullOutPath)
@@ -174,6 +205,8 @@ def main():
         else:
             continue
         break
+
+    log_mem_usage()
 
     log("total    : " + str(total))
     log("tTime    : " + str(tTime))

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -133,12 +133,11 @@ def main():
 
             makedirs(curOutDir, exist_ok = True)
 
-            with open(fullInPath, "r") as inFile:
-                inData = inFile.read()
+            p = Preprocessor(CPPLexer)
+
+            inData = p.read_include_file(fullInPath)
 
             outFile = open(fullOutPath, "w")
-
-            p = Preprocessor(CPPLexer)
 
             if inc_cache is None:
                 if hasattr(p, "inc_cache"):

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -199,6 +199,11 @@ def main():
 
     inc_cache = None
 
+    prev_spaces = set()
+    # cache
+    account_spaces = prev_spaces.update
+    clear_spaces = prev_spaces.clear
+
     allIncPaths = tuple(chain(CPPPaths, systemCPPPaths))
 
     for dirPath, __, fileNames in walk(inDir):
@@ -237,12 +242,9 @@ def main():
                     lex = CPPLexer.clone()
                     lex.input(outData)
 
-                    prev_spaces = set()
-
-                    # cache
-                    account_spaces = prev_spaces.update
                     token = lex.token
 
+                    clear_spaces()
                     tok = token()
                     while tok:
                         if tok.type in WS:
@@ -253,6 +255,8 @@ def main():
                                     write('\n')
                                 else:
                                     write(next(iter(prev_spaces)))
+                                clear_spaces()
+
                             write(tok.value)
 
                         tok = token()
@@ -274,13 +278,9 @@ def main():
                 # cache
                 token = p.token
 
+                clear_spaces()
                 tok = token()
                 if normalize:
-                    prev_spaces = set()
-
-                    # cache
-                    account_spaces = prev_spaces.update
-
                     while tok:
                         if tok.type in WS:
                             account_spaces(tok.value)
@@ -290,6 +290,8 @@ def main():
                                     write('\n')
                                 else:
                                     write(next(iter(prev_spaces)))
+                                clear_spaces()
+
                             write(tok.value)
 
                         tok = token()

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -1,0 +1,181 @@
+from common import (
+    qdtdirs,
+    makedirs,
+)
+from libe.common.pypath import (
+    pypath,
+)
+from source import (
+    get_cpp_search_paths,
+)
+
+from argparse import (
+    ArgumentParser,
+)
+from itertools import (
+    chain,
+)
+from os import (
+    walk,
+)
+from os.path import (
+    dirname,
+    join,
+    sep,
+)
+with pypath("..ply"):
+    import ply.cpp
+    from ply.cpp import (
+        Preprocessor,
+    )
+    from ply.lex import (
+        lex,
+    )
+from re import (
+    compile,
+)
+from time import (
+    time,
+)
+
+logDrop = lambda __: None
+logWrite = logDrop
+
+def log(msg):
+    logWrite(msg + "\n")
+    print(msg)
+
+
+systemCPPPaths = get_cpp_search_paths()
+CPPLexer = lex(ply.cpp)
+
+def main():
+    global logWrite
+
+    ap = ArgumentParser()
+    arg = ap.add_argument
+
+    arg("-o",
+        default = join(qdtdirs.user_cache_dir, "cpptest", str(time())),
+        help = "output directory",
+        metavar = "output_dir",
+    )
+    arg("-p",
+        default = ".*[.](h|c|(cpp)|(hpp))$",
+        help = "inclusion pattern",
+        metavar = "pattern",
+    )
+    arg("i",
+        help = "input directory",
+        metavar = "input_dir",
+    )
+    arg("-I",
+        action = "append",
+        help = "extra CPP search path for #include",
+        metavar = "include_dir",
+    )
+    arg("-t",
+        default = "60.",
+        help = "time limit",
+        metavar = "seconds",
+    )
+
+    args = ap.parse_args()
+
+    # cache
+    inDir = args.i
+    pattern = args.p
+    outDir = args.o
+    CPPPaths = sorted(set(args.I))
+    tLimit = float(args.t)
+
+    logFileName = join(outDir, "log.txt")
+    makedirs(outDir, exist_ok = True)
+    logFile = open(logFileName, "w")
+    logWrite = logFile.write
+
+    log("logFileName   : " + logFileName)
+    log("inDir         : " + inDir)
+    log("pattern       : " + pattern)
+    log("outDir        : " + outDir)
+    log("systemCPPPaths:" + "\n\t-I".join(("",) + systemCPPPaths))
+    log("CPPPaths      :" + "\n\t-I".join([""] + CPPPaths))
+    log("tLimit        : " + str(tLimit))
+
+    rePattern = compile(pattern)
+
+    # cache
+    matches = rePattern.match
+    inDirSfxLen = len(inDir) + len(sep)
+    pathSlice = slice(inDirSfxLen, None)
+
+    tStart = time()
+    total = 0
+
+    inc_cache = None
+
+    for dirPath, __, fileNames in walk(inDir):
+        for fileName in fileNames:
+            fullInPath = join(dirPath, fileName)
+            if not matches(fullInPath):
+                continue
+
+            pathSfx = fullInPath[pathSlice]
+            fullOutPath = join(outDir, pathSfx) + ".pp"
+            curOutDir = dirname(fullOutPath)
+
+            log(
+                str(total) + ": "
+                + pathSfx + " -> " + fullOutPath
+                + " at " + str(time() - tStart)
+            )
+
+            makedirs(curOutDir, exist_ok = True)
+
+            with open(fullInPath, "r") as inFile:
+                inData = inFile.read()
+
+            outFile = open(fullOutPath, "w")
+
+            p = Preprocessor(CPPLexer)
+
+            if inc_cache is None:
+                if hasattr(p, "inc_cache"):
+                    inc_cache = p.inc_cache
+            else:
+                p.inc_cache = inc_cache
+
+            for __ in map(p.add_path, chain(CPPPaths, systemCPPPaths)): pass
+            p.parse(inData, fullInPath)
+
+            # cache
+            write = outFile.write
+            token = p.token
+
+            tok = token()
+            while tok:
+                write(tok.value)
+                tok = token()
+
+            outFile.close()
+
+            total += 1
+            tEnd = time()
+            tTime = tEnd - tStart
+
+            if tTime > tLimit:
+                break
+        else:
+            continue
+        break
+
+    log("total    : " + str(total))
+    log("tTime    : " + str(tTime))
+    log("speed f/s: " + str(total / tTime) if tTime else "-")
+    log("speed s/f: " + str(tTime / total) if total else "-")
+
+    logWrite = logDrop
+    logFile.close()
+
+if __name__ == "__main__":
+    exit(main() or 0)

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -268,7 +268,7 @@ def main():
     total = 0
 
     inc_cache = None
-    prev_stats = CacheStats()
+    statsPrev = CacheStats()
 
     prev_spaces = set()
     # cache
@@ -386,10 +386,12 @@ def main():
                         write(tok.value)
                         tok = token()
 
-                stats = CacheStats.compute(inc_cache)
-                log("stat:\n\t%s" % stats.lines(indent = "\t"))
-                log("diff:\n\t%s" % (stats - prev_stats).lines(indent = "\t"))
-                prev_stats = stats
+                statsNow = CacheStats.compute(inc_cache)
+                log("stat:\n\t%s" % statsNow.lines(indent = "\t"))
+                log(
+                    "diff:\n\t%s" % (statsNow - statsPrev).lines(indent = "\t")
+                )
+                statsPrev = statsNow
 
             outFile.close()
 

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -75,7 +75,7 @@ def log_mem_usage():
     mu = "_".join(reversed(tuple(
         "".join(reversed(t)) for t in by3(reversed(mu))
     )))
-    log("memory: " + mu)
+    log("memory:\n\t" + mu)
 
 
 def main():
@@ -129,14 +129,14 @@ def main():
     logFile = open(logFileName, "w")
     logWrite = logFile.write
 
-    log("logFileName   : " + logFileName)
-    log("tag           : " + args.tag)
-    log("inDir         : " + inDir)
-    log("pattern       : " + pattern)
-    log("outDir        : " + outDir)
-    log("systemCPPPaths:" + "\n\t-I".join(("",) + systemCPPPaths))
-    log("CPPPaths      :" + "\n\t-I".join([""] + CPPPaths))
-    log("tLimit        : " + str(tLimit))
+    log("logFileName:\n\t" + logFileName)
+    log("tag:\n\t" + args.tag)
+    log("inDir:\n\t" + inDir)
+    log("pattern:\n\t" + pattern)
+    log("outDir:\n\t" + outDir)
+    log("systemCPPPaths:\n\t" + "\n\t-I".join(systemCPPPaths))
+    log("CPPPaths:\n\t" + "\n\t-I".join(CPPPaths))
+    log("tLimit:\n\t" + str(tLimit))
 
     rePattern = compile(pattern)
 
@@ -164,7 +164,7 @@ def main():
 
             log(
                 str(total) + ": "
-                + pathSfx + " -> " + fullOutPath
+                + pathSfx + "\n\t" + fullOutPath
                 + " at " + str(time() - tStart)
             )
 
@@ -208,10 +208,10 @@ def main():
 
     log_mem_usage()
 
-    log("total    : " + str(total))
-    log("tTime    : " + str(tTime))
-    log("speed f/s: " + str(total / tTime) if tTime else "-")
-    log("speed s/f: " + str(tTime / total) if total else "-")
+    log("total:\n\t" + str(total))
+    log("tTime:\n\t" + str(tTime))
+    log("speed f/s:\n\t" + str(total / tTime) if tTime else "-")
+    log("speed s/f:\n\t" + str(tTime / total) if total else "-")
 
     logWrite = logDrop
     logFile.close()

--- a/misc/cpptest.py
+++ b/misc/cpptest.py
@@ -183,6 +183,8 @@ def main():
 
     inc_cache = None
 
+    allIncPaths = tuple(chain(CPPPaths, systemCPPPaths))
+
     for dirPath, __, fileNames in walk(inDir):
         for fileName in sorted(fileNames):
             fullInPath = join(dirPath, fileName)
@@ -220,7 +222,7 @@ def main():
                 else:
                     p.inc_cache = inc_cache
 
-                for __ in map(p.add_path, chain(CPPPaths, systemCPPPaths)): pass
+                for __ in map(p.add_path, allIncPaths): pass
                 p.parse(inData, fullInPath)
 
                 # cache


### PR DESCRIPTION
- `cpptest.py`, a tool that evaluates single `cpp` instance,
  system `cpp`  or `ply`'s `cpp`.
- `cppevaluate.sh`, an example of night running multiple
 `cpp` evaluation script based on `cpptest.py`.

# v3
- join related commits
- outline generic `common.byN` (implemented using  `zip_longest`)
- implement `log_mem_usage` using `byN`

# v2
- typos